### PR TITLE
feat: database cluster migration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -75,6 +75,12 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Regenerate CRDs
+        run: make helm-crds
+
       - name: Install Helm
         uses: azure/setup-helm@v4
 

--- a/Makefile
+++ b/Makefile
@@ -103,15 +103,19 @@ release-patch release-minor release-major:
 	git push origin HEAD "v$(VERSION)"
 	@echo "Done — CI will build and publish v$(VERSION)."
 
+KUBE_CONTEXT ?= minikube
+KUBECTL := kubectl --context=$(KUBE_CONTEXT)
+
 install: docker-build helm-crds
-	kubectl scale deployment/odoo-operator -n odoo-operator --replicas=0
-	kubectl rollout status deployment/odoo-operator -n odoo-operator --timeout=60s || true
+	$(KUBECTL) scale deployment/odoo-operator -n odoo-operator --replicas=0
+	$(KUBECTL) rollout status deployment/odoo-operator -n odoo-operator --timeout=60s || true
 
 	docker build --no-cache -t registry.bemade.org/bemade/odoo-operator:local-dev .
 	minikube image load --overwrite=true registry.bemade.org/bemade/odoo-operator:local-dev
 
 	helm upgrade odoo-operator "charts/odoo-operator" \
 	--namespace odoo-operator \
+	--kube-context=$(KUBE_CONTEXT) \
 	-f "testing/helm/values.yaml"
 
-	kubectl rollout status deployment/odoo-operator -n odoo-operator --timeout=120s
+	$(KUBECTL) rollout status deployment/odoo-operator -n odoo-operator --timeout=120s

--- a/STATE_MACHINE.md
+++ b/STATE_MACHINE.md
@@ -25,6 +25,8 @@ stateDiagram-v2
     Starting --> BackingUp : [backup_job present]
     Starting --> Running : [ready >= desired]
 
+    Running --> MigratingFilestore : [storage_class_mismatch] / BeginFilestoreMigration
+    Running --> MigratingDatabase : [cluster_mismatch] / BeginDatabaseMigration
     Running --> Stopped : [replicas == 0]
     Running --> Restoring : [restore_job present]
     Running --> Upgrading : [upgrade_job ready]
@@ -32,6 +34,8 @@ stateDiagram-v2
     Running --> Degraded : [ready < desired && ready > 0]
     Running --> Starting : [ready == 0]
 
+    Degraded --> MigratingFilestore : [storage_class_mismatch] / BeginFilestoreMigration
+    Degraded --> MigratingDatabase : [cluster_mismatch] / BeginDatabaseMigration
     Degraded --> Stopped : [replicas == 0]
     Degraded --> Restoring : [restore_job present]
     Degraded --> Upgrading : [upgrade_job ready]
@@ -60,9 +64,25 @@ stateDiagram-v2
     Restoring --> Starting : [restore_job failed] / FailRestoreJob
     Restoring --> Starting : [restore_job absent]
 
+    Stopped --> MigratingFilestore : [storage_class_mismatch] / BeginFilestoreMigration
+    Stopped --> MigratingDatabase : [cluster_mismatch] / BeginDatabaseMigration
     Stopped --> Restoring : [restore_job present]
     Stopped --> Upgrading : [upgrade_job ready]
     Stopped --> Starting : [replicas > 0]
+
+    MigratingFilestore --> FinalizingFilestoreMigration : [migration_job succeeded] / CompleteFilestoreMigration
+    MigratingFilestore --> Starting : [migration_job failed/absent && replicas > 0] / RollbackFilestoreMigration
+    MigratingFilestore --> Stopped : [migration_job failed/absent && replicas == 0] / RollbackFilestoreMigration
+
+    FinalizingFilestoreMigration --> Starting : [pvc rebound && replicas > 0] / ClearFilestoreMigrationStatus
+    FinalizingFilestoreMigration --> Stopped : [pvc rebound && replicas == 0] / ClearFilestoreMigrationStatus
+
+    MigratingDatabase --> FinalizingDatabaseMigration : [db_migration_job succeeded] / CompleteDatabaseMigration
+    MigratingDatabase --> Starting : [db_migration_job failed/absent && replicas > 0] / RollbackDatabaseMigration
+    MigratingDatabase --> Stopped : [db_migration_job failed/absent && replicas == 0] / RollbackDatabaseMigration
+
+    FinalizingDatabaseMigration --> Starting : [cluster switched && replicas > 0] / ClearDatabaseMigrationStatus
+    FinalizingDatabaseMigration --> Stopped : [cluster switched && replicas == 0] / ClearDatabaseMigrationStatus
 
     Error --> Starting : [db_initialized]
     Error --> Uninitialized : [!db_initialized]

--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -818,6 +818,9 @@ spec:
             description: OdooInstanceStatus defines the observed state of OdooInstance.
             nullable: true
             properties:
+              activeCluster:
+                nullable: true
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
@@ -853,6 +856,9 @@ spec:
               dbInitialized:
                 default: false
                 type: boolean
+              dbMigrationJobName:
+                nullable: true
+                type: string
               lastBackup:
                 nullable: true
                 type: string
@@ -860,6 +866,9 @@ spec:
                 nullable: true
                 type: string
               migrationJobName:
+                nullable: true
+                type: string
+              migrationPreviousCluster:
                 nullable: true
                 type: string
               migrationPreviousStorageClass:
@@ -884,6 +893,8 @@ spec:
                 - BackingUp
                 - MigratingFilestore
                 - FinalizingFilestoreMigration
+                - MigratingDatabase
+                - FinalizingDatabaseMigration
                 - Error
                 nullable: true
                 type: string

--- a/scripts/migrate-database.sh
+++ b/scripts/migrate-database.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Migrates an Odoo database from one PostgreSQL cluster to another.
+#
+# Creates the role on the destination cluster, pipes pg_dump | pg_restore,
+# and verifies the result by checking that the Odoo base tables exist.
+#
+# Required env vars:
+#   SRC_HOST, SRC_PORT, SRC_ADMIN_USER, SRC_ADMIN_PASSWORD — source cluster admin
+#   DST_HOST, DST_PORT, DST_ADMIN_USER, DST_ADMIN_PASSWORD — destination cluster admin
+#   DB_USER, DB_PASSWORD — Odoo database role credentials
+#   DB_NAME              — database name to migrate
+
+set -ex
+
+echo "=== Starting database cluster migration ==="
+echo "Source:      $SRC_HOST:$SRC_PORT"
+echo "Destination: $DST_HOST:$DST_PORT"
+echo "Database:    $DB_NAME"
+echo "Role:        $DB_USER"
+
+# 1. Create role on destination cluster (idempotent).
+echo "=== Ensuring role on destination cluster ==="
+PGPASSWORD=$DST_ADMIN_PASSWORD psql \
+  -h "$DST_HOST" -p "$DST_PORT" -U "$DST_ADMIN_USER" -d postgres \
+  -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '$DB_USER') THEN CREATE ROLE \"$DB_USER\" WITH PASSWORD '$DB_PASSWORD' CREATEDB LOGIN; END IF; END \$\$;"
+
+# 2. Drop target database on destination if exists (idempotent).
+echo "=== Dropping existing database on destination (if any) ==="
+PGPASSWORD=$DST_ADMIN_PASSWORD psql \
+  -h "$DST_HOST" -p "$DST_PORT" -U "$DST_ADMIN_USER" -d postgres \
+  -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" || true
+
+# 3. Create empty database on destination owned by the role.
+echo "=== Creating database on destination ==="
+PGPASSWORD=$DST_ADMIN_PASSWORD createdb \
+  -h "$DST_HOST" -p "$DST_PORT" -U "$DST_ADMIN_USER" -O "$DB_USER" "$DB_NAME"
+
+# 4. Pipe pg_dump from source into pg_restore on destination.
+#    Dump with admin creds (full access to read), restore with the Odoo user
+#    so tables are owned by the correct role.
+echo "=== Migrating data (pg_dump | pg_restore) ==="
+PGPASSWORD=$SRC_ADMIN_PASSWORD pg_dump \
+  -h "$SRC_HOST" -p "$SRC_PORT" -U "$SRC_ADMIN_USER" -d "$DB_NAME" \
+  --format=custom --no-owner | \
+PGPASSWORD=$DB_PASSWORD pg_restore \
+  -h "$DST_HOST" -p "$DST_PORT" -U "$DB_USER" -d "$DB_NAME" \
+  --no-owner || true
+
+# 5. Verify the migrated database has core Odoo tables.
+echo "=== Verifying migration integrity ==="
+TABLE_COUNT=$(PGPASSWORD=$DB_PASSWORD psql \
+  -h "$DST_HOST" -p "$DST_PORT" -U "$DB_USER" -d "$DB_NAME" -t -A \
+  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN ('ir_module_module', 'res_users', 'ir_config_parameter');" 2>/dev/null || echo "0")
+if [ "$TABLE_COUNT" -lt 3 ]; then
+    echo "FATAL: migration verification failed — expected core tables not found (count=$TABLE_COUNT)"
+    echo "Cleaning up failed database on destination..."
+    PGPASSWORD=$DST_ADMIN_PASSWORD psql \
+      -h "$DST_HOST" -p "$DST_PORT" -U "$DST_ADMIN_USER" -d postgres \
+      -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" || true
+    exit 1
+fi
+echo "Verification passed: $TABLE_COUNT/3 core tables found"
+
+echo "=== Database cluster migration complete ==="

--- a/src/bin/statemachine_diagram.rs
+++ b/src/bin/statemachine_diagram.rs
@@ -40,6 +40,10 @@ fn action_name(a: &TransitionAction) -> &'static str {
         TransitionAction::CompleteFilestoreMigration => "CompleteFilestoreMigration",
         TransitionAction::ClearFilestoreMigrationStatus => "ClearFilestoreMigrationStatus",
         TransitionAction::RollbackFilestoreMigration => "RollbackFilestoreMigration",
+        TransitionAction::BeginDatabaseMigration => "BeginDatabaseMigration",
+        TransitionAction::CompleteDatabaseMigration => "CompleteDatabaseMigration",
+        TransitionAction::ClearDatabaseMigrationStatus => "ClearDatabaseMigrationStatus",
+        TransitionAction::RollbackDatabaseMigration => "RollbackDatabaseMigration",
     }
 }
 

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -294,7 +294,7 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
     }
 
     // Load postgres cluster config.
-    let (_cluster_name, pg_cluster) = load_postgres_cluster(ctx, instance).await?;
+    let (cluster_name, pg_cluster) = load_postgres_cluster(ctx, instance).await?;
 
     // Ensure all child resources (phase-independent infrastructure).
     let oref = controller_owner_ref(instance);
@@ -302,27 +302,38 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         .await?;
     child_resources::ensure_odoo_user_secret(client, &ns, &name, &oref).await?;
     child_resources::ensure_postgres_role(ctx, instance, &pg_cluster).await?;
-    let is_migrating = matches!(
-        instance.status.as_ref().and_then(|s| s.phase.as_ref()),
+    let current_phase_ref = instance.status.as_ref().and_then(|s| s.phase.as_ref());
+    let is_migrating_filestore = matches!(
+        current_phase_ref,
         Some(
             &OdooInstancePhase::MigratingFilestore
                 | &OdooInstancePhase::FinalizingFilestoreMigration
         )
     );
-    if !is_migrating {
+    // Database migration doesn't need to skip child resource creation —
+    // the state's ensure() handles scaling deployments to 0, and
+    // ensure_deployment/ensure_config_map preserve current replicas and
+    // update connection details (which is desirable for the switchover).
+    if !is_migrating_filestore {
         child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
     }
     child_resources::ensure_config_map(client, &ns, &name, instance, &pg_cluster, &oref).await?;
     child_resources::ensure_service(client, &ns, &name, &oref).await?;
     child_resources::ensure_routing(client, &ns, &name, instance, &oref).await?;
-    if !is_migrating {
+    if !is_migrating_filestore {
         child_resources::ensure_deployment(client, &ns, &name, instance, ctx, &oref).await?;
         child_resources::ensure_cron_deployment(client, &ns, &name, instance, ctx, &oref).await?;
     }
 
     // Gather the observed world into a snapshot.
-    let snapshot =
-        super::state_machine::ReconcileSnapshot::gather(client, &ns, &name, instance).await?;
+    let snapshot = super::state_machine::ReconcileSnapshot::gather(
+        client,
+        &ns,
+        &name,
+        instance,
+        &cluster_name,
+    )
+    .await?;
 
     // Ensure report.url points to the in-cluster web service so cron workers
     // can reach the report rendering endpoint (wkhtmltopdf via HTTP).
@@ -356,29 +367,46 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         .and_then(|s| s.phase.clone())
         .unwrap_or(OdooInstancePhase::Provisioning);
 
+    // Track active cluster — only update when not in a database migration phase.
+    let is_db_migrating = matches!(
+        current_phase_ref,
+        Some(
+            &OdooInstancePhase::MigratingDatabase | &OdooInstancePhase::FinalizingDatabaseMigration
+        )
+    );
+    let active_cluster_changed = !is_db_migrating
+        && instance
+            .status
+            .as_ref()
+            .and_then(|s| s.active_cluster.as_deref())
+            != Some(&cluster_name);
+
     let cur = instance.status.as_ref();
-    let status_changed = !cur.is_some_and(|s| {
-        s.ready_replicas == snapshot.ready_replicas
-            && s.ready == ready
-            && s.url == url
-            && s.target_replicas == Some(instance.spec.replicas)
-            && s.db_initialized == snapshot.db_initialized
-    });
+    let status_changed = active_cluster_changed
+        || !cur.is_some_and(|s| {
+            s.ready_replicas == snapshot.ready_replicas
+                && s.ready == ready
+                && s.url == url
+                && s.target_replicas == Some(instance.spec.replicas)
+                && s.db_initialized == snapshot.db_initialized
+        });
 
     let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
     if status_changed {
         let conditions =
             phase_to_conditions(&current_phase, instance.metadata.generation.unwrap_or(0));
-        let status_patch = json!({
-            "status": {
-                "readyReplicas": snapshot.ready_replicas,
-                "ready": current_phase == OdooInstancePhase::Running,
-                "url": url,
-                "targetReplicas": instance.spec.replicas,
-                "dbInitialized": snapshot.db_initialized,
-                "conditions": conditions,
-            }
+        let mut status_obj = json!({
+            "readyReplicas": snapshot.ready_replicas,
+            "ready": current_phase == OdooInstancePhase::Running,
+            "url": url,
+            "targetReplicas": instance.spec.replicas,
+            "dbInitialized": snapshot.db_initialized,
+            "conditions": conditions,
         });
+        if active_cluster_changed {
+            status_obj["activeCluster"] = json!(cluster_name);
+        }
+        let status_patch = json!({ "status": status_obj });
         api.patch_status(
             &name,
             &PatchParams::apply(FIELD_MANAGER),
@@ -459,8 +487,8 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
     )
     .await;
 
-    if let Ok((_cluster_name, pg_cluster)) = load_postgres_cluster(ctx, instance).await {
-        let username = odoo_username(&ns, &name);
+    let username = odoo_username(&ns, &name);
+    if let Ok((cluster_name, pg_cluster)) = load_postgres_cluster(ctx, instance).await {
         if let Err(e) = ctx.postgres.delete_role(&pg_cluster, &username).await {
             warn!(%name, %e, "failed to delete postgres role — removing finalizer anyway");
             publish_event(
@@ -472,6 +500,24 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
                 Some(format!("Failed to delete postgres role: {e}")),
             )
             .await;
+        }
+
+        // If deleted mid-migration, also clean up the old cluster.
+        if let Some(ref old_cluster) = instance
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_previous_cluster.clone())
+        {
+            if old_cluster != &cluster_name {
+                if let Ok(old_pg) = load_postgres_cluster_by_name(ctx, old_cluster).await {
+                    if let Err(e) = ctx.postgres.delete_role(&old_pg, &username).await {
+                        warn!(
+                            %name, %old_cluster, %e,
+                            "failed to delete role on old cluster during cleanup"
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -497,6 +543,8 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
         BackingUp => ("False", "Backup in progress"),
         MigratingFilestore => ("False", "Filestore storage class migration in progress"),
         FinalizingFilestoreMigration => ("False", "Finalizing filestore migration (PVC rebind)"),
+        MigratingDatabase => ("False", "Database cluster migration in progress"),
+        FinalizingDatabaseMigration => ("False", "Finalizing database cluster migration"),
         Error => ("False", "Reconciliation error"),
     };
 
@@ -510,6 +558,8 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
             | BackingUp
             | MigratingFilestore
             | FinalizingFilestoreMigration
+            | MigratingDatabase
+            | FinalizingDatabaseMigration
     );
 
     let now = Time(chrono::Utc::now());
@@ -538,10 +588,10 @@ pub fn phase_to_conditions(phase: &OdooInstancePhase, generation: i64) -> Vec<Co
 
 // ── Postgres cluster config loading ───────────────────────────────────────────
 
-async fn load_postgres_cluster(
+/// Load all cluster configs from the postgres-clusters Secret.
+async fn load_all_postgres_clusters(
     ctx: &Context,
-    instance: &OdooInstance,
-) -> Result<(String, PostgresClusterConfig)> {
+) -> Result<BTreeMap<String, PostgresClusterConfig>> {
     let secret_name = if ctx.postgres_clusters_secret.is_empty() {
         "postgres-clusters"
     } else {
@@ -559,7 +609,15 @@ async fn load_postgres_cluster(
         .get("clusters.yaml")
         .ok_or_else(|| Error::config("postgres-clusters secret missing clusters.yaml key"))?;
     let yaml_str = String::from_utf8_lossy(&raw.0);
-    let clusters: BTreeMap<String, PostgresClusterConfig> = serde_yaml::from_str(&yaml_str)?;
+    Ok(serde_yaml::from_str(&yaml_str)?)
+}
+
+/// Resolve the postgres cluster for the given instance (spec.database.cluster or default).
+pub async fn load_postgres_cluster(
+    ctx: &Context,
+    instance: &OdooInstance,
+) -> Result<(String, PostgresClusterConfig)> {
+    let clusters = load_all_postgres_clusters(ctx).await?;
 
     // If spec.database.cluster is set, use it directly.
     if let Some(ref db) = instance.spec.database {
@@ -580,7 +638,25 @@ async fn load_postgres_cluster(
         }
     }
 
+    let secret_name = if ctx.postgres_clusters_secret.is_empty() {
+        "postgres-clusters"
+    } else {
+        &ctx.postgres_clusters_secret
+    };
     Err(Error::config(format!(
         "no default postgres cluster configured in {secret_name} secret"
     )))
+}
+
+/// Load a specific postgres cluster by name (for migration actions that need
+/// the old cluster config).
+pub async fn load_postgres_cluster_by_name(
+    ctx: &Context,
+    cluster_name: &str,
+) -> Result<PostgresClusterConfig> {
+    let clusters = load_all_postgres_clusters(ctx).await?;
+    clusters
+        .get(cluster_name)
+        .cloned()
+        .ok_or_else(|| Error::config(format!("postgres cluster {cluster_name:?} not found")))
 }

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -90,6 +90,10 @@ pub struct ReconcileSnapshot {
     pub storage_class_mismatch: bool,
     pub actual_storage_class: Option<String>,
     pub migration_job: JobStatus,
+
+    // ── Database migration ────────────────────────────────────────────
+    pub cluster_mismatch: bool,
+    pub db_migration_job: JobStatus,
 }
 
 impl ReconcileSnapshot {
@@ -111,6 +115,7 @@ impl ReconcileSnapshot {
         ns: &str,
         instance_name: &str,
         instance: &OdooInstance,
+        desired_cluster: &str,
     ) -> Result<Self> {
         let db_initialized = instance
             .status
@@ -328,6 +333,42 @@ impl ReconcileSnapshot {
             }
         };
 
+        // ── Database cluster mismatch detection ──────────────────────
+        let cluster_mismatch = instance
+            .status
+            .as_ref()
+            .and_then(|s| s.active_cluster.as_deref())
+            .map(|active| active != desired_cluster)
+            .unwrap_or(false);
+
+        // ── Database migration job status ───────────────────────────
+        let db_migration_job = {
+            let job_name = instance
+                .status
+                .as_ref()
+                .and_then(|s| s.db_migration_job_name.clone());
+            let status = match job_name {
+                Some(ref name) => match jobs_api.get(name).await {
+                    Ok(job) => {
+                        let succeeded =
+                            job.status.as_ref().and_then(|s| s.succeeded).unwrap_or(0) > 0;
+                        let failed = job.status.as_ref().and_then(|s| s.failed).unwrap_or(0) > 0;
+                        if succeeded {
+                            JobStatus::Succeeded
+                        } else if failed {
+                            JobStatus::Failed
+                        } else {
+                            JobStatus::Active
+                        }
+                    }
+                    Err(kube::Error::Api(ref err)) if err.code == 404 => JobStatus::Absent,
+                    Err(_) => JobStatus::Active,
+                },
+                None => JobStatus::Absent,
+            };
+            status
+        };
+
         Ok(Self {
             ready_replicas,
             deployment_replicas,
@@ -345,6 +386,8 @@ impl ReconcileSnapshot {
             storage_class_mismatch,
             actual_storage_class,
             migration_job,
+            cluster_mismatch,
+            db_migration_job,
         })
     }
 }
@@ -409,6 +452,10 @@ pub enum TransitionAction {
     CompleteFilestoreMigration,
     ClearFilestoreMigrationStatus,
     RollbackFilestoreMigration,
+    BeginDatabaseMigration,
+    CompleteDatabaseMigration,
+    ClearDatabaseMigrationStatus,
+    RollbackDatabaseMigration,
 }
 
 pub async fn execute_action(
@@ -594,6 +641,18 @@ pub async fn execute_action(
         RollbackFilestoreMigration => {
             rollback_filestore_migration(instance, ctx).await?;
         }
+        BeginDatabaseMigration => {
+            begin_database_migration(instance, ctx).await?;
+        }
+        CompleteDatabaseMigration => {
+            complete_database_migration(instance, ctx).await?;
+        }
+        ClearDatabaseMigrationStatus => {
+            clear_database_migration_status(instance, ctx).await?;
+        }
+        RollbackDatabaseMigration => {
+            rollback_database_migration(instance, ctx).await?;
+        }
     }
     Ok(())
 }
@@ -738,6 +797,13 @@ pub static TRANSITIONS: &[Transition] = &[
     },
     Transition {
         from: Running,
+        to: MigratingDatabase,
+        guard: |_, s| s.cluster_mismatch,
+        guard_name: "cluster_mismatch",
+        actions: &[TransitionAction::BeginDatabaseMigration],
+    },
+    Transition {
+        from: Running,
         to: Stopped,
         guard: |i, _| i.spec.replicas == 0,
         guard_name: "replicas == 0",
@@ -785,6 +851,13 @@ pub static TRANSITIONS: &[Transition] = &[
         guard: |_, s| s.storage_class_mismatch,
         guard_name: "storage_class_mismatch",
         actions: &[TransitionAction::BeginFilestoreMigration],
+    },
+    Transition {
+        from: Degraded,
+        to: MigratingDatabase,
+        guard: |_, s| s.cluster_mismatch,
+        guard_name: "cluster_mismatch",
+        actions: &[TransitionAction::BeginDatabaseMigration],
     },
     Transition {
         from: Degraded,
@@ -981,6 +1054,13 @@ pub static TRANSITIONS: &[Transition] = &[
     },
     Transition {
         from: Stopped,
+        to: MigratingDatabase,
+        guard: |_, s| s.cluster_mismatch,
+        guard_name: "cluster_mismatch",
+        actions: &[TransitionAction::BeginDatabaseMigration],
+    },
+    Transition {
+        from: Stopped,
         to: Restoring,
         guard: |_, s| s.restore_job.is_present(),
         guard_name: "restore_job present",
@@ -1043,6 +1123,50 @@ pub static TRANSITIONS: &[Transition] = &[
         guard: |i, s| !s.storage_class_mismatch && i.spec.replicas == 0,
         guard_name: "pvc rebound && replicas == 0",
         actions: &[TransitionAction::ClearFilestoreMigrationStatus],
+    },
+    // ── MigratingDatabase ──────────────────────────────────
+    // pg_dump|pg_restore succeeded — switch over to new cluster.
+    Transition {
+        from: MigratingDatabase,
+        to: FinalizingDatabaseMigration,
+        guard: |_, s| s.db_migration_job == Succeeded,
+        guard_name: "db_migration_job succeeded",
+        actions: &[TransitionAction::CompleteDatabaseMigration],
+    },
+    // Job failed or lost — rollback to previous cluster.
+    Transition {
+        from: MigratingDatabase,
+        to: Starting,
+        guard: |i, s| {
+            (s.db_migration_job == Failed || s.db_migration_job == Absent) && i.spec.replicas > 0
+        },
+        guard_name: "db_migration_job failed/absent && replicas > 0",
+        actions: &[TransitionAction::RollbackDatabaseMigration],
+    },
+    Transition {
+        from: MigratingDatabase,
+        to: Stopped,
+        guard: |i, s| {
+            (s.db_migration_job == Failed || s.db_migration_job == Absent) && i.spec.replicas == 0
+        },
+        guard_name: "db_migration_job failed/absent && replicas == 0",
+        actions: &[TransitionAction::RollbackDatabaseMigration],
+    },
+    // ── FinalizingDatabaseMigration ────────────────────────
+    // activeCluster updated (no mismatch) — clear status and start up.
+    Transition {
+        from: FinalizingDatabaseMigration,
+        to: Starting,
+        guard: |i, s| !s.cluster_mismatch && i.spec.replicas > 0,
+        guard_name: "cluster switched && replicas > 0",
+        actions: &[TransitionAction::ClearDatabaseMigrationStatus],
+    },
+    Transition {
+        from: FinalizingDatabaseMigration,
+        to: Stopped,
+        guard: |i, s| !s.cluster_mismatch && i.spec.replicas == 0,
+        guard_name: "cluster switched && replicas == 0",
+        actions: &[TransitionAction::ClearDatabaseMigrationStatus],
     },
     // ── Error ───────────────────────────────────────────────
     Transition {
@@ -1132,7 +1256,9 @@ fn requeue_for(phase: &OdooInstancePhase, snapshot: &ReconcileSnapshot) -> Actio
         | BackingUp
         | Degraded
         | MigratingFilestore
-        | FinalizingFilestoreMigration => Action::requeue(Duration::from_secs(10)),
+        | FinalizingFilestoreMigration
+        | MigratingDatabase
+        | FinalizingDatabaseMigration => Action::requeue(Duration::from_secs(10)),
         _ => Action::await_change(),
     }
 }
@@ -1180,3 +1306,10 @@ pub async fn scale_deployment(client: &Client, name: &str, ns: &str, replicas: i
 
 use super::states::finalizing_filestore_migration::complete_filestore_migration;
 use super::states::migrating_filestore::{begin_filestore_migration, rollback_filestore_migration};
+
+// ── Database migration actions ───────────────────────────────────────────
+
+use super::states::finalizing_database_migration::{
+    clear_database_migration_status, complete_database_migration,
+};
+use super::states::migrating_database::{begin_database_migration, rollback_database_migration};

--- a/src/controller/states/finalizing_database_migration.rs
+++ b/src/controller/states/finalizing_database_migration.rs
@@ -1,0 +1,131 @@
+//! FinalizingDatabaseMigration state — migration Job succeeded, switching over.
+//!
+//! The `ensure()` method keeps deployments at zero.  The transition actions
+//! clean up the migration Job, delete the old role on the source cluster,
+//! and update `status.activeCluster` so the mismatch guard clears.
+
+use async_trait::async_trait;
+use k8s_openapi::api::batch::v1::Job;
+use kube::api::{Api, DeleteParams, Patch, PatchParams, ResourceExt};
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::crd::odoo_instance::OdooInstance;
+use crate::error::Result;
+use crate::helpers::odoo_username;
+
+use super::super::helpers::{cron_depl_name, FIELD_MANAGER};
+use super::super::odoo_instance::{load_postgres_cluster_by_name, Context};
+use super::super::state_machine::{scale_deployment, ReconcileSnapshot};
+use super::State;
+
+pub struct FinalizingDatabaseMigration;
+
+#[async_trait]
+impl State for FinalizingDatabaseMigration {
+    async fn ensure(
+        &self,
+        instance: &OdooInstance,
+        ctx: &Context,
+        _snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let client = &ctx.client;
+
+        // Keep both deployments at 0 until transition fires.
+        scale_deployment(client, &inst_name, &ns, 0).await?;
+        scale_deployment(client, &cron_depl_name(instance), &ns, 0).await?;
+
+        Ok(())
+    }
+}
+
+/// Transition action: delete migration Job, clean up old cluster, update activeCluster.
+/// Called by `CompleteDatabaseMigration` when entering this phase.
+pub async fn complete_database_migration(instance: &OdooInstance, ctx: &Context) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let inst_name = instance.name_any();
+    let client = &ctx.client;
+
+    // 1. Delete the migration Job.
+    if let Some(ref job_name) = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.db_migration_job_name.clone())
+    {
+        let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+        match jobs.delete(job_name, &DeleteParams::background()).await {
+            Ok(_) => info!(%inst_name, %job_name, "deleted database migration job"),
+            Err(e) => warn!(%inst_name, %job_name, %e, "failed to delete migration job"),
+        }
+    }
+
+    // 2. Clean up old role/database on the source cluster (best-effort).
+    if let Some(ref old_cluster_name) = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.migration_previous_cluster.clone())
+    {
+        match load_postgres_cluster_by_name(ctx, old_cluster_name).await {
+            Ok(old_pg) => {
+                let username = odoo_username(&ns, &inst_name);
+                if let Err(e) = ctx.postgres.delete_role(&old_pg, &username).await {
+                    warn!(
+                        %inst_name, %old_cluster_name, %e,
+                        "failed to delete old role on source cluster — manual cleanup may be needed"
+                    );
+                } else {
+                    info!(%inst_name, %old_cluster_name, "deleted old role on source cluster");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    %inst_name, %old_cluster_name, %e,
+                    "failed to load old cluster config — cannot clean up old role"
+                );
+            }
+        }
+    }
+
+    // 3. Update activeCluster to the new cluster.
+    let (new_cluster_name, _) =
+        super::super::odoo_instance::load_postgres_cluster(ctx, instance).await?;
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+    let patch = json!({
+        "status": {
+            "activeCluster": &new_cluster_name,
+        }
+    });
+    api.patch_status(
+        &inst_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    info!(%inst_name, %new_cluster_name, "updated activeCluster after database migration");
+
+    Ok(())
+}
+
+/// Transition action: clear migration status fields.
+/// Called by `ClearDatabaseMigrationStatus` when leaving this phase.
+pub async fn clear_database_migration_status(instance: &OdooInstance, ctx: &Context) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let inst_name = instance.name_any();
+    let api: Api<OdooInstance> = Api::namespaced(ctx.client.clone(), &ns);
+    let patch = json!({
+        "status": {
+            "dbMigrationJobName": null,
+            "migrationPreviousCluster": null,
+            "message": null,
+        }
+    });
+    api.patch_status(
+        &inst_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    Ok(())
+}

--- a/src/controller/states/migrating_database.rs
+++ b/src/controller/states/migrating_database.rs
@@ -1,0 +1,239 @@
+//! MigratingDatabase state — waits for the pg_dump|pg_restore Job to complete.
+//!
+//! All orchestration (job creation, rollback) is handled by transition actions.
+//! The `ensure()` method only keeps both deployments scaled to zero.
+
+use async_trait::async_trait;
+use k8s_openapi::api::{
+    batch::v1::{Job, JobSpec},
+    core::v1::{Container, EnvVar, PodSpec, PodTemplateSpec},
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, Patch, PatchParams, PostParams, ResourceExt};
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::crd::odoo_instance::OdooInstance;
+use crate::error::Result;
+use crate::postgres::PostgresClusterConfig;
+
+use super::super::helpers::{
+    cron_depl_name, env, image_pull_secrets, odoo_security_context, odoo_volume_mounts,
+    odoo_volumes, FIELD_MANAGER,
+};
+use super::super::odoo_instance::{load_postgres_cluster_by_name, Context};
+use super::super::state_machine::{scale_deployment, ReconcileSnapshot};
+use super::State;
+
+const MIGRATE_SCRIPT: &str = include_str!("../../../scripts/migrate-database.sh");
+
+pub struct MigratingDatabase;
+
+#[async_trait]
+impl State for MigratingDatabase {
+    async fn ensure(
+        &self,
+        instance: &OdooInstance,
+        ctx: &Context,
+        _snapshot: &ReconcileSnapshot,
+    ) -> Result<()> {
+        let ns = instance.namespace().unwrap_or_default();
+        let inst_name = instance.name_any();
+        let client = &ctx.client;
+
+        // Keep both deployments at 0 during migration.
+        scale_deployment(client, &inst_name, &ns, 0).await?;
+        scale_deployment(client, &cron_depl_name(instance), &ns, 0).await?;
+
+        Ok(())
+    }
+}
+
+/// Scale down deployments, create migration Job, store state.
+/// Called by the `BeginDatabaseMigration` transition action.
+pub async fn begin_database_migration(instance: &OdooInstance, ctx: &Context) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let inst_name = instance.name_any();
+    let client = &ctx.client;
+
+    // Scale down both deployments.
+    scale_deployment(client, &inst_name, &ns, 0).await?;
+    scale_deployment(client, &cron_depl_name(instance), &ns, 0).await?;
+
+    // Load old cluster config (from status.activeCluster).
+    let old_cluster_name = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.active_cluster.as_deref())
+        .ok_or_else(|| {
+            crate::error::Error::config("cannot begin database migration: activeCluster not set")
+        })?;
+    let old_pg = load_postgres_cluster_by_name(ctx, old_cluster_name).await?;
+
+    // Load new cluster config (from spec.database.cluster / default).
+    let (new_cluster_name, new_pg) =
+        super::super::odoo_instance::load_postgres_cluster(ctx, instance).await?;
+
+    // Build env vars with connection details for both clusters.
+    let odoo_conf_name = format!("{inst_name}-odoo-conf");
+    let db = crate::helpers::db_name(instance);
+
+    let migration_env = build_migration_env(&old_pg, &new_pg, &odoo_conf_name, &db);
+
+    // Build the migration Job.
+    let image = instance.spec.image.as_deref().unwrap_or("odoo:18.0");
+    let job = build_migration_job(&inst_name, &ns, instance, image, migration_env);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+    let created = jobs.create(&PostParams::default(), &job).await?;
+    let job_name = created.name_any();
+    info!(%inst_name, %job_name, from = %old_cluster_name, to = %new_cluster_name, "created database migration job");
+
+    // Store migration state.
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+    let patch = json!({
+        "status": {
+            "dbMigrationJobName": &job_name,
+            "migrationPreviousCluster": old_cluster_name,
+            "message": format!("Migrating database from cluster {old_cluster_name} to {new_cluster_name}"),
+        }
+    });
+    api.patch_status(
+        &inst_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&patch),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Rollback: delete job, revert spec to previous cluster, clear status.
+/// Called by the `RollbackDatabaseMigration` transition action.
+pub async fn rollback_database_migration(instance: &OdooInstance, ctx: &Context) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let inst_name = instance.name_any();
+    let client = &ctx.client;
+
+    let prev_cluster = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.migration_previous_cluster.clone())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    warn!(%inst_name, %prev_cluster, "rolling back database migration");
+
+    // Delete migration job.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
+    if let Some(ref job_name) = instance
+        .status
+        .as_ref()
+        .and_then(|s| s.db_migration_job_name.clone())
+    {
+        let _ = jobs.delete(job_name, &DeleteParams::background()).await;
+    }
+
+    // Revert spec.database.cluster to previous value.
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+    if prev_cluster != "unknown" {
+        let spec_patch = json!({"spec": {"database": {"cluster": &prev_cluster}}});
+        api.patch(
+            &inst_name,
+            &PatchParams::apply(FIELD_MANAGER),
+            &Patch::Merge(&spec_patch),
+        )
+        .await?;
+    }
+
+    // Clear migration status.
+    let status_patch = json!({
+        "status": {
+            "dbMigrationJobName": null,
+            "migrationPreviousCluster": null,
+            "message": format!("Database migration rolled back to cluster {prev_cluster}"),
+        }
+    });
+    api.patch_status(
+        &inst_name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&status_patch),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Build env vars for the migration Job with both source and destination creds.
+fn build_migration_env(
+    old_pg: &PostgresClusterConfig,
+    new_pg: &PostgresClusterConfig,
+    odoo_conf_name: &str,
+    db_name: &str,
+) -> Vec<EnvVar> {
+    use super::super::helpers::cm_env;
+    vec![
+        // Source cluster (admin creds injected directly).
+        env("SRC_HOST", &old_pg.host),
+        env("SRC_PORT", old_pg.port.to_string()),
+        env("SRC_ADMIN_USER", &old_pg.admin_user),
+        env("SRC_ADMIN_PASSWORD", &old_pg.admin_password),
+        // Destination cluster (admin creds injected directly).
+        env("DST_HOST", &new_pg.host),
+        env("DST_PORT", new_pg.port.to_string()),
+        env("DST_ADMIN_USER", &new_pg.admin_user),
+        env("DST_ADMIN_PASSWORD", &new_pg.admin_password),
+        // Odoo role credentials (from ConfigMap, which has already been
+        // updated to point to the new cluster — but user/password are the same).
+        cm_env("DB_USER", odoo_conf_name, "db_user"),
+        cm_env("DB_PASSWORD", odoo_conf_name, "db_password"),
+        // Database name.
+        env("DB_NAME", db_name),
+    ]
+}
+
+/// Build the migration batch/v1 Job.
+fn build_migration_job(
+    inst_name: &str,
+    ns: &str,
+    instance: &OdooInstance,
+    image: &str,
+    env_vars: Vec<EnvVar>,
+) -> Job {
+    Job {
+        metadata: ObjectMeta {
+            generate_name: Some(format!("{inst_name}-migrate-db-")),
+            namespace: Some(ns.to_string()),
+            ..Default::default()
+        },
+        spec: Some(JobSpec {
+            backoff_limit: Some(0),
+            active_deadline_seconds: Some(7200),
+            ttl_seconds_after_finished: Some(300),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(
+                        [("app".to_string(), inst_name.to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    restart_policy: Some("Never".to_string()),
+                    security_context: Some(odoo_security_context()),
+                    image_pull_secrets: image_pull_secrets(instance),
+                    containers: vec![Container {
+                        name: "migrate-db".to_string(),
+                        image: Some(image.to_string()),
+                        command: Some(vec!["/bin/sh".to_string(), "-c".to_string()]),
+                        args: Some(vec![MIGRATE_SCRIPT.to_string()]),
+                        env: Some(env_vars),
+                        volume_mounts: Some(odoo_volume_mounts()),
+                        ..Default::default()
+                    }],
+                    volumes: Some(odoo_volumes(inst_name)),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}

--- a/src/controller/states/mod.rs
+++ b/src/controller/states/mod.rs
@@ -14,9 +14,11 @@ use super::state_machine::ReconcileSnapshot;
 mod backing_up;
 mod degraded;
 mod error;
+pub(crate) mod finalizing_database_migration;
 pub(crate) mod finalizing_filestore_migration;
 mod init_failed;
 mod initializing;
+pub(crate) mod migrating_database;
 pub(crate) mod migrating_filestore;
 mod provisioning;
 mod restoring;
@@ -29,9 +31,11 @@ mod upgrading;
 pub use backing_up::BackingUp;
 pub use degraded::Degraded;
 pub use error::Error;
+pub use finalizing_database_migration::FinalizingDatabaseMigration;
 pub use finalizing_filestore_migration::FinalizingFilestoreMigration;
 pub use init_failed::InitFailed;
 pub use initializing::Initializing;
+pub use migrating_database::MigratingDatabase;
 pub use migrating_filestore::MigratingFilestore;
 pub use provisioning::Provisioning;
 pub use restoring::Restoring;
@@ -64,6 +68,8 @@ pub fn state_for(phase: &OdooInstancePhase) -> &'static dyn State {
         OdooInstancePhase::InitFailed => &InitFailed,
         OdooInstancePhase::MigratingFilestore => &MigratingFilestore,
         OdooInstancePhase::FinalizingFilestoreMigration => &FinalizingFilestoreMigration,
+        OdooInstancePhase::MigratingDatabase => &MigratingDatabase,
+        OdooInstancePhase::FinalizingDatabaseMigration => &FinalizingDatabaseMigration,
         OdooInstancePhase::Starting => &Starting,
         OdooInstancePhase::Running => &Running,
         OdooInstancePhase::Degraded => &Degraded,

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -251,6 +251,8 @@ pub enum OdooInstancePhase {
     BackingUp,
     MigratingFilestore,
     FinalizingFilestoreMigration,
+    MigratingDatabase,
+    FinalizingDatabaseMigration,
     Error,
 }
 
@@ -270,6 +272,8 @@ impl std::fmt::Display for OdooInstancePhase {
             Self::BackingUp => "BackingUp",
             Self::MigratingFilestore => "MigratingFilestore",
             Self::FinalizingFilestoreMigration => "FinalizingFilestoreMigration",
+            Self::MigratingDatabase => "MigratingDatabase",
+            Self::FinalizingDatabaseMigration => "FinalizingDatabaseMigration",
             Self::Error => "Error",
         };
         write!(f, "{s}")
@@ -316,4 +320,14 @@ pub struct OdooInstanceStatus {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub migration_previous_storage_class: Option<String>,
+
+    // ── Database migration ──────────────────────────────────────────────
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_cluster: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_migration_job_name: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration_previous_cluster: Option<String>,
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -2,12 +2,10 @@
 //!
 //! Rejects updates that would:
 //! - Decrease filestore storage size (PVCs cannot shrink)
-//! - Change the postgres cluster (migration not implemented)
 //!
-//! StorageClass changes are allowed — the operator handles migration
-//! automatically via the MigratingFilestore phase.  Changes are rejected
-//! during unsafe phases (Restoring, Upgrading, BackingUp, MigratingFilestore,
-//! Uninitialized).
+//! StorageClass and database cluster changes are allowed — the operator
+//! handles migration automatically.  Changes are rejected during unsafe
+//! phases (Restoring, Upgrading, BackingUp, migrating phases, Uninitialized).
 
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, AdmissionReview};
 use tracing::{info, warn};
@@ -71,7 +69,8 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
         }
     }
 
-    // 2. Reject database cluster changes — cluster migration is not yet implemented.
+    // 2. Reject database cluster changes during unsafe phases.
+    //    Allow rollback: changing back to the previous cluster stored in status.
     let old_cluster = old
         .spec
         .database
@@ -84,11 +83,34 @@ fn validate(req: AdmissionRequest<OdooInstance>) -> AdmissionResponse {
         .as_ref()
         .and_then(|d| d.cluster.as_deref())
         .unwrap_or("");
-    if !old_cluster.is_empty() && new_cluster != old_cluster {
-        return AdmissionResponse::from(&req).deny(format!(
-            "spec.database.cluster: changing the postgres cluster from {:?} to {:?} is not supported",
-            old_cluster, new_cluster
-        ));
+    if !old_cluster.is_empty() && !new_cluster.is_empty() && new_cluster != old_cluster {
+        use crate::crd::odoo_instance::OdooInstancePhase::*;
+        let phase = old.status.as_ref().and_then(|s| s.phase.as_ref());
+        let prev_cluster = old
+            .status
+            .as_ref()
+            .and_then(|s| s.migration_previous_cluster.as_deref());
+        let is_rollback = prev_cluster.is_some_and(|c| c == new_cluster);
+        let blocked = !is_rollback
+            && matches!(
+                phase,
+                Some(
+                    Restoring
+                        | Upgrading
+                        | BackingUp
+                        | MigratingFilestore
+                        | FinalizingFilestoreMigration
+                        | MigratingDatabase
+                        | FinalizingDatabaseMigration
+                        | Uninitialized,
+                )
+            );
+        if blocked {
+            return AdmissionResponse::from(&req).deny(format!(
+                "spec.database.cluster: cannot change cluster while instance is in {} phase",
+                phase.unwrap()
+            ));
+        }
     }
 
     // 3. Reject storageClass changes when the instance is in an unsafe phase.
@@ -295,6 +317,36 @@ mod tests {
         ar.try_into().expect("valid AdmissionRequest")
     }
 
+    fn make_cluster_change_request(
+        old_cluster: &str,
+        new_cluster: &str,
+        old_phase: Option<&str>,
+    ) -> AdmissionRequest<OdooInstance> {
+        let mut old_obj = make_instance_json(None, Some(old_cluster));
+        if let Some(phase) = old_phase {
+            old_obj["status"] = serde_json::json!({"phase": phase});
+        }
+        let review: serde_json::Value = serde_json::json!({
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "request": {
+                "uid": "req-cluster",
+                "kind": { "group": "bemade.org", "version": "v1alpha1", "kind": "OdooInstance" },
+                "resource": { "group": "bemade.org", "version": "v1alpha1", "resource": "odooinstances" },
+                "name": "test",
+                "namespace": "default",
+                "operation": "UPDATE",
+                "userInfo": { "username": "test" },
+                "object": make_instance_json(None, Some(new_cluster)),
+                "oldObject": old_obj,
+                "dryRun": false,
+            }
+        });
+        let ar: kube::core::admission::AdmissionReview<OdooInstance> =
+            serde_json::from_value(review).expect("valid AdmissionReview");
+        ar.try_into().expect("valid AdmissionRequest")
+    }
+
     #[test]
     fn test_parse_quantity() {
         assert_eq!(parse_quantity("2Gi").unwrap(), 2 * 1024 * 1024 * 1024);
@@ -324,10 +376,33 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_rejects_cluster_change() {
+    fn test_validate_allows_cluster_change_when_running() {
         let req = make_update_request(None, Some("pg-cluster-a"), None, Some("pg-cluster-b"));
         let resp = validate(req);
-        assert!(!resp.allowed);
+        assert!(
+            resp.allowed,
+            "cluster change should be allowed (no phase = safe state)"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_cluster_change_when_restoring() {
+        let req = make_cluster_change_request("pg-a", "pg-b", Some("Restoring"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "cluster change should be rejected when Restoring"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_cluster_change_when_migrating_db() {
+        let req = make_cluster_change_request("pg-a", "pg-b", Some("MigratingDatabase"));
+        let resp = validate(req);
+        assert!(
+            !resp.allowed,
+            "cluster change should be rejected when already migrating"
+        );
     }
 
     #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod child_resources;
 mod degraded;
 mod finalizer;
 mod init_job;
+mod migrate_database;
 mod migrate_filestore;
 mod orphaned_jobs;
 mod restore_job;

--- a/tests/integration/migrate_database.rs
+++ b/tests/integration/migrate_database.rs
@@ -1,0 +1,297 @@
+//! Integration tests for database cluster migration.
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
+use serde_json::json;
+use std::time::Duration;
+
+use odoo_operator::controller::helpers::FIELD_MANAGER;
+use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
+
+use crate::common::*;
+
+/// Add a second cluster to the postgres-clusters Secret so migration has a target.
+async fn ensure_secondary_cluster(client: &kube::Client) {
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), "default");
+    let yaml = serde_yaml::to_string(&json!({
+        "default": {
+            "host": "localhost",
+            "port": 5432,
+            "adminUser": "postgres",
+            "adminPassword": "postgres",
+            "default": true
+        },
+        "secondary": {
+            "host": "secondary.local",
+            "port": 5432,
+            "adminUser": "postgres",
+            "adminPassword": "postgres",
+            "default": false
+        }
+    }))
+    .unwrap();
+    let patch = json!({
+        "stringData": { "clusters.yaml": yaml }
+    });
+    secrets
+        .patch(
+            "postgres-clusters",
+            &PatchParams::apply(FIELD_MANAGER),
+            &Patch::Merge(&patch),
+        )
+        .await
+        .unwrap();
+}
+
+/// Wait for a batch/v1 Job to appear with a name matching the given prefix.
+async fn wait_for_db_migration_job(client: &kube::Client, ns: &str, prefix: &str) -> String {
+    let jobs: Api<Job> = Api::namespaced(client.clone(), ns);
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let jobs = jobs.clone();
+            let pfx = prefix.to_string();
+            async move {
+                if let Ok(list) = jobs.list(&ListParams::default()).await {
+                    for job in list.items {
+                        if let Some(ref n) = job.metadata.name {
+                            if n.starts_with(&pfx) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                false
+            }
+        })
+        .await,
+        "migration job with prefix {prefix} never appeared"
+    );
+    let list = jobs.list(&ListParams::default()).await.unwrap();
+    list.items
+        .iter()
+        .find_map(|j| {
+            j.metadata
+                .name
+                .as_ref()
+                .filter(|n| n.starts_with(prefix))
+                .cloned()
+        })
+        .unwrap()
+}
+
+// ─── Test 1: Happy path from Running ────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_database_from_running() {
+    let name = "test-dbmig-run";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    ensure_secondary_cluster(c).await;
+
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    // Verify activeCluster is set after reaching Running.
+    let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let inst = api.get_status(name).await.unwrap();
+    let active_cluster = inst
+        .status
+        .as_ref()
+        .and_then(|s| s.active_cluster.as_deref());
+    assert_eq!(
+        active_cluster,
+        Some("default"),
+        "activeCluster should be set to 'default'"
+    );
+
+    // Change database.cluster to trigger migration.
+    patch_instance_spec(c, ns, name, json!({"database": {"cluster": "secondary"}})).await;
+
+    // Should transition to MigratingDatabase.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingDatabase).await,
+        "expected MigratingDatabase phase"
+    );
+
+    // Fake deployments scaled down.
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+
+    // Fake migration job success.
+    let job_name = wait_for_db_migration_job(c, ns, &format!("{name}-migrate-db-")).await;
+    fake_job_succeeded(c, ns, &job_name).await;
+
+    // Should transition through FinalizingDatabaseMigration → Starting.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Starting).await,
+        "expected Starting phase after migration"
+    );
+
+    // Verify activeCluster was updated.
+    let inst = api.get_status(name).await.unwrap();
+    let active_cluster = inst
+        .status
+        .as_ref()
+        .and_then(|s| s.active_cluster.as_deref());
+    assert_eq!(
+        active_cluster,
+        Some("secondary"),
+        "activeCluster should be updated to 'secondary'"
+    );
+
+    // Verify migration status fields are cleared.
+    let status = inst.status.as_ref().unwrap();
+    assert!(
+        status.db_migration_job_name.is_none(),
+        "dbMigrationJobName should be cleared"
+    );
+    assert!(
+        status.migration_previous_cluster.is_none(),
+        "migrationPreviousCluster should be cleared"
+    );
+
+    // Scale up to reach Running.
+    fake_deployment_ready(c, ns, name, 1).await;
+    let _handle = keep_deployment_ready(c.clone(), ns.to_string(), name.to_string(), 1);
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Running).await,
+        "expected Running phase"
+    );
+}
+
+// ─── Test 2: Migration from Stopped ─────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_database_from_stopped() {
+    let name = "test-dbmig-stop";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    ensure_secondary_cluster(c).await;
+
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    // Scale to 0 → Stopped.
+    patch_instance_spec(c, ns, name, json!({"replicas": 0})).await;
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Stopped).await,
+        "expected Stopped"
+    );
+
+    // Trigger migration.
+    patch_instance_spec(c, ns, name, json!({"database": {"cluster": "secondary"}})).await;
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingDatabase).await,
+        "expected MigratingDatabase"
+    );
+
+    // Fake job success.
+    let job_name = wait_for_db_migration_job(c, ns, &format!("{name}-migrate-db-")).await;
+    fake_job_succeeded(c, ns, &job_name).await;
+
+    // With replicas=0, should end up Stopped.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Stopped).await,
+        "expected Stopped after migration with replicas=0"
+    );
+}
+
+// ─── Test 3: Job failure → rollback ─────────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_database_job_failure_rollback() {
+    let name = "test-dbmig-fail";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    ensure_secondary_cluster(c).await;
+
+    let ready_handle = fast_track_to_running(&ctx, &format!("{name}-init")).await;
+    ready_handle.abort();
+
+    patch_instance_spec(c, ns, name, json!({"database": {"cluster": "secondary"}})).await;
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::MigratingDatabase).await,
+        "expected MigratingDatabase"
+    );
+
+    fake_deployment_ready(c, ns, name, 0).await;
+    fake_deployment_ready(c, ns, &format!("{name}-cron"), 0).await;
+
+    // Fake job failure.
+    let job_name = wait_for_db_migration_job(c, ns, &format!("{name}-migrate-db-")).await;
+    fake_job_failed(c, ns, &job_name).await;
+
+    // Rollback should revert spec.database.cluster and transition to Starting.
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Starting).await,
+        "expected Starting after rollback"
+    );
+
+    // Verify cluster was reverted.
+    let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let inst = api.get(name).await.unwrap();
+    let cluster = inst
+        .spec
+        .database
+        .as_ref()
+        .and_then(|d| d.cluster.as_deref());
+    assert_eq!(
+        cluster,
+        Some("default"),
+        "database.cluster should be reverted to 'default'"
+    );
+}
+
+// ─── Test 4: Not triggered during init ──────────────────────────────────────
+
+#[tokio::test]
+async fn migrate_database_not_triggered_during_init() {
+    let name = "test-dbmig-noinit";
+    let ctx = TestContext::new(name).await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    ensure_secondary_cluster(c).await;
+
+    // Create an init job to get into Initializing.
+    let init_api: Api<odoo_operator::crd::odoo_init_job::OdooInitJob> =
+        Api::namespaced(c.clone(), ns);
+    let init_job: odoo_operator::crd::odoo_init_job::OdooInitJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInitJob",
+        "metadata": { "name": format!("{name}-init"), "namespace": ns },
+        "spec": { "odooInstanceRef": { "name": name } }
+    }))
+    .unwrap();
+    init_api
+        .create(&PostParams::default(), &init_job)
+        .await
+        .unwrap();
+
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Initializing).await,
+        "expected Initializing"
+    );
+
+    // Change cluster while initializing.
+    patch_instance_spec(c, ns, name, json!({"database": {"cluster": "secondary"}})).await;
+
+    // Wait a bit and verify migration was NOT triggered.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let inst = api.get_status(name).await.unwrap();
+    let phase = inst.status.as_ref().and_then(|s| s.phase.as_ref());
+    assert_ne!(
+        phase,
+        Some(&OdooInstancePhase::MigratingDatabase),
+        "migration should not trigger during Initializing"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds two new phases (`MigratingDatabase`, `FinalizingDatabaseMigration`) to migrate an OdooInstance between PostgreSQL clusters
- Triggered by changing `spec.database.cluster` — operator detects mismatch via new `status.activeCluster` field
- Migration Job pipes `pg_dump | pg_restore` between clusters, then cleans up old role on source
- Rollback on failure reverts `spec.database.cluster` to previous value
- Webhook updated to allow cluster changes during safe phases (Running, Degraded, Stopped)
- Makefile now supports `KUBE_CONTEXT` variable (defaults to minikube)

## Verified
- `cargo fmt`, `cargo clippy`, `cargo test` (all 27 integration + 16 webhook unit tests pass)
- End-to-end on minikube: migrated a live OdooInstance from standalone postgres to a CNPG cluster, verified data intact and old role cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)