### PR TITLE
fix: regenerate CRDs with MigratingFilestore phase

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -859,6 +859,18 @@ spec:
               message:
                 nullable: true
                 type: string
+              migrationJobName:
+                nullable: true
+                type: string
+              migrationPreviousStorageClass:
+                nullable: true
+                type: string
+              migrationPvName:
+                nullable: true
+                type: string
+              migrationStep:
+                nullable: true
+                type: string
               phase:
                 description: OdooInstancePhase represents the lifecycle state of an OdooInstance.
                 enum:
@@ -873,6 +885,7 @@ spec:
                 - Upgrading
                 - Restoring
                 - BackingUp
+                - MigratingFilestore
                 - Error
                 nullable: true
                 type: string


### PR DESCRIPTION
## Summary

- Regenerated CRD YAML for the Helm chart (`make helm-crds`) which was missed in the v1.5.0 release
- The API server was rejecting `MigratingFilestore` as an invalid phase value because the CRD schema wasn't updated

## Root cause

`make helm-crds` is not part of CI — it's a manual step. Should be added to the CI pipeline to prevent this in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)