### PR TITLE
feat: automatic filestore StorageClass migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ Transitions are a static table of `(from, to, guard, action)` tuples. Guards
 are pure functions over `ReconcileSnapshot`.
 
 **Phases**: Provisioning, Uninitialized, Initializing, InitFailed, Starting,
-Running, Degraded, Stopped, Upgrading, Restoring, BackingUp, Error.
+Running, Degraded, Stopped, Upgrading, Restoring, BackingUp, MigratingFilestore,
+Error.
 
 Auto-generate the Mermaid diagram: `make state-machine`
 
@@ -120,3 +121,4 @@ subresource patches. Key helpers in `tests/integration/common.rs`:
 | Running | spec.replicas | spec.cron.replicas | Steady state |
 | BackingUp | unchanged | unchanged | Non-disruptive |
 | Degraded | unchanged | unchanged | Partial readiness |
+| MigratingFilestore | 0 | 0 | Both down during storage class migration |

--- a/scripts/migrate-filestore.sh
+++ b/scripts/migrate-filestore.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+echo "Starting filestore migration rsync..."
+echo "Source: /mnt/old"
+echo "Dest:   /mnt/new"
+echo "Source files: $(find /mnt/old -type f 2>/dev/null | wc -l)"
+rsync -avH --delete /mnt/old/ /mnt/new/
+echo "Dest files:   $(find /mnt/new -type f | wc -l)"
+echo "Filestore migration rsync complete."

--- a/src/bin/statemachine_diagram.rs
+++ b/src/bin/statemachine_diagram.rs
@@ -36,6 +36,8 @@ fn action_name(a: &TransitionAction) -> &'static str {
         TransitionAction::FailUpgradeJob => "FailUpgradeJob",
         TransitionAction::CompleteBackupJob => "CompleteBackupJob",
         TransitionAction::FailBackupJob => "FailBackupJob",
+        TransitionAction::BeginFilestoreMigration => "BeginFilestoreMigration",
+        TransitionAction::CompleteFilestoreMigration => "CompleteFilestoreMigration",
     }
 }
 

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -302,12 +302,18 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         .await?;
     child_resources::ensure_odoo_user_secret(client, &ns, &name, &oref).await?;
     child_resources::ensure_postgres_role(ctx, instance, &pg_cluster).await?;
-    child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
+    let is_migrating = instance.status.as_ref().and_then(|s| s.phase.as_ref())
+        == Some(&OdooInstancePhase::MigratingFilestore);
+    if !is_migrating {
+        child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
+    }
     child_resources::ensure_config_map(client, &ns, &name, instance, &pg_cluster, &oref).await?;
     child_resources::ensure_service(client, &ns, &name, &oref).await?;
     child_resources::ensure_routing(client, &ns, &name, instance, &oref).await?;
-    child_resources::ensure_deployment(client, &ns, &name, instance, ctx, &oref).await?;
-    child_resources::ensure_cron_deployment(client, &ns, &name, instance, ctx, &oref).await?;
+    if !is_migrating {
+        child_resources::ensure_deployment(client, &ns, &name, instance, ctx, &oref).await?;
+        child_resources::ensure_cron_deployment(client, &ns, &name, instance, ctx, &oref).await?;
+    }
 
     // Gather the observed world into a snapshot.
     let snapshot =
@@ -484,12 +490,19 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
         Upgrading => ("False", "Module upgrade in progress"),
         Restoring => ("False", "Database restore in progress"),
         BackingUp => ("False", "Backup in progress"),
+        MigratingFilestore => ("False", "Filestore storage class migration in progress"),
         Error => ("False", "Reconciliation error"),
     };
 
     let progressing = matches!(
         phase,
-        Provisioning | Initializing | Starting | Upgrading | Restoring | BackingUp
+        Provisioning
+            | Initializing
+            | Starting
+            | Upgrading
+            | Restoring
+            | BackingUp
+            | MigratingFilestore
     );
 
     let now = Time(chrono::Utc::now());

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -11,7 +11,7 @@
 
 use std::time::Duration;
 
-use k8s_openapi::api::{apps::v1::Deployment, batch::v1::Job};
+use k8s_openapi::api::{apps::v1::Deployment, batch::v1::Job, core::v1::PersistentVolumeClaim};
 use kube::api::{Api, ListParams, Patch, PatchParams, ResourceExt};
 use kube::runtime::controller::Action;
 use kube::Client;
@@ -85,6 +85,11 @@ pub struct ReconcileSnapshot {
     pub active_restore_job: Option<OdooRestoreJob>,
     pub active_upgrade_job: Option<OdooUpgradeJob>,
     pub active_backup_job: Option<OdooBackupJob>,
+
+    // ── Filestore migration ─────────────────────────────────────────────
+    pub storage_class_mismatch: bool,
+    pub actual_storage_class: Option<String>,
+    pub migration_job: JobStatus,
 }
 
 impl ReconcileSnapshot {
@@ -274,6 +279,55 @@ impl ReconcileSnapshot {
         )
         .await;
 
+        // ── Filestore PVC storage-class mismatch detection ────────────
+        let (storage_class_mismatch, actual_storage_class) = {
+            let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
+            let pvc_name = format!("{instance_name}-filestore-pvc");
+            match pvcs.get(&pvc_name).await {
+                Ok(pvc) => {
+                    let actual = pvc.spec.as_ref().and_then(|s| s.storage_class_name.clone());
+                    let desired = instance
+                        .spec
+                        .filestore
+                        .as_ref()
+                        .and_then(|f| f.storage_class.clone());
+                    let mismatch = match (&actual, &desired) {
+                        (Some(a), Some(d)) => a != d,
+                        _ => false,
+                    };
+                    (mismatch, actual)
+                }
+                Err(_) => (false, None),
+            }
+        };
+
+        // ── Migration job status ────────────────────────────────────────
+        let migration_job = {
+            let job_name = instance
+                .status
+                .as_ref()
+                .and_then(|s| s.migration_job_name.clone());
+            match job_name {
+                Some(ref name) => match jobs_api.get(name).await {
+                    Ok(job) => {
+                        let succeeded =
+                            job.status.as_ref().and_then(|s| s.succeeded).unwrap_or(0) > 0;
+                        let failed = job.status.as_ref().and_then(|s| s.failed).unwrap_or(0) > 0;
+                        if succeeded {
+                            JobStatus::Succeeded
+                        } else if failed {
+                            JobStatus::Failed
+                        } else {
+                            JobStatus::Active
+                        }
+                    }
+                    Err(kube::Error::Api(ref err)) if err.code == 404 => JobStatus::Absent,
+                    Err(_) => JobStatus::Active,
+                },
+                None => JobStatus::Absent,
+            }
+        };
+
         Ok(Self {
             ready_replicas,
             deployment_replicas,
@@ -288,6 +342,9 @@ impl ReconcileSnapshot {
             active_restore_job,
             active_upgrade_job,
             active_backup_job,
+            storage_class_mismatch,
+            actual_storage_class,
+            migration_job,
         })
     }
 }
@@ -348,6 +405,8 @@ pub enum TransitionAction {
     FailUpgradeJob,
     CompleteBackupJob,
     FailBackupJob,
+    BeginFilestoreMigration,
+    CompleteFilestoreMigration,
 }
 
 pub async fn execute_action(
@@ -506,6 +565,46 @@ pub async fn execute_action(
                 }
             }
         }
+        BeginFilestoreMigration => {
+            let name = instance.name_any();
+            let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+            let prev_sc = snapshot
+                .actual_storage_class
+                .as_deref()
+                .unwrap_or("unknown");
+            let patch = json!({
+                "status": {
+                    "migrationStep": "ScalingDown",
+                    "migrationPreviousStorageClass": prev_sc,
+                    "message": format!("Migrating filestore from storage class {prev_sc}"),
+                }
+            });
+            api.patch_status(
+                &name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await?;
+        }
+        CompleteFilestoreMigration => {
+            let name = instance.name_any();
+            let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+            let patch = json!({
+                "status": {
+                    "migrationStep": null,
+                    "migrationPreviousStorageClass": null,
+                    "migrationJobName": null,
+                    "migrationPvName": null,
+                    "message": null,
+                }
+            });
+            api.patch_status(
+                &name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await?;
+        }
     }
     Ok(())
 }
@@ -643,6 +742,13 @@ pub static TRANSITIONS: &[Transition] = &[
     // ── Running ─────────────────────────────────────────────
     Transition {
         from: Running,
+        to: MigratingFilestore,
+        guard: |_, s| s.storage_class_mismatch,
+        guard_name: "storage_class_mismatch",
+        actions: &[TransitionAction::BeginFilestoreMigration],
+    },
+    Transition {
+        from: Running,
         to: Stopped,
         guard: |i, _| i.spec.replicas == 0,
         guard_name: "replicas == 0",
@@ -684,6 +790,13 @@ pub static TRANSITIONS: &[Transition] = &[
         actions: &[],
     },
     // ── Degraded ────────────────────────────────────────────
+    Transition {
+        from: Degraded,
+        to: MigratingFilestore,
+        guard: |_, s| s.storage_class_mismatch,
+        guard_name: "storage_class_mismatch",
+        actions: &[TransitionAction::BeginFilestoreMigration],
+    },
     Transition {
         from: Degraded,
         to: Stopped,
@@ -872,6 +985,13 @@ pub static TRANSITIONS: &[Transition] = &[
     // ── Stopped ─────────────────────────────────────────────
     Transition {
         from: Stopped,
+        to: MigratingFilestore,
+        guard: |_, s| s.storage_class_mismatch,
+        guard_name: "storage_class_mismatch",
+        actions: &[TransitionAction::BeginFilestoreMigration],
+    },
+    Transition {
+        from: Stopped,
         to: Restoring,
         guard: |_, s| s.restore_job.is_present(),
         guard_name: "restore_job present",
@@ -890,6 +1010,35 @@ pub static TRANSITIONS: &[Transition] = &[
         guard: |i, _| i.spec.replicas > 0,
         guard_name: "replicas > 0",
         actions: &[],
+    },
+    // ── MigratingFilestore ───────────────────────────────────
+    Transition {
+        from: MigratingFilestore,
+        to: Starting,
+        guard: |i, _s| {
+            let step = i
+                .status
+                .as_ref()
+                .and_then(|st| st.migration_step.as_deref())
+                .unwrap_or("");
+            step == "Complete" && i.spec.replicas > 0
+        },
+        guard_name: "migration complete && replicas > 0",
+        actions: &[TransitionAction::CompleteFilestoreMigration],
+    },
+    Transition {
+        from: MigratingFilestore,
+        to: Stopped,
+        guard: |i, _s| {
+            let step = i
+                .status
+                .as_ref()
+                .and_then(|st| st.migration_step.as_deref())
+                .unwrap_or("");
+            step == "Complete" && i.spec.replicas == 0
+        },
+        guard_name: "migration complete && replicas == 0",
+        actions: &[TransitionAction::CompleteFilestoreMigration],
     },
     // ── Error ───────────────────────────────────────────────
     Transition {
@@ -972,9 +1121,8 @@ fn requeue_for(phase: &OdooInstancePhase, snapshot: &ReconcileSnapshot) -> Actio
     }
 
     match phase {
-        Starting | Initializing | Restoring | Upgrading | BackingUp | Degraded => {
-            Action::requeue(Duration::from_secs(10))
-        }
+        Starting | Initializing | Restoring | Upgrading | BackingUp | Degraded
+        | MigratingFilestore => Action::requeue(Duration::from_secs(10)),
         _ => Action::await_change(),
     }
 }

--- a/src/controller/states/migrating_filestore.rs
+++ b/src/controller/states/migrating_filestore.rs
@@ -1,0 +1,478 @@
+//! MigratingFilestore state — orchestrates filestore PVC migration to a new
+//! StorageClass.  Uses internal sub-steps tracked in `status.migrationStep`.
+
+use async_trait::async_trait;
+use k8s_openapi::api::{
+    batch::v1::{Job, JobSpec},
+    core::v1::{
+        Container, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+        PersistentVolumeClaimVolumeSource, PodSpec, PodTemplateSpec, Volume, VolumeMount,
+    },
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, Patch, PatchParams, ResourceExt};
+use kube::Client;
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::crd::odoo_instance::OdooInstance;
+use crate::error::Result;
+
+use super::super::helpers::{cron_depl_name, FIELD_MANAGER};
+use super::super::odoo_instance::Context;
+use super::super::state_machine::{scale_deployment, JobStatus, ReconcileSnapshot};
+use super::State;
+
+const MIGRATE_SCRIPT: &str = include_str!("../../../scripts/migrate-filestore.sh");
+
+pub struct MigratingFilestore;
+
+#[async_trait]
+impl State for MigratingFilestore {
+    async fn ensure(
+        &self,
+        instance: &OdooInstance,
+        ctx: &Context,
+        snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let client = &ctx.client;
+
+        // Always keep deployments at 0 during migration.
+        scale_deployment(client, &inst_name, &ns, 0).await?;
+        scale_deployment(client, &cron_depl_name(instance), &ns, 0).await?;
+
+        let step = instance
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_step.as_deref())
+            .unwrap_or("ScalingDown");
+
+        match step {
+            "ScalingDown" => self.ensure_scaling_down(instance, client, snapshot).await,
+            "CreatingTempPvc" => self.ensure_creating_temp_pvc(instance, client, ctx).await,
+            "RsyncRunning" => {
+                self.ensure_rsync_running(instance, client, ctx, snapshot)
+                    .await
+            }
+            "DeletingOldPvc" => self.ensure_deleting_old_pvc(instance, client).await,
+            "RebindingPv" => self.ensure_rebinding_pv(instance, client).await,
+            "Complete" => Ok(()), // transition guard will fire
+            _ => Ok(()),
+        }
+    }
+}
+
+impl MigratingFilestore {
+    /// Wait for both deployments to be fully scaled down.
+    async fn ensure_scaling_down(
+        &self,
+        instance: &OdooInstance,
+        client: &Client,
+        snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        if snapshot.ready_replicas == 0
+            && snapshot.cron_ready_replicas == 0
+            && snapshot.deployment_replicas == 0
+            && snapshot.cron_deployment_replicas == 0
+        {
+            advance_step(client, instance, "CreatingTempPvc").await?;
+        }
+        Ok(())
+    }
+
+    /// Create the temporary PVC with the new StorageClass.
+    async fn ensure_creating_temp_pvc(
+        &self,
+        instance: &OdooInstance,
+        client: &Client,
+        ctx: &Context,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let temp_pvc_name = format!("{inst_name}-filestore-pvc-temp");
+
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+
+        // Idempotent: check if temp PVC already exists.
+        if pvcs.get(&temp_pvc_name).await.is_ok() {
+            info!(%inst_name, "temp PVC already exists, advancing to RsyncRunning");
+            advance_step(client, instance, "RsyncRunning").await?;
+            return Ok(());
+        }
+
+        let desired_class = instance
+            .spec
+            .filestore
+            .as_ref()
+            .and_then(|f| f.storage_class.clone())
+            .unwrap_or_else(|| ctx.defaults.storage_class.clone());
+
+        // Read size from the existing PVC (not the spec, since the PVC may have
+        // been expanded beyond the original spec size).
+        let orig_pvc_name = format!("{inst_name}-filestore-pvc");
+        let storage_size = match pvcs.get(&orig_pvc_name).await {
+            Ok(pvc) => pvc
+                .spec
+                .as_ref()
+                .and_then(|s| s.resources.as_ref())
+                .and_then(|r| r.requests.as_ref())
+                .and_then(|r| r.get("storage"))
+                .map(|q| q.0.clone())
+                .unwrap_or_else(|| "2Gi".to_string()),
+            Err(_) => "2Gi".to_string(),
+        };
+
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some(temp_pvc_name.clone()),
+                namespace: Some(ns.clone()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeClaimSpec {
+                access_modes: Some(vec!["ReadWriteMany".to_string()]),
+                storage_class_name: Some(desired_class),
+                resources: Some(k8s_openapi::api::core::v1::VolumeResourceRequirements {
+                    requests: Some(
+                        [("storage".to_string(), Quantity(storage_size))]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        pvcs.create(&Default::default(), &pvc).await?;
+        info!(%inst_name, %temp_pvc_name, "created temp PVC for migration");
+        advance_step(client, instance, "RsyncRunning").await?;
+        Ok(())
+    }
+
+    /// Create the rsync Job (if not yet created) and wait for it to succeed.
+    async fn ensure_rsync_running(
+        &self,
+        instance: &OdooInstance,
+        client: &Client,
+        ctx: &Context,
+        snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let migration_job_name = instance
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_job_name.clone());
+
+        // If no job yet, create one.
+        if migration_job_name.is_none() {
+            let job = build_rsync_job(&inst_name, &ns, instance, ctx);
+            let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+            let created = jobs.create(&Default::default(), &job).await?;
+            let job_name = created.name_any();
+            info!(%inst_name, %job_name, "created rsync migration job");
+
+            // Store the job name in status.
+            let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+            let patch = json!({"status": {"migrationJobName": &job_name}});
+            api.patch_status(
+                &inst_name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await?;
+            return Ok(());
+        }
+
+        // Job exists — check status.
+        match snapshot.migration_job {
+            JobStatus::Succeeded => {
+                info!(%inst_name, "migration rsync succeeded");
+                // Clean up the completed Job.
+                let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+                if let Some(ref name) = migration_job_name {
+                    let _ = jobs.delete(name, &DeleteParams::background()).await;
+                }
+                advance_step(client, instance, "DeletingOldPvc").await?;
+            }
+            JobStatus::Failed => {
+                warn!(%inst_name, "migration rsync failed — will retry");
+                // Clear the job name so a new one is created on next reconcile.
+                let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+                if let Some(ref name) = migration_job_name {
+                    let _ = jobs.delete(name, &DeleteParams::background()).await;
+                }
+                let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+                let patch = json!({"status": {"migrationJobName": null}});
+                api.patch_status(
+                    &inst_name,
+                    &PatchParams::apply(FIELD_MANAGER),
+                    &Patch::Merge(&patch),
+                )
+                .await?;
+            }
+            _ => {} // Active or Absent — wait.
+        }
+        Ok(())
+    }
+
+    /// Delete the original PVC.
+    async fn ensure_deleting_old_pvc(
+        &self,
+        instance: &OdooInstance,
+        client: &Client,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let pvc_name = format!("{inst_name}-filestore-pvc");
+
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+        match pvcs.get(&pvc_name).await {
+            Ok(_) => {
+                pvcs.delete(&pvc_name, &DeleteParams::default()).await?;
+                info!(%inst_name, "deleted old filestore PVC");
+                // Verify deletion completed (may still have deletionTimestamp).
+                match pvcs.get(&pvc_name).await {
+                    Err(kube::Error::Api(ref err)) if err.code == 404 => {
+                        advance_step(client, instance, "RebindingPv").await?;
+                    }
+                    _ => {} // Still exists (finalizer?) — will retry next reconcile.
+                }
+            }
+            Err(kube::Error::Api(ref err)) if err.code == 404 => {
+                // Already gone — advance.
+                advance_step(client, instance, "RebindingPv").await?;
+            }
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+
+    /// Rebind: get PV from temp PVC → set Retain + clear claimRef → delete temp
+    /// PVC → create final PVC with original name bound to that PV.
+    async fn ensure_rebinding_pv(&self, instance: &OdooInstance, client: &Client) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let temp_pvc_name = format!("{inst_name}-filestore-pvc-temp");
+        let final_pvc_name = format!("{inst_name}-filestore-pvc");
+
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+        let pvs: Api<k8s_openapi::api::core::v1::PersistentVolume> = Api::all(client.clone());
+
+        let stored_pv = instance
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_pv_name.clone());
+
+        // Phase A: temp PVC still exists — extract PV, patch it, delete temp PVC.
+        if let Ok(temp_pvc) = pvcs.get(&temp_pvc_name).await {
+            let pv_name = temp_pvc
+                .spec
+                .as_ref()
+                .and_then(|s| s.volume_name.clone())
+                .or(stored_pv.clone());
+
+            let Some(ref pv_name) = pv_name else {
+                // PVC not yet bound — wait for provisioner.
+                return Ok(());
+            };
+
+            // Store PV name in status if not already done.
+            if stored_pv.is_none() {
+                let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+                let patch = json!({"status": {"migrationPvName": pv_name}});
+                api.patch_status(
+                    &inst_name,
+                    &PatchParams::apply(FIELD_MANAGER),
+                    &Patch::Merge(&patch),
+                )
+                .await?;
+            }
+
+            // Patch PV: set Retain policy and clear claimRef.
+            let pv_patch = json!({
+                "spec": {
+                    "persistentVolumeReclaimPolicy": "Retain",
+                    "claimRef": null,
+                }
+            });
+            pvs.patch(
+                pv_name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&pv_patch),
+            )
+            .await?;
+
+            // Delete temp PVC.
+            pvcs.delete(&temp_pvc_name, &DeleteParams::default())
+                .await?;
+            info!(%inst_name, %pv_name, "patched PV and deleted temp PVC");
+            return Ok(());
+        }
+
+        // Phase B: temp PVC is gone — create final PVC bound to the PV.
+        let Some(ref pv_name) = stored_pv else {
+            warn!(%inst_name, "no temp PVC and no stored PV name — cannot rebind");
+            return Ok(());
+        };
+
+        match pvcs.get(&final_pvc_name).await {
+            Ok(pvc) => {
+                // PVC exists — check if bound.
+                let phase = pvc
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.phase.as_deref())
+                    .unwrap_or("");
+                if phase == "Bound" {
+                    info!(%inst_name, "final PVC bound — migration complete");
+                    advance_step(client, instance, "Complete").await?;
+                }
+                // else: still pending, wait.
+            }
+            Err(kube::Error::Api(ref err)) if err.code == 404 => {
+                // Create the final PVC.
+                let desired_class = instance
+                    .spec
+                    .filestore
+                    .as_ref()
+                    .and_then(|f| f.storage_class.clone())
+                    .unwrap_or_default();
+
+                let storage_size = instance
+                    .spec
+                    .filestore
+                    .as_ref()
+                    .and_then(|f| f.storage_size.clone())
+                    .unwrap_or_else(|| "2Gi".to_string());
+
+                // Build ownerReference from the instance.
+                let oref = super::super::helpers::controller_owner_ref(instance);
+
+                let pvc = PersistentVolumeClaim {
+                    metadata: ObjectMeta {
+                        name: Some(final_pvc_name.clone()),
+                        namespace: Some(ns.clone()),
+                        owner_references: Some(vec![oref]),
+                        ..Default::default()
+                    },
+                    spec: Some(PersistentVolumeClaimSpec {
+                        access_modes: Some(vec!["ReadWriteMany".to_string()]),
+                        storage_class_name: Some(desired_class),
+                        volume_name: Some(pv_name.clone()),
+                        resources: Some(k8s_openapi::api::core::v1::VolumeResourceRequirements {
+                            requests: Some(
+                                [("storage".to_string(), Quantity(storage_size))]
+                                    .into_iter()
+                                    .collect(),
+                            ),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+
+                pvcs.create(&Default::default(), &pvc).await?;
+                info!(%inst_name, %pv_name, "created final PVC bound to migrated PV");
+            }
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+}
+
+/// Advance the migration sub-step by patching `status.migrationStep`.
+async fn advance_step(client: &Client, instance: &OdooInstance, step: &str) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let name = instance.name_any();
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+    let patch = json!({"status": {"migrationStep": step}});
+    api.patch_status(
+        &name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    info!(%name, %step, "migration step advanced");
+    Ok(())
+}
+
+/// Build the rsync batch/v1 Job that copies data between PVCs.
+fn build_rsync_job(inst_name: &str, ns: &str, instance: &OdooInstance, _ctx: &Context) -> Job {
+    let old_pvc = format!("{inst_name}-filestore-pvc");
+    let temp_pvc = format!("{inst_name}-filestore-pvc-temp");
+
+    Job {
+        metadata: ObjectMeta {
+            generate_name: Some(format!("{inst_name}-migrate-")),
+            namespace: Some(ns.to_string()),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(3),
+            active_deadline_seconds: Some(3600),
+            ttl_seconds_after_finished: Some(300),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(
+                        [("app".to_string(), inst_name.to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    restart_policy: Some("Never".to_string()),
+                    security_context: Some(super::super::helpers::odoo_security_context()),
+                    image_pull_secrets: super::super::helpers::image_pull_secrets(instance),
+                    containers: vec![Container {
+                        name: "rsync".to_string(),
+                        image: Some("instrumentisto/rsync-ssh:latest".to_string()),
+                        command: Some(vec!["/bin/sh".to_string(), "-c".to_string()]),
+                        args: Some(vec![MIGRATE_SCRIPT.to_string()]),
+                        volume_mounts: Some(vec![
+                            VolumeMount {
+                                name: "old-filestore".to_string(),
+                                mount_path: "/mnt/old".to_string(),
+                                read_only: Some(true),
+                                ..Default::default()
+                            },
+                            VolumeMount {
+                                name: "new-filestore".to_string(),
+                                mount_path: "/mnt/new".to_string(),
+                                ..Default::default()
+                            },
+                        ]),
+                        ..Default::default()
+                    }],
+                    volumes: Some(vec![
+                        Volume {
+                            name: "old-filestore".to_string(),
+                            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                                claim_name: old_pvc,
+                                read_only: Some(true),
+                            }),
+                            ..Default::default()
+                        },
+                        Volume {
+                            name: "new-filestore".to_string(),
+                            persistent_volume_claim: Some(PersistentVolumeClaimVolumeSource {
+                                claim_name: temp_pvc,
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                    ]),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}

--- a/src/controller/states/mod.rs
+++ b/src/controller/states/mod.rs
@@ -16,6 +16,7 @@ mod degraded;
 mod error;
 mod init_failed;
 mod initializing;
+mod migrating_filestore;
 mod provisioning;
 mod restoring;
 mod running;
@@ -29,6 +30,7 @@ pub use degraded::Degraded;
 pub use error::Error;
 pub use init_failed::InitFailed;
 pub use initializing::Initializing;
+pub use migrating_filestore::MigratingFilestore;
 pub use provisioning::Provisioning;
 pub use restoring::Restoring;
 pub use running::Running;
@@ -58,6 +60,7 @@ pub fn state_for(phase: &OdooInstancePhase) -> &'static dyn State {
         OdooInstancePhase::Uninitialized => &Uninitialized,
         OdooInstancePhase::Initializing => &Initializing,
         OdooInstancePhase::InitFailed => &InitFailed,
+        OdooInstancePhase::MigratingFilestore => &MigratingFilestore,
         OdooInstancePhase::Starting => &Starting,
         OdooInstancePhase::Running => &Running,
         OdooInstancePhase::Degraded => &Degraded,

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -249,6 +249,7 @@ pub enum OdooInstancePhase {
     Upgrading,
     Restoring,
     BackingUp,
+    MigratingFilestore,
     Error,
 }
 
@@ -266,6 +267,7 @@ impl std::fmt::Display for OdooInstancePhase {
             Self::Upgrading => "Upgrading",
             Self::Restoring => "Restoring",
             Self::BackingUp => "BackingUp",
+            Self::MigratingFilestore => "MigratingFilestore",
             Self::Error => "Error",
         };
         write!(f, "{s}")
@@ -302,4 +304,17 @@ pub struct OdooInstanceStatus {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition>,
+
+    // ── Filestore migration ──────────────────────────────────────────────
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_step: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_pv_name: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_job_name: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_previous_storage_class: Option<String>,
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -3,7 +3,11 @@
 //! Rejects updates that would:
 //! - Decrease filestore storage size (PVCs cannot shrink)
 //! - Change the postgres cluster (migration not implemented)
-//! - Change the filestore storageClass (PVC storageClass is immutable)
+//!
+//! StorageClass changes are allowed — the operator handles migration
+//! automatically via the MigratingFilestore phase.  Changes are rejected
+//! during unsafe phases (Restoring, Upgrading, BackingUp, MigratingFilestore,
+//! Uninitialized).
 
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, AdmissionReview};
 use tracing::{info, warn};
@@ -87,7 +91,7 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
         ));
     }
 
-    // 3. Reject storageClass changes — the filestore PVC storageClass is immutable.
+    // 3. Reject storageClass changes when the instance is in an unsafe phase.
     let old_class = old
         .spec
         .filestore
@@ -100,12 +104,19 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
         .as_ref()
         .and_then(|f| f.storage_class.as_deref())
         .unwrap_or("");
-    if !old_class.is_empty() && new_class != old_class {
-        return AdmissionResponse::from(&req).deny(format!(
-            "spec.filestore.storageClass: cannot change storage class from {:?} to {:?}; \
-             the filestore PVC is immutable after creation",
-            old_class, new_class
-        ));
+    if !old_class.is_empty() && !new_class.is_empty() && old_class != new_class {
+        use crate::crd::odoo_instance::OdooInstancePhase::*;
+        let phase = old.status.as_ref().and_then(|s| s.phase.as_ref());
+        let blocked = matches!(
+            phase,
+            Some(Restoring | Upgrading | BackingUp | MigratingFilestore | Uninitialized)
+        );
+        if blocked {
+            return AdmissionResponse::from(&req).deny(format!(
+                "spec.filestore.storageClass: cannot change storage class while instance is in {} phase",
+                phase.unwrap()
+            ));
+        }
     }
 
     AdmissionResponse::from(&req)
@@ -166,7 +177,11 @@ mod tests {
     use super::*;
     use kube::core::admission::AdmissionRequest;
 
-    fn make_instance_json(db_name: Option<&str>, cluster: Option<&str>) -> serde_json::Value {
+    fn make_instance_json_full(
+        db_name: Option<&str>,
+        cluster: Option<&str>,
+        storage_class: Option<&str>,
+    ) -> serde_json::Value {
         let mut db = serde_json::Map::new();
         if let Some(n) = db_name {
             db.insert("name".into(), serde_json::json!(n));
@@ -181,12 +196,19 @@ mod tests {
         if !db.is_empty() {
             spec["database"] = serde_json::Value::Object(db);
         }
+        if let Some(sc) = storage_class {
+            spec["filestore"] = serde_json::json!({ "storageClass": sc });
+        }
         serde_json::json!({
             "apiVersion": "bemade.org/v1alpha1",
             "kind": "OdooInstance",
             "metadata": { "name": "test", "namespace": "default", "uid": "test-uid" },
             "spec": spec
         })
+    }
+
+    fn make_instance_json(db_name: Option<&str>, cluster: Option<&str>) -> serde_json::Value {
+        make_instance_json_full(db_name, cluster, None)
     }
 
     fn make_update_request(
@@ -208,6 +230,36 @@ mod tests {
                 "userInfo": { "username": "test" },
                 "object": make_instance_json(new_db_name, new_cluster),
                 "oldObject": make_instance_json(old_db_name, old_cluster),
+                "dryRun": false,
+            }
+        });
+        let ar: kube::core::admission::AdmissionReview<OdooInstance> =
+            serde_json::from_value(review).expect("valid AdmissionReview");
+        ar.try_into().expect("valid AdmissionRequest")
+    }
+
+    fn make_sc_change_request(
+        old_class: &str,
+        new_class: &str,
+        old_phase: Option<&str>,
+    ) -> AdmissionRequest<OdooInstance> {
+        let mut old_obj = make_instance_json_full(None, None, Some(old_class));
+        if let Some(phase) = old_phase {
+            old_obj["status"] = serde_json::json!({"phase": phase});
+        }
+        let review: serde_json::Value = serde_json::json!({
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "request": {
+                "uid": "req-sc",
+                "kind": { "group": "bemade.org", "version": "v1alpha1", "kind": "OdooInstance" },
+                "resource": { "group": "bemade.org", "version": "v1alpha1", "resource": "odooinstances" },
+                "name": "test",
+                "namespace": "default",
+                "operation": "UPDATE",
+                "userInfo": { "username": "test" },
+                "object": make_instance_json_full(None, None, Some(new_class)),
+                "oldObject": old_obj,
                 "dryRun": false,
             }
         });
@@ -249,5 +301,75 @@ mod tests {
         let req = make_update_request(None, Some("pg-cluster-a"), None, Some("pg-cluster-b"));
         let resp = validate(req);
         assert!(!resp.allowed);
+    }
+
+    #[test]
+    fn test_validate_allows_storage_class_change_when_running() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("Running"));
+        let resp = validate(req);
+        assert!(
+            resp.allowed,
+            "storageClass change should be allowed when Running"
+        );
+    }
+
+    #[test]
+    fn test_validate_allows_storage_class_change_when_stopped() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("Stopped"));
+        let resp = validate(req);
+        assert!(
+            resp.allowed,
+            "storageClass change should be allowed when Stopped"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_storage_class_change_when_restoring() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("Restoring"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "storageClass change should be rejected when Restoring"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_storage_class_change_when_upgrading() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("Upgrading"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "storageClass change should be rejected when Upgrading"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_storage_class_change_when_backing_up() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("BackingUp"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "storageClass change should be rejected when BackingUp"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_storage_class_change_when_migrating() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("MigratingFilestore"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "storageClass change should be rejected when already migrating"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_storage_class_change_when_uninitialized() {
+        let req = make_sc_change_request("cephfs", "juicefs", Some("Uninitialized"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "storageClass change should be rejected when Uninitialized"
+        );
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod child_resources;
 mod degraded;
 mod finalizer;
 mod init_job;
+mod migrate_filestore;
 mod orphaned_jobs;
 mod restore_job;
 mod scaling;

--- a/tests/integration/migrate_filestore.rs
+++ b/tests/integration/migrate_filestore.rs
@@ -1,0 +1,460 @@
+//! Integration tests for filestore StorageClass migration.
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::{
+    HostPathVolumeSource, PersistentVolume, PersistentVolumeClaim, PersistentVolumeSpec,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
+use serde_json::json;
+use std::time::Duration;
+
+use odoo_operator::controller::helpers::FIELD_MANAGER;
+use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
+
+use crate::common::*;
+
+/// Wait for a batch/v1 Job to appear with a name matching the given prefix.
+async fn wait_for_migration_job(client: &kube::Client, ns: &str, prefix: &str) -> String {
+    let jobs: Api<Job> = Api::namespaced(client.clone(), ns);
+    let name = wait_for(TIMEOUT, POLL, || {
+        let jobs = jobs.clone();
+        let pfx = prefix.to_string();
+        async move {
+            if let Ok(list) = jobs.list(&ListParams::default()).await {
+                for job in list.items {
+                    if let Some(ref n) = job.metadata.name {
+                        if n.starts_with(&pfx) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        }
+    })
+    .await;
+    assert!(name, "migration job with prefix {prefix} never appeared");
+
+    // Return the actual job name.
+    let list = jobs.list(&ListParams::default()).await.unwrap();
+    list.items
+        .iter()
+        .find_map(|j| {
+            j.metadata
+                .name
+                .as_ref()
+                .filter(|n| n.starts_with(prefix))
+                .cloned()
+        })
+        .unwrap()
+}
+
+/// Wait for a PVC to appear.
+async fn wait_for_pvc(client: &kube::Client, ns: &str, pvc_name: &str) {
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let api = pvcs.clone();
+            let n = pvc_name.to_string();
+            async move { api.get(&n).await.is_ok() }
+        })
+        .await,
+        "PVC {pvc_name} never appeared"
+    );
+}
+
+/// Create a fake PV and bind a PVC to it (simulates what a provisioner does).
+async fn fake_pvc_bound(client: &kube::Client, ns: &str, pvc_name: &str, pv_name: &str) {
+    let pvs: Api<PersistentVolume> = Api::all(client.clone());
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
+
+    // Create the PV if it doesn't exist.
+    if pvs.get(pv_name).await.is_err() {
+        let pv = PersistentVolume {
+            metadata: ObjectMeta {
+                name: Some(pv_name.to_string()),
+                ..Default::default()
+            },
+            spec: Some(PersistentVolumeSpec {
+                capacity: Some(
+                    [("storage".to_string(), Quantity("1Gi".to_string()))]
+                        .into_iter()
+                        .collect(),
+                ),
+                access_modes: Some(vec!["ReadWriteMany".to_string()]),
+                persistent_volume_reclaim_policy: Some("Retain".to_string()),
+                storage_class_name: Some("standard".to_string()),
+                host_path: Some(HostPathVolumeSource {
+                    path: "/tmp/fake-pv".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        pvs.create(&PostParams::default(), &pv).await.unwrap();
+    }
+
+    // Patch PVC spec to bind to PV.
+    let spec_patch = json!({"spec": {"volumeName": pv_name}});
+    pvcs.patch(
+        pvc_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&spec_patch),
+    )
+    .await
+    .unwrap();
+
+    // Patch PVC status to Bound.
+    let status_patch = json!({"status": {"phase": "Bound"}});
+    pvcs.patch_status(
+        pvc_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&status_patch),
+    )
+    .await
+    .unwrap();
+}
+
+// ─── Test 1: Happy path from Running ────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_filestore_from_running() {
+    let name = "test-mig-run";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    // Fast-track to Running.
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    // Fake the original PVC as bound with storageClass "standard".
+    let orig_pvc = format!("{name}-filestore-pvc");
+    fake_pvc_bound(c, ns, &orig_pvc, &format!("{name}-pv-old")).await;
+
+    // Change storageClass to trigger migration.
+    patch_instance_spec(
+        c,
+        ns,
+        name,
+        json!({"filestore": {"storageClass": "juicefs"}}),
+    )
+    .await;
+
+    // Should transition to MigratingFilestore.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingFilestore).await,
+        "expected MigratingFilestore phase"
+    );
+
+    // Fake both deployments as scaled down (envtest has no kubelet).
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+
+    // Wait for temp PVC to appear.
+    let temp_pvc = format!("{name}-filestore-pvc-temp");
+    wait_for_pvc(c, ns, &temp_pvc).await;
+
+    // Fake temp PVC as bound.
+    fake_pvc_bound(c, ns, &temp_pvc, &format!("{name}-pv-new")).await;
+
+    // Wait for rsync job.
+    let job_name = wait_for_migration_job(c, ns, &format!("{name}-migrate-")).await;
+
+    // Fake job success.
+    fake_job_succeeded(c, ns, &job_name).await;
+
+    // Help envtest through the DeletingOldPvc → RebindingPv → Complete flow.
+    // Continuously fake PVC state in the background until migration finishes.
+    let pv_name = format!("{name}-pv-new");
+    let assist_handle = {
+        let client = c.clone();
+        let ns = ns.to_string();
+        let orig_pvc = orig_pvc.clone();
+        let temp_pvc = temp_pvc.clone();
+        let pv_name = pv_name.clone();
+        tokio::spawn(async move {
+            let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+            loop {
+                // Force-delete old PVC if stuck.
+                let _ = pvcs
+                    .patch(
+                        &orig_pvc,
+                        &PatchParams::apply(FIELD_MANAGER),
+                        &Patch::Merge(&json!({"metadata": {"finalizers": null}})),
+                    )
+                    .await;
+                // Force-delete temp PVC if stuck.
+                let _ = pvcs
+                    .patch(
+                        &temp_pvc,
+                        &PatchParams::apply(FIELD_MANAGER),
+                        &Patch::Merge(&json!({"metadata": {"finalizers": null}})),
+                    )
+                    .await;
+                // If final PVC exists, fake it as bound.
+                if pvcs.get(&orig_pvc).await.is_ok() {
+                    let _ = pvcs
+                        .patch(
+                            &orig_pvc,
+                            &PatchParams::apply(FIELD_MANAGER),
+                            &Patch::Merge(&json!({"spec": {"volumeName": &pv_name}})),
+                        )
+                        .await;
+                    let _ = pvcs
+                        .patch_status(
+                            &orig_pvc,
+                            &PatchParams::apply(FIELD_MANAGER),
+                            &Patch::Merge(&json!({"status": {"phase": "Bound"}})),
+                        )
+                        .await;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+    };
+
+    // Should transition to Starting.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Starting).await,
+        "expected Starting phase after migration"
+    );
+    assist_handle.abort();
+
+    fake_deployment_ready(c, ns, name, 1).await;
+    let _handle = keep_deployment_ready(c.clone(), ns.to_string(), name.to_string(), 1);
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Running).await,
+        "expected Running phase after migration"
+    );
+}
+
+// ─── Test 2: Migration from Stopped ─────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_filestore_from_stopped() {
+    let name = "test-mig-stop";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    // Fast-track to Running, then stop.
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    // Fake PVC bound.
+    let orig_pvc = format!("{name}-filestore-pvc");
+    fake_pvc_bound(c, ns, &orig_pvc, &format!("{name}-pv-old")).await;
+
+    // Scale to 0 → Stopped.
+    patch_instance_spec(c, ns, name, json!({"replicas": 0})).await;
+    // Fake deployments scaled down.
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Stopped).await,
+        "expected Stopped"
+    );
+
+    // Change storageClass.
+    patch_instance_spec(
+        c,
+        ns,
+        name,
+        json!({"filestore": {"storageClass": "juicefs"}}),
+    )
+    .await;
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingFilestore).await,
+        "expected MigratingFilestore"
+    );
+
+    // Fast-forward through migration: temp PVC → rsync → rebind.
+    let temp_pvc = format!("{name}-filestore-pvc-temp");
+    wait_for_pvc(c, ns, &temp_pvc).await;
+    fake_pvc_bound(c, ns, &temp_pvc, &format!("{name}-pv-new2")).await;
+
+    let job_name = wait_for_migration_job(c, ns, &format!("{name}-migrate-")).await;
+    fake_job_succeeded(c, ns, &job_name).await;
+
+    // Help envtest through the PVC rebind flow with a background assistant.
+    let pv_name = format!("{name}-pv-new2");
+    let assist_handle = {
+        let client = c.clone();
+        let ns = ns.to_string();
+        let orig_pvc = orig_pvc.clone();
+        let temp_pvc = temp_pvc.clone();
+        let pv_name = pv_name.clone();
+        tokio::spawn(async move {
+            let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+            loop {
+                let _ = pvcs
+                    .patch(
+                        &orig_pvc,
+                        &PatchParams::apply(FIELD_MANAGER),
+                        &Patch::Merge(&json!({"metadata": {"finalizers": null}})),
+                    )
+                    .await;
+                let _ = pvcs
+                    .patch(
+                        &temp_pvc,
+                        &PatchParams::apply(FIELD_MANAGER),
+                        &Patch::Merge(&json!({"metadata": {"finalizers": null}})),
+                    )
+                    .await;
+                if pvcs.get(&orig_pvc).await.is_ok() {
+                    let _ = pvcs
+                        .patch(
+                            &orig_pvc,
+                            &PatchParams::apply(FIELD_MANAGER),
+                            &Patch::Merge(&json!({"spec": {"volumeName": &pv_name}})),
+                        )
+                        .await;
+                    let _ = pvcs
+                        .patch_status(
+                            &orig_pvc,
+                            &PatchParams::apply(FIELD_MANAGER),
+                            &Patch::Merge(&json!({"status": {"phase": "Bound"}})),
+                        )
+                        .await;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+    };
+
+    // Should end up Stopped since replicas=0.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Stopped).await,
+        "expected Stopped after migration with replicas=0"
+    );
+    assist_handle.abort();
+}
+
+// ─── Test 3: Rsync failure retries ──────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_filestore_rsync_failure() {
+    let name = "test-mig-fail";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    let orig_pvc = format!("{name}-filestore-pvc");
+    fake_pvc_bound(c, ns, &orig_pvc, &format!("{name}-pv-old")).await;
+
+    patch_instance_spec(
+        c,
+        ns,
+        name,
+        json!({"filestore": {"storageClass": "juicefs"}}),
+    )
+    .await;
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingFilestore).await,
+        "expected MigratingFilestore"
+    );
+
+    // Fake deployments scaled down.
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+
+    let temp_pvc = format!("{name}-filestore-pvc-temp");
+    wait_for_pvc(c, ns, &temp_pvc).await;
+    fake_pvc_bound(c, ns, &temp_pvc, &format!("{name}-pv-new3")).await;
+
+    // First rsync job fails.
+    let job_name = wait_for_migration_job(c, ns, &format!("{name}-migrate-")).await;
+    fake_job_failed(c, ns, &job_name).await;
+
+    // Should still be in MigratingFilestore. The operator retries by creating
+    // a new job — wait for a different job name to appear (proving retry happened).
+    let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let api = api.clone();
+            let n = name.to_string();
+            let old_job = job_name.clone();
+            async move {
+                let current = api
+                    .get_status(&n)
+                    .await
+                    .ok()
+                    .and_then(|i| i.status)
+                    .and_then(|s| s.migration_job_name);
+                // Either cleared (None) or changed to a new job name.
+                current.as_deref() != Some(&old_job)
+            }
+        })
+        .await,
+        "expected migration job to be retried after failure"
+    );
+    let inst = api.get_status(name).await.unwrap();
+    assert_eq!(
+        inst.status.as_ref().and_then(|s| s.phase.as_ref()),
+        Some(&OdooInstancePhase::MigratingFilestore),
+        "should remain in MigratingFilestore after rsync failure"
+    );
+}
+
+// ─── Test 4: Not triggered during init ──────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_filestore_not_triggered_during_init() {
+    let name = "test-mig-noinit";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    // Wait for operator to create PVC, then fake it as bound.
+    let orig_pvc = format!("{name}-filestore-pvc");
+    wait_for_pvc(c, ns, &orig_pvc).await;
+    fake_pvc_bound(c, ns, &orig_pvc, &format!("{name}-pv-old")).await;
+
+    // Create init job to enter Initializing.
+    let init_api: Api<odoo_operator::crd::odoo_init_job::OdooInitJob> =
+        Api::namespaced(c.clone(), ns);
+    let init_job: odoo_operator::crd::odoo_init_job::OdooInitJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInitJob",
+        "metadata": { "name": format!("{name}-init"), "namespace": ns },
+        "spec": { "odooInstanceRef": { "name": name } }
+    }))
+    .unwrap();
+    init_api
+        .create(&PostParams::default(), &init_job)
+        .await
+        .unwrap();
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Initializing).await,
+        "expected Initializing"
+    );
+
+    // Change storageClass while Initializing.
+    patch_instance_spec(
+        c,
+        ns,
+        name,
+        json!({"filestore": {"storageClass": "juicefs"}}),
+    )
+    .await;
+
+    // Give the operator a few reconcile cycles.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Should still be Initializing, NOT MigratingFilestore.
+    let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let inst = api.get_status(name).await.unwrap();
+    let phase = inst.status.as_ref().and_then(|s| s.phase.as_ref());
+    assert_ne!(
+        phase,
+        Some(&OdooInstancePhase::MigratingFilestore),
+        "migration should not trigger during Initializing"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a new `MigratingFilestore` phase to the OdooInstance state machine that automatically migrates filestore data when `spec.filestore.storageClass` is changed
- Migration flow: scale down → create temp PVC → rsync data → delete old PVC → rebind PV → scale back up
- Webhook validation rejects StorageClass changes during unsafe phases (Restoring, Upgrading, BackingUp, MigratingFilestore, Uninitialized)
- Previous StorageClass stored in `status.migrationPreviousStorageClass` for rollback visibility
- Rsync failures automatically retry

## Test plan

- [x] 4 integration tests: happy path from Running, from Stopped, rsync failure retry, not triggered during init
- [x] 7 webhook unit tests: allow during Running/Stopped, reject during Restoring/Upgrading/BackingUp/MigratingFilestore/Uninitialized
- [x] All 70 existing tests continue to pass
- [ ] Manual test: deploy to dev cluster, change an OdooInstance's storageClass, observe full migration flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)