### PR TITLE
fix: use proper issuer for self-signed cert and CA injection

### DIFF
--- a/charts/odoo-operator/templates/webhooks/certificate.yaml
+++ b/charts/odoo-operator/templates/webhooks/certificate.yaml
@@ -9,5 +9,5 @@ spec:
     - {{ .Release.Name }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
-    name: {{ .Release.Name }}-selfsigned-issuer
+    name: {{ .Release.Name }}-ca-issuer
   secretName: {{ .Release.Name }}-webhook-cert

--- a/charts/odoo-operator/templates/webhooks/selfsigned-issuer.yaml
+++ b/charts/odoo-operator/templates/webhooks/selfsigned-issuer.yaml
@@ -5,3 +5,25 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-webhook-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ .Release.Name }}-webhook-ca
+  secretName: {{ .Release.Name }}-webhook-ca
+  issuerRef:
+    kind: Issuer
+    name: {{ .Release.Name }}-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Release.Name }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ .Release.Name }}-webhook-ca

--- a/charts/odoo-operator/templates/webhooks/validating-webhook.yaml
+++ b/charts/odoo-operator/templates/webhooks/validating-webhook.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Release.Name }}-validating-webhook
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-webhook-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-webhook-ca
 webhooks:
   - name: vodooinstance.kb.io
     admissionReviewVersions: ["v1"]


### PR DESCRIPTION
Adds an Issuer and its Certificate to the odoo-operator namespace, for adding the CA bundle to the webhook certificate.