### PR TITLE
fix: add PVC delete and PV patch permissions to operator RBAC

### DIFF
--- a/charts/odoo-operator/templates/rbac/role.yaml
+++ b/charts/odoo-operator/templates/rbac/role.yaml
@@ -38,7 +38,12 @@ rules:
   # Core resources managed as children of OdooInstance
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "services", "persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # PersistentVolumes (for filestore StorageClass migration rebind)
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "patch"]
 
   # Deployments
   - apiGroups: ["apps"]


### PR DESCRIPTION
## Summary

- Add `delete` verb to PVC permissions in the operator ClusterRole
- Add PersistentVolume `get`, `list`, `patch` permissions for PV rebind during migration

Required for the filestore StorageClass migration (DeletingOldPvc and RebindingPv steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)