### PR TITLE
fix: pass --with-demo flag when init.demo is true

### DIFF
--- a/src/controller/states/initializing.rs
+++ b/src/controller/states/initializing.rs
@@ -99,7 +99,9 @@ pub fn build_init_job(
                     "--no-http".into(),
                     "--stop-after-init".into(),
                 ];
-                if !init_job.spec.demo {
+                if init_job.spec.demo {
+                    args.push("--with-demo".into());
+                } else {
                     args.push("--without-demo=all".into());
                 }
                 args


### PR DESCRIPTION
## Summary

- Odoo 19 defaults to `--without-demo` (no demo data)
- The init job was only passing `--without-demo=all` when `demo: false`, but omitting the flag when `demo: true` — which still results in no demo data
- Now explicitly passes `--with-demo` when `spec.init.demo` is `true`

## Test plan

- [ ] Create an OdooInstance with `spec.init.demo: true` and verify demo data is installed
- [ ] Create an OdooInstance with `spec.init.demo: false` (or default) and verify no demo data