### PR TITLE
fix: split migration finalization into separate phase, fix PVC rebind race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ are pure functions over `ReconcileSnapshot`.
 
 **Phases**: Provisioning, Uninitialized, Initializing, InitFailed, Starting,
 Running, Degraded, Stopped, Upgrading, Restoring, BackingUp, MigratingFilestore,
-Error.
+FinalizingFilestoreMigration, Error.
 
 Auto-generate the Mermaid diagram: `make state-machine`
 
@@ -122,3 +122,4 @@ subresource patches. Key helpers in `tests/integration/common.rs`:
 | BackingUp | unchanged | unchanged | Non-disruptive |
 | Degraded | unchanged | unchanged | Partial readiness |
 | MigratingFilestore | 0 | 0 | Both down during storage class migration |
+| FinalizingFilestoreMigration | 0 | 0 | PVC rebind after successful rsync |

--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -868,9 +868,6 @@ spec:
               migrationPvName:
                 nullable: true
                 type: string
-              migrationStep:
-                nullable: true
-                type: string
               phase:
                 description: OdooInstancePhase represents the lifecycle state of an OdooInstance.
                 enum:
@@ -886,6 +883,7 @@ spec:
                 - Restoring
                 - BackingUp
                 - MigratingFilestore
+                - FinalizingFilestoreMigration
                 - Error
                 nullable: true
                 type: string

--- a/src/bin/statemachine_diagram.rs
+++ b/src/bin/statemachine_diagram.rs
@@ -38,6 +38,7 @@ fn action_name(a: &TransitionAction) -> &'static str {
         TransitionAction::FailBackupJob => "FailBackupJob",
         TransitionAction::BeginFilestoreMigration => "BeginFilestoreMigration",
         TransitionAction::CompleteFilestoreMigration => "CompleteFilestoreMigration",
+        TransitionAction::ClearFilestoreMigrationStatus => "ClearFilestoreMigrationStatus",
         TransitionAction::RollbackFilestoreMigration => "RollbackFilestoreMigration",
     }
 }

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -302,8 +302,13 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         .await?;
     child_resources::ensure_odoo_user_secret(client, &ns, &name, &oref).await?;
     child_resources::ensure_postgres_role(ctx, instance, &pg_cluster).await?;
-    let is_migrating = instance.status.as_ref().and_then(|s| s.phase.as_ref())
-        == Some(&OdooInstancePhase::MigratingFilestore);
+    let is_migrating = matches!(
+        instance.status.as_ref().and_then(|s| s.phase.as_ref()),
+        Some(
+            &OdooInstancePhase::MigratingFilestore
+                | &OdooInstancePhase::FinalizingFilestoreMigration
+        )
+    );
     if !is_migrating {
         child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
     }
@@ -491,6 +496,7 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
         Restoring => ("False", "Database restore in progress"),
         BackingUp => ("False", "Backup in progress"),
         MigratingFilestore => ("False", "Filestore storage class migration in progress"),
+        FinalizingFilestoreMigration => ("False", "Finalizing filestore migration (PVC rebind)"),
         Error => ("False", "Reconciliation error"),
     };
 
@@ -503,6 +509,7 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
             | Restoring
             | BackingUp
             | MigratingFilestore
+            | FinalizingFilestoreMigration
     );
 
     let now = Time(chrono::Utc::now());

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -416,6 +416,7 @@ pub enum TransitionAction {
     FailBackupJob,
     BeginFilestoreMigration,
     CompleteFilestoreMigration,
+    ClearFilestoreMigrationStatus,
     RollbackFilestoreMigration,
 }
 
@@ -580,6 +581,24 @@ pub async fn execute_action(
         }
         CompleteFilestoreMigration => {
             complete_filestore_migration(instance, ctx).await?;
+        }
+        ClearFilestoreMigrationStatus => {
+            let name = instance.name_any();
+            let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+            let patch = json!({
+                "status": {
+                    "migrationJobName": null,
+                    "migrationPvName": null,
+                    "migrationPreviousStorageClass": null,
+                    "message": null,
+                }
+            });
+            api.patch_status(
+                &name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await?;
         }
         RollbackFilestoreMigration => {
             rollback_filestore_migration(instance, ctx).await?;
@@ -991,22 +1010,15 @@ pub static TRANSITIONS: &[Transition] = &[
         actions: &[],
     },
     // ── MigratingFilestore ───────────────────────────────────
-    // Success: rsync job completed — rebind PVC and start up.
+    // Rsync succeeded — delete old PVC, rebind PV, create final PVC.
     Transition {
         from: MigratingFilestore,
-        to: Starting,
-        guard: |i, s| s.migration_job == Succeeded && i.spec.replicas > 0,
-        guard_name: "migration_job succeeded && replicas > 0",
+        to: FinalizingFilestoreMigration,
+        guard: |_, s| s.migration_job == Succeeded,
+        guard_name: "migration_job succeeded",
         actions: &[TransitionAction::CompleteFilestoreMigration],
     },
-    Transition {
-        from: MigratingFilestore,
-        to: Stopped,
-        guard: |i, s| s.migration_job == Succeeded && i.spec.replicas == 0,
-        guard_name: "migration_job succeeded && replicas == 0",
-        actions: &[TransitionAction::CompleteFilestoreMigration],
-    },
-    // Failure or lost job: rollback to previous StorageClass.
+    // Rsync failed or job lost — rollback to previous StorageClass.
     Transition {
         from: MigratingFilestore,
         to: Starting,
@@ -1024,6 +1036,22 @@ pub static TRANSITIONS: &[Transition] = &[
         },
         guard_name: "migration_job failed/absent && replicas == 0",
         actions: &[TransitionAction::RollbackFilestoreMigration],
+    },
+    // ── FinalizingFilestoreMigration ───────────────────────
+    // PVC rebind complete (no mismatch) — clear status and start up.
+    Transition {
+        from: FinalizingFilestoreMigration,
+        to: Starting,
+        guard: |i, s| !s.storage_class_mismatch && i.spec.replicas > 0,
+        guard_name: "pvc rebound && replicas > 0",
+        actions: &[TransitionAction::ClearFilestoreMigrationStatus],
+    },
+    Transition {
+        from: FinalizingFilestoreMigration,
+        to: Stopped,
+        guard: |i, s| !s.storage_class_mismatch && i.spec.replicas == 0,
+        guard_name: "pvc rebound && replicas == 0",
+        actions: &[TransitionAction::ClearFilestoreMigrationStatus],
     },
     // ── Error ───────────────────────────────────────────────
     Transition {
@@ -1106,8 +1134,14 @@ fn requeue_for(phase: &OdooInstancePhase, snapshot: &ReconcileSnapshot) -> Actio
     }
 
     match phase {
-        Starting | Initializing | Restoring | Upgrading | BackingUp | Degraded
-        | MigratingFilestore => Action::requeue(Duration::from_secs(10)),
+        Starting
+        | Initializing
+        | Restoring
+        | Upgrading
+        | BackingUp
+        | Degraded
+        | MigratingFilestore
+        | FinalizingFilestoreMigration => Action::requeue(Duration::from_secs(10)),
         _ => Action::await_change(),
     }
 }
@@ -1246,89 +1280,114 @@ async fn begin_filestore_migration(
     Ok(())
 }
 
-/// Delete old PVC, rebind PV to new PVC with original name, clean up.
-///
-/// Idempotent: stores PV name in `status.migrationPvName` on first call
-/// so retries don't depend on the temp PVC still existing.  Each step
-/// checks current state before acting.
+/// Transition action: store PV name and delete the rsync Job.
+/// The PVC rebind is handled by `finalize_filestore_pvc_rebind()` in the
+/// FinalizingFilestoreMigration ensure().
 async fn complete_filestore_migration(instance: &OdooInstance, ctx: &Context) -> Result<()> {
     let ns = instance.namespace().unwrap_or_default();
     let inst_name = instance.name_any();
     let client = &ctx.client;
+
+    // 1. Read PV name from temp PVC and persist in status.
+    if instance
+        .status
+        .as_ref()
+        .and_then(|s| s.migration_pv_name.as_ref())
+        .is_none()
+    {
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
+        let temp_pvc_name = format!("{inst_name}-filestore-pvc-temp");
+        let pv_name = pvcs
+            .get(&temp_pvc_name)
+            .await?
+            .spec
+            .as_ref()
+            .and_then(|s| s.volume_name.clone())
+            .ok_or_else(|| {
+                crate::error::Error::Reconcile("temp PVC has no volumeName — not bound yet".into())
+            })?;
+        let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+        let patch = json!({"status": {"migrationPvName": &pv_name}});
+        api.patch_status(
+            &inst_name,
+            &PatchParams::apply(FIELD_MANAGER),
+            &Patch::Merge(&patch),
+        )
+        .await?;
+        info!(%inst_name, %pv_name, "stored migration PV name");
+    }
+
+    // 2. Delete the rsync Job — its completed pod holds pvc-protection on the
+    //    old PVC.  Foreground deletion cascades to the pod.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+    if let Some(ref job_name) = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.migration_job_name.clone())
+    {
+        match jobs.delete(job_name, &DeleteParams::foreground()).await {
+            Ok(_) => info!(%inst_name, %job_name, "deleted migration job"),
+            Err(kube::Error::Api(ref e)) if e.code == 404 => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(())
+}
+
+/// Idempotent PVC rebind — called by `FinalizingFilestoreMigration::ensure()`.
+/// Deletes old PVC, patches PV, deletes temp PVC, creates final PVC.
+pub async fn finalize_filestore_pvc_rebind(instance: &OdooInstance, ctx: &Context) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let inst_name = instance.name_any();
+    let client = &ctx.client;
     let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), &ns);
-    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
 
     let orig_pvc_name = format!("{inst_name}-filestore-pvc");
     let temp_pvc_name = format!("{inst_name}-filestore-pvc-temp");
 
-    // 1. Resolve PV name — from status (retry) or from temp PVC (first run).
-    let pv_name = match instance
+    let pv_name = instance
         .status
         .as_ref()
         .and_then(|s| s.migration_pv_name.clone())
-    {
-        Some(name) => name,
-        None => {
-            // First run: read from temp PVC and persist in status.
-            let name = pvcs
-                .get(&temp_pvc_name)
-                .await?
-                .spec
-                .as_ref()
-                .and_then(|s| s.volume_name.clone())
-                .ok_or_else(|| {
-                    crate::error::Error::Reconcile(
-                        "temp PVC has no volumeName — not bound yet".into(),
-                    )
-                })?;
-            let patch = json!({"status": {"migrationPvName": &name}});
-            api.patch_status(
-                &inst_name,
-                &PatchParams::apply(FIELD_MANAGER),
-                &Patch::Merge(&patch),
-            )
-            .await?;
-            name
-        }
-    };
+        .ok_or_else(|| {
+            crate::error::Error::Reconcile("migrationPvName not set in status".into())
+        })?;
 
-    // 2. Delete old PVC (idempotent — ignores 404).
+    // 1. Delete old PVC (idempotent).
     match pvcs.delete(&orig_pvc_name, &DeleteParams::default()).await {
         Ok(_) => info!(%inst_name, "deleted old filestore PVC"),
         Err(kube::Error::Api(ref e)) if e.code == 404 => {}
         Err(e) => return Err(e.into()),
     }
 
-    // 3. Wait for old PVC to be fully gone (not just Terminating).
+    // 2. If old PVC still terminating, return Ok — next reconcile will retry.
     if pvcs.get(&orig_pvc_name).await.is_ok() {
-        return Err(crate::error::Error::Reconcile(
-            "old PVC still terminating — will retry".into(),
-        ));
+        return Ok(());
     }
 
-    // 4. Patch PV: set Retain + clear claimRef so we can rebind.
+    // 3. Patch PV: set Retain + clear claimRef.
     let pvs: Api<k8s_openapi::api::core::v1::PersistentVolume> = Api::all(client.clone());
-    let pv_patch = json!({
-        "spec": {
-            "persistentVolumeReclaimPolicy": "Retain",
-            "claimRef": null,
-        }
-    });
     pvs.patch(
         &pv_name,
         &PatchParams::apply(FIELD_MANAGER),
-        &Patch::Merge(&pv_patch),
+        &Patch::Merge(&json!({
+            "spec": {
+                "persistentVolumeReclaimPolicy": "Retain",
+                "claimRef": null,
+            }
+        })),
     )
     .await?;
 
-    // 5. Delete temp PVC (idempotent — ignores 404).
+    // 4. Delete temp PVC (idempotent).
     match pvcs.delete(&temp_pvc_name, &DeleteParams::default()).await {
         Ok(_) => {}
         Err(kube::Error::Api(ref e)) if e.code == 404 => {}
         Err(e) => return Err(e.into()),
     }
 
-    // 6. Create final PVC with original name (idempotent — skip if exists).
+    // 5. Create final PVC (idempotent — skip if exists).
     if pvcs.get(&orig_pvc_name).await.is_err() {
         let desired_class = instance
             .spec
@@ -1371,31 +1430,6 @@ async fn complete_filestore_migration(instance: &OdooInstance, ctx: &Context) ->
         info!(%inst_name, %pv_name, "created final PVC bound to migrated PV");
     }
 
-    // 7. Clean up rsync job (idempotent).
-    let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
-    if let Some(ref job_name) = instance
-        .status
-        .as_ref()
-        .and_then(|s| s.migration_job_name.clone())
-    {
-        let _ = jobs.delete(job_name, &DeleteParams::background()).await;
-    }
-
-    // 8. Clear migration status.
-    let patch = json!({
-        "status": {
-            "migrationJobName": null,
-            "migrationPvName": null,
-            "migrationPreviousStorageClass": null,
-            "message": null,
-        }
-    });
-    api.patch_status(
-        &inst_name,
-        &PatchParams::apply(FIELD_MANAGER),
-        &Patch::Merge(&patch),
-    )
-    .await?;
     Ok(())
 }
 

--- a/src/controller/states/backing_up.rs
+++ b/src/controller/states/backing_up.rs
@@ -143,7 +143,7 @@ impl State for BackingUp {
         };
 
         let job = OdooJobBuilder::new(&format!("{crd_name}-"), &ns, backup_job, instance)
-            .active_deadline(1800)
+            .active_deadline(5400)
             .extra_volumes(vec![backup_vol])
             .affinity(pod_affinity)
             .init_containers(vec![Container {

--- a/src/controller/states/finalizing_filestore_migration.rs
+++ b/src/controller/states/finalizing_filestore_migration.rs
@@ -1,0 +1,44 @@
+//! FinalizingFilestoreMigration state — rsync is done, PVC rebind in progress.
+//!
+//! The `ensure()` method keeps deployments at zero and drives the idempotent
+//! PVC rebind sequence (delete old PVC, patch PV, create final PVC).
+//! Once the final PVC exists with the correct StorageClass, the transition
+//! guard fires and clears migration status.
+
+use async_trait::async_trait;
+use kube::ResourceExt;
+
+use crate::crd::odoo_instance::OdooInstance;
+use crate::error::Result;
+
+use super::super::helpers::cron_depl_name;
+use super::super::odoo_instance::Context;
+use super::super::state_machine::{
+    finalize_filestore_pvc_rebind, scale_deployment, ReconcileSnapshot,
+};
+use super::State;
+
+pub struct FinalizingFilestoreMigration;
+
+#[async_trait]
+impl State for FinalizingFilestoreMigration {
+    async fn ensure(
+        &self,
+        instance: &OdooInstance,
+        ctx: &Context,
+        _snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let client = &ctx.client;
+
+        // Keep both deployments at 0.
+        scale_deployment(client, &inst_name, &ns, 0).await?;
+        scale_deployment(client, &cron_depl_name(instance), &ns, 0).await?;
+
+        // Drive the PVC rebind — idempotent, retries on each reconcile tick.
+        finalize_filestore_pvc_rebind(instance, ctx).await?;
+
+        Ok(())
+    }
+}

--- a/src/controller/states/mod.rs
+++ b/src/controller/states/mod.rs
@@ -14,6 +14,7 @@ use super::state_machine::ReconcileSnapshot;
 mod backing_up;
 mod degraded;
 mod error;
+mod finalizing_filestore_migration;
 mod init_failed;
 mod initializing;
 mod migrating_filestore;
@@ -28,6 +29,7 @@ mod upgrading;
 pub use backing_up::BackingUp;
 pub use degraded::Degraded;
 pub use error::Error;
+pub use finalizing_filestore_migration::FinalizingFilestoreMigration;
 pub use init_failed::InitFailed;
 pub use initializing::Initializing;
 pub use migrating_filestore::MigratingFilestore;
@@ -61,6 +63,7 @@ pub fn state_for(phase: &OdooInstancePhase) -> &'static dyn State {
         OdooInstancePhase::Initializing => &Initializing,
         OdooInstancePhase::InitFailed => &InitFailed,
         OdooInstancePhase::MigratingFilestore => &MigratingFilestore,
+        OdooInstancePhase::FinalizingFilestoreMigration => &FinalizingFilestoreMigration,
         OdooInstancePhase::Starting => &Starting,
         OdooInstancePhase::Running => &Running,
         OdooInstancePhase::Degraded => &Degraded,

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -250,6 +250,7 @@ pub enum OdooInstancePhase {
     Restoring,
     BackingUp,
     MigratingFilestore,
+    FinalizingFilestoreMigration,
     Error,
 }
 
@@ -268,6 +269,7 @@ impl std::fmt::Display for OdooInstancePhase {
             Self::Restoring => "Restoring",
             Self::BackingUp => "BackingUp",
             Self::MigratingFilestore => "MigratingFilestore",
+            Self::FinalizingFilestoreMigration => "FinalizingFilestoreMigration",
             Self::Error => "Error",
         };
         write!(f, "{s}")

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -92,6 +92,7 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
     }
 
     // 3. Reject storageClass changes when the instance is in an unsafe phase.
+    //    Allow rollback: changing back to the previous SC stored in status.
     let old_class = old
         .spec
         .filestore
@@ -107,10 +108,23 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
     if !old_class.is_empty() && !new_class.is_empty() && old_class != new_class {
         use crate::crd::odoo_instance::OdooInstancePhase::*;
         let phase = old.status.as_ref().and_then(|s| s.phase.as_ref());
-        let blocked = matches!(
-            phase,
-            Some(Restoring | Upgrading | BackingUp | MigratingFilestore | Uninitialized)
-        );
+        let prev_sc = old
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_previous_storage_class.as_deref());
+        let is_rollback = prev_sc.is_some_and(|sc| sc == new_class);
+        let blocked = !is_rollback
+            && matches!(
+                phase,
+                Some(
+                    Restoring
+                        | Upgrading
+                        | BackingUp
+                        | MigratingFilestore
+                        | FinalizingFilestoreMigration
+                        | Uninitialized,
+                )
+            );
         if blocked {
             return AdmissionResponse::from(&req).deny(format!(
                 "spec.filestore.storageClass: cannot change storage class while instance is in {} phase",
@@ -243,9 +257,22 @@ mod tests {
         new_class: &str,
         old_phase: Option<&str>,
     ) -> AdmissionRequest<OdooInstance> {
+        make_sc_change_request_with_prev(old_class, new_class, old_phase, None)
+    }
+
+    fn make_sc_change_request_with_prev(
+        old_class: &str,
+        new_class: &str,
+        old_phase: Option<&str>,
+        prev_sc: Option<&str>,
+    ) -> AdmissionRequest<OdooInstance> {
         let mut old_obj = make_instance_json_full(None, None, Some(old_class));
         if let Some(phase) = old_phase {
-            old_obj["status"] = serde_json::json!({"phase": phase});
+            let mut status = serde_json::json!({"phase": phase});
+            if let Some(sc) = prev_sc {
+                status["migrationPreviousStorageClass"] = serde_json::json!(sc);
+            }
+            old_obj["status"] = status;
         }
         let review: serde_json::Value = serde_json::json!({
             "apiVersion": "admission.k8s.io/v1",
@@ -370,6 +397,40 @@ mod tests {
         assert!(
             !resp.allowed,
             "storageClass change should be rejected when Uninitialized"
+        );
+    }
+
+    #[test]
+    fn test_validate_allows_rollback_during_migration() {
+        // Reverting to the previous SC (stored in status) should be allowed
+        // even during MigratingFilestore.
+        let req = make_sc_change_request_with_prev(
+            "juicefs",
+            "cephfs",
+            Some("MigratingFilestore"),
+            Some("cephfs"),
+        );
+        let resp = validate(req);
+        assert!(
+            resp.allowed,
+            "rollback to previous storageClass should be allowed during migration"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_non_rollback_during_migration() {
+        // Changing to a DIFFERENT SC (not the previous one) during migration
+        // should still be rejected.
+        let req = make_sc_change_request_with_prev(
+            "juicefs",
+            "longhorn",
+            Some("MigratingFilestore"),
+            Some("cephfs"),
+        );
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "changing to a third storageClass during migration should be rejected"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **New `FinalizingFilestoreMigration` phase**: separates rsync wait from PVC rebind
- **PVC rebind in ensure()**: idempotent, retries gracefully if old PVC still terminating (returns Ok, not error)
- **Job deleted before PVC**: foreground propagation cascades to pod, releasing pvc-protection finalizer
- **Webhook rollback support**: allows changing SC back to `migrationPreviousStorageClass` during blocked phases
- **Clear Absent semantics**: Absent in MigratingFilestore → rollback; FinalizingFilestoreMigration never sees Absent
- **Backup deadline**: increased from 1800s to 5400s

## Bugs fixed

1. Transition action erroring on "old PVC still terminating" caused phase patch to succeed but reconcile to fail → stale watch event triggered rollback from wrong phase
2. Completed rsync pod held pvc-protection finalizer, blocking PVC deletion indefinitely until Job TTL
3. Rollback action blocked by own webhook (SC change during MigratingFilestore)

## Tested

- [x] All unit + integration tests pass (70 total)
- [x] End-to-end on minikube: standard → standard-v2 migration completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)