### PR TITLE
fix: use unprefixed v* tags for release-please to match release workflow trigger

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "packages": {
     ".": {
       "release-type": "rust",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
release-please was creating `odoo-operator-v*` tags instead of `v*`, so `release.yml` (which triggers on `v*`) never fired. Adding `include-component-in-tag: false` fixes the tag format going forward.