### PR TITLE
fix: exclude JuiceFS virtual files from migration rsync

### DIFF
--- a/scripts/migrate-filestore.sh
+++ b/scripts/migrate-filestore.sh
@@ -4,6 +4,11 @@ echo "Starting filestore migration rsync..."
 echo "Source: /mnt/old"
 echo "Dest:   /mnt/new"
 echo "Source files: $(find /mnt/old -type f 2>/dev/null | wc -l)"
-rsync -avH --delete /mnt/old/ /mnt/new/
+rsync -avH --delete \
+  --exclude='.accesslog' \
+  --exclude='.config' \
+  --exclude='.stats' \
+  --no-perms --no-owner --no-group \
+  /mnt/old/ /mnt/new/
 echo "Dest files:   $(find /mnt/new -type f | wc -l)"
 echo "Filestore migration rsync complete."


### PR DESCRIPTION
## Summary

- Exclude JuiceFS FUSE virtual files (`.stats`, `.config`, `.accesslog`) from rsync `--delete`
- Disable permission/ownership sync (`--no-perms --no-owner --no-group`)

## Context

Discovered during first real migration (bemade-staging cephfs → juicefs). Rsync fails with `Operation not permitted` trying to delete JuiceFS virtual files at the mount root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)