### PR TITLE
fix(restore): harden pipeline against un-neutralized DB incidents

### DIFF
--- a/STATE_MACHINE.md
+++ b/STATE_MACHINE.md
@@ -61,7 +61,7 @@ stateDiagram-v2
     Upgrading --> Starting : [upgrade_job absent]
 
     Restoring --> Starting : [restore_job succeeded] / CompleteRestoreJob, MarkDbInitialized
-    Restoring --> Starting : [restore_job failed] / FailRestoreJob
+    Restoring --> Uninitialized : [restore_job failed] / FailRestoreJob, MarkDbUninitialized
     Restoring --> Starting : [restore_job absent]
 
     Stopped --> MigratingFilestore : [storage_class_mismatch] / BeginFilestoreMigration

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,79 +1,121 @@
 #!/bin/sh
-# Restores an Odoo database from a backup artifact in /mnt/backup/.
+# Restores an Odoo database (and filestore, for zip backups) from an artifact
+# in /mnt/backup/.
 #
-# The format is detected by filename:
-#   /mnt/backup/backup.zip  — Odoo zip backup  (odoo db load)
-#   /mnt/backup/dump.dump   — pg_dump custom format (pg_restore)
-#   /mnt/backup/dump.sql    — pg_dump plain SQL (psql)
+# Format detected by filename:
+#   /mnt/backup/backup.zip  — Odoo zip backup: dump.sql + filestore/ tree
+#   /mnt/backup/dump.dump   — pg_dump custom format
+#   /mnt/backup/dump.sql    — pg_dump plain SQL
+#
+# Pipeline (identical for all three formats):
+#   1. Load the database into $DB_NAME with strict error handling.
+#   2. Run `odoo neutralize` if NEUTRALIZE=True.
+#   3. Verify neutralization flag and that no active mail servers remain.
+#   4. Rsync the extracted filestore into the PVC (zip format only).
+#
+# On ANY failure after this script touches the target DB, the DB is dropped
+# via EXIT trap so the instance transitions to Uninitialized rather than
+# starting up against a half-restored or un-neutralized database.
 #
 # Required env vars:
 #   HOST, PORT, USER, PASSWORD — PostgreSQL connection
 #   DB_NAME                    — target database name
 #   NEUTRALIZE                 — "True" to neutralize after restore, "False" to skip
 
-set -ex
+set -eu
 export PGPASSWORD=$PASSWORD
+
+DB_TOUCHED=0
+
+cleanup_on_failure() {
+    rc=$?
+    if [ "$rc" -ne 0 ] && [ "$DB_TOUCHED" -eq 1 ]; then
+        echo "=== Restore failed (rc=$rc) — dropping database $DB_NAME ==="
+        dropdb -h "$HOST" -p "$PORT" -U "$USER" --if-exists --force "$DB_NAME" || \
+            echo "WARNING: dropdb failed — database may be left behind"
+    fi
+    exit "$rc"
+}
+trap cleanup_on_failure EXIT
 
 echo "=== Starting restore process ==="
 echo "Target database: $DB_NAME"
 echo "Neutralize: $NEUTRALIZE"
-
-# Drop the target database unconditionally using SQL catalog check.
-# We cannot rely on `odoo db drop` or `odoo db load -f` because they use
-# exp_db_exist() which tries to *connect* to the database. An "invalid"
-# database (e.g. from a previously interrupted CREATE DATABASE) exists in
-# pg_database but refuses connections, so exp_db_exist returns False and
-# the drop is silently skipped. DROP DATABASE IF EXISTS works on the catalog
-# directly and handles both valid and invalid databases.
-echo "=== Dropping existing database if present ==="
-psql -h "$HOST" -p "$PORT" -U "$USER" -d postgres \
-  -c "DROP DATABASE IF EXISTS \"$DB_NAME\"" || true
-
 echo "Backup directory contents:"
 ls -lh /mnt/backup/
 
-if [ -f /mnt/backup/dump.dump ]; then
-    echo "Found dump.dump — using pg_restore method"
+# Drop any pre-existing target database. An "invalid" database (e.g. from a
+# previously interrupted CREATE DATABASE) exists in pg_database but refuses
+# connections, so exp_db_exist-based checks silently skip it. DROP DATABASE
+# IF EXISTS works on the catalog directly.
+echo "=== Dropping existing database if present ==="
+psql -h "$HOST" -p "$PORT" -U "$USER" -d postgres \
+    -c "DROP DATABASE IF EXISTS \"$DB_NAME\" WITH (FORCE)"
+
+WORKDIR=""
+FILESTORE_SRC=""
+
+extract_zip() {
+    WORKDIR=$(mktemp -d)
+    echo "=== Extracting zip backup to $WORKDIR ==="
+    # The odoo image ships python3 but not unzip. zipfile handles Odoo's
+    # dump.sql + filestore/ tree without any external deps.
+    python3 -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+        /mnt/backup/backup.zip "$WORKDIR"
+    if [ ! -f "$WORKDIR/dump.sql" ]; then
+        echo "ERROR: backup.zip does not contain dump.sql"
+        ls -la "$WORKDIR"
+        exit 1
+    fi
+    if [ -d "$WORKDIR/filestore" ]; then
+        FILESTORE_SRC="$WORKDIR/filestore"
+        echo "Found filestore directory in zip"
+    else
+        echo "No filestore directory in zip (DB-only backup)"
+    fi
+}
+
+load_sql() {
+    SQL_FILE="$1"
+    echo "=== Loading plain SQL dump into $DB_NAME ==="
     createdb -h "$HOST" -p "$PORT" -U "$USER" "$DB_NAME"
-    # pg_restore may emit warnings (ownership, sequences) but still succeed; || true guards that.
-    pg_restore -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" --no-owner /mnt/backup/dump.dump || true
+    DB_TOUCHED=1
+    # Filter cross-cluster noise (ownership/ACL statements reference roles
+    # that may not exist in the target cluster). The actual data and schema
+    # statements still flow through with ON_ERROR_STOP active.
+    #
+    # Each pattern requires the matching statement to begin AND end on the
+    # same line (ending in `;`) — pg_dump plain output always emits these
+    # forms as single-line statements, but requiring the terminator makes
+    # the filter robust to any future multi-line variant: a partial match
+    # simply won't fire, instead of surgically corrupting a multi-line stmt.
+    sed -E \
+        -e '/^ALTER [A-Z ]+[^;]*OWNER TO [^;]*;$/d' \
+        -e '/^GRANT [^;]*;$/d' \
+        -e '/^REVOKE [^;]*;$/d' \
+        -e '/^REASSIGN OWNED BY [^;]*;$/d' \
+        "$SQL_FILE" | \
+        psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+             -v ON_ERROR_STOP=1 --quiet
+}
 
-elif [ -f /mnt/backup/dump.sql ]; then
-    echo "Found dump.sql — using psql method"
+load_custom_dump() {
+    echo "=== Loading custom-format dump into $DB_NAME ==="
     createdb -h "$HOST" -p "$PORT" -U "$USER" "$DB_NAME"
-    # psql may emit non-fatal errors; || true guards that.
-    psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" -f /mnt/backup/dump.sql || true
-
-elif [ -f /mnt/backup/backup.zip ]; then
-    echo "Found backup.zip — using odoo db load method"
-    ls -lh /mnt/backup/backup.zip
-    NEUTRALIZE_FLAG=""
-    [ "$NEUTRALIZE" = "True" ] && NEUTRALIZE_FLAG="-n"
-    odoo db --db_host "$HOST" --db_port "$PORT" --db_user "$USER" --db_password "$PASSWORD" \
-      load $NEUTRALIZE_FLAG "$DB_NAME" /mnt/backup/backup.zip
-
-else
-    echo "ERROR: No backup file found in /mnt/backup/"
-    ls -la /mnt/backup/
-    exit 1
-fi
-
-# Verify the restore actually produced a working database.
-# pg_restore/odoo-db-load exit codes are unreliable (non-zero on harmless
-# ownership warnings), so we use || true above and validate here instead.
-echo "=== Verifying restore integrity ==="
-if ! odoo --stop-after-init -d "$DB_NAME" \
-  --db_host "$HOST" --db_port "$PORT" --db_user "$USER" --db_password "$PASSWORD" \
-  -c /etc/odoo/odoo.conf --no-http; then
-    echo "FATAL: restore verification failed — database is broken"
-    exit 1
-fi
-echo "Restore verification passed"
+    DB_TOUCHED=1
+    pg_restore -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+        --no-owner --no-acl --exit-on-error \
+        /mnt/backup/dump.dump
+}
 
 reinit_db_params() {
     echo "=== Re-initializing database parameters ==="
-    psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" << 'EOSQL'
-DO $$
+    # Tagged dollar quote ($body$) avoids a shell-interpretation pitfall:
+    # dash (which is /bin/sh in the odoo image) expands $$ inside quoted
+    # heredocs, mangling PL/pgSQL's anonymous DO block before it reaches psql.
+    psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+         -v ON_ERROR_STOP=1 << 'EOSQL'
+DO $body$
 DECLARE
     new_secret TEXT := gen_random_uuid()::text;
     new_uuid TEXT := gen_random_uuid()::text;
@@ -83,41 +125,116 @@ BEGIN
         'web.base.url', 'base.login_cooldown_after', 'base.login_cooldown_duration'
     );
     INSERT INTO ir_config_parameter (key, value, create_uid, create_date, write_uid, write_date) VALUES
-        ('database.secret',              new_secret,          1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
-        ('database.uuid',                new_uuid,            1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
-        ('database.create_date',         LOCALTIMESTAMP::text,1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
+        ('database.secret',              new_secret,              1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
+        ('database.uuid',                new_uuid,                1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
+        ('database.create_date',         LOCALTIMESTAMP::text,    1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
         ('web.base.url',                 'http://localhost:8069', 1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
-        ('base.login_cooldown_after',    '10',                1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
-        ('base.login_cooldown_duration', '60',                1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP);
-    RAISE NOTICE 'Database parameters re-initialized successfully';
-EXCEPTION WHEN OTHERS THEN
-    RAISE WARNING 'Could not re-initialize database parameters: %', SQLERRM;
-END $$;
+        ('base.login_cooldown_after',    '10',                    1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP),
+        ('base.login_cooldown_duration', '60',                    1, LOCALTIMESTAMP, 1, LOCALTIMESTAMP);
+END $body$;
 EOSQL
-    echo "Database parameter re-initialization complete"
 }
 
 verify_neutralization() {
     echo "=== Verifying neutralization ==="
     NEUTRALIZED=$(psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" -t -A \
-        -c "SELECT value FROM ir_config_parameter WHERE key = 'database.is_neutralized';" 2>/dev/null || echo "")
-    if [ "$NEUTRALIZED" = "true" ] || [ "$NEUTRALIZED" = "True" ]; then
-        echo "Neutralization verified: database.is_neutralized = $NEUTRALIZED"
-        return 0
+        -c "SELECT value FROM ir_config_parameter WHERE key = 'database.is_neutralized';")
+    if [ "$NEUTRALIZED" != "true" ] && [ "$NEUTRALIZED" != "True" ]; then
+        echo "CRITICAL: database.is_neutralized='$NEUTRALIZED' (expected 'true')"
+        exit 1
+    fi
+    echo "database.is_neutralized = $NEUTRALIZED"
+}
+
+# Verify no active mail servers remain after neutralization. `odoo neutralize`
+# relies on per-module hooks; if a custom module owns a mail model whose hook
+# is missing, or if fetchmail's neutralize hook didn't fire (module not
+# installed at neutralize time, upgrade skew, etc.), active mail servers can
+# survive neutralization. Those will cheerfully fetch from / send to real
+# mail accounts. Catch them here before the instance starts.
+verify_no_active_mail_servers() {
+    echo "=== Verifying no active mail servers ==="
+    # Odoo's neutralize deletes all ir_mail_server rows and inserts a single
+    # sentinel record with smtp_host='invalid'. That's expected. The incident
+    # we guard against is a REAL smtp_host (real hostname, IP, or "localhost")
+    # surviving neutralization — which can happen when a custom module owns
+    # a mail model whose neutralize hook is missing or didn't run.
+    OUT_DANGEROUS=$(psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" -t -A \
+        -c "SELECT COUNT(*) FROM ir_mail_server WHERE active AND smtp_host != 'invalid'")
+    if [ "$OUT_DANGEROUS" != "0" ]; then
+        echo "CRITICAL: $OUT_DANGEROUS active outgoing mail servers with real hosts after neutralize"
+        psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+            -c "SELECT id, name, smtp_host FROM ir_mail_server WHERE active AND smtp_host != 'invalid'"
+        exit 1
+    fi
+    echo "Outgoing mail servers: no dangerous hosts (sentinel-only)"
+
+    # fetchmail_server only exists when the fetchmail module is installed.
+    FETCH_EXISTS=$(psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" -t -A \
+        -c "SELECT to_regclass('public.fetchmail_server') IS NOT NULL")
+    if [ "$FETCH_EXISTS" = "t" ]; then
+        IN_ACTIVE=$(psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" -t -A \
+            -c "SELECT COUNT(*) FROM fetchmail_server WHERE active")
+        if [ "$IN_ACTIVE" != "0" ]; then
+            echo "CRITICAL: $IN_ACTIVE active incoming mail servers after neutralize"
+            psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+                -c "SELECT id, name, server FROM fetchmail_server WHERE active"
+            exit 1
+        fi
+        echo "Incoming mail servers: 0 active"
     else
-        echo "CRITICAL: Neutralization verification FAILED (database.is_neutralized='$NEUTRALIZED')"
-        echo "Dropping database to prevent un-neutralized DB from running."
-        dropdb -h "$HOST" -p "$PORT" -U "$USER" --if-exists "$DB_NAME"
-        return 1
+        echo "fetchmail_server table absent (module not installed) — skipping"
     fi
 }
 
-if [ "$NEUTRALIZE" = "True" ]; then
-    reinit_db_params
-    odoo neutralize --db_host "$HOST" --db_port "$PORT" --db_user "$USER" --db_password "$PASSWORD" -d "$DB_NAME"
-    verify_neutralization || exit 1
+# Additive merge — filestore entries are content-addressable (sha1 filenames),
+# so leaving existing files on the PVC is safe: any colliding name refers to
+# identical content by construction. shutil.copytree with dirs_exist_ok=True
+# merges source into dest without removing entries already there. rsync isn't
+# available in the odoo image.
+sync_filestore() {
+    if [ -z "$FILESTORE_SRC" ]; then
+        return 0
+    fi
+    DEST="/var/lib/odoo/filestore/$DB_NAME"
+    echo "=== Syncing filestore: $FILESTORE_SRC/ -> $DEST/ ==="
+    mkdir -p "$DEST"
+    python3 -c "import shutil, sys; shutil.copytree(sys.argv[1], sys.argv[2], dirs_exist_ok=True)" \
+        "$FILESTORE_SRC" "$DEST"
+    echo "Filestore sync complete"
+}
+
+# ── Dispatch on input format ─────────────────────────────────────────────
+if [ -f /mnt/backup/dump.dump ]; then
+    load_custom_dump
+elif [ -f /mnt/backup/dump.sql ]; then
+    load_sql /mnt/backup/dump.sql
+elif [ -f /mnt/backup/backup.zip ]; then
+    extract_zip
+    load_sql "$WORKDIR/dump.sql"
 else
-    echo "Skipping neutralization (neutralize=False)"
+    echo "ERROR: No backup file found in /mnt/backup/"
+    ls -la /mnt/backup/
+    exit 1
 fi
 
+# ── Neutralize ───────────────────────────────────────────────────────────
+if [ "$NEUTRALIZE" = "True" ]; then
+    reinit_db_params
+    echo "=== Running odoo neutralize ==="
+    odoo neutralize \
+        --db_host "$HOST" --db_port "$PORT" \
+        --db_user "$USER" --db_password "$PASSWORD" \
+        -d "$DB_NAME"
+    verify_neutralization
+    verify_no_active_mail_servers
+else
+    echo "Skipping neutralization (NEUTRALIZE=$NEUTRALIZE)"
+fi
+
+# ── Filestore (zip backups only) ─────────────────────────────────────────
+sync_filestore
+
+# Success — disarm the cleanup trap so we don't drop the DB on normal exit.
+DB_TOUCHED=0
 echo "=== Restore process complete ==="

--- a/src/bin/statemachine_diagram.rs
+++ b/src/bin/statemachine_diagram.rs
@@ -28,6 +28,7 @@ fn main() {
 fn action_name(a: &TransitionAction) -> &'static str {
     match a {
         TransitionAction::MarkDbInitialized => "MarkDbInitialized",
+        TransitionAction::MarkDbUninitialized => "MarkDbUninitialized",
         TransitionAction::CompleteInitJob => "CompleteInitJob",
         TransitionAction::FailInitJob => "FailInitJob",
         TransitionAction::CompleteRestoreJob => "CompleteRestoreJob",

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -150,9 +150,16 @@ impl ReconcileSnapshot {
         let jobs_api: Api<Job> = Api::namespaced(client.clone(), ns);
 
         // ── Init jobs ───────────────────────────────────────────────────
+        // db_initialized is authoritative from status — it's written by the
+        // MarkDbInitialized / MarkDbUninitialized transition actions.  Old
+        // Completed init/restore CRs must NOT override it back to true: a
+        // failed restore drops the DB and explicitly flips the status to
+        // false, even though an older Completed init CR still exists in
+        // history.  Respecting that flip is what keeps pods down after a
+        // failed restore.
         let mut active_init_job: Option<OdooInitJob> = None;
         let mut init_job_active = false;
-        let mut db_init_from_jobs = db_initialized;
+        let db_init_from_jobs = db_initialized;
         {
             let inits: Api<OdooInitJob> = Api::namespaced(client.clone(), ns);
             for job in inits.list(&ListParams::default()).await?.items {
@@ -161,10 +168,7 @@ impl ReconcileSnapshot {
                 }
                 let phase = job.status.as_ref().and_then(|s| s.phase.as_ref());
                 match phase {
-                    Some(Phase::Completed) => {
-                        db_init_from_jobs = true;
-                    }
-                    Some(Phase::Failed) => {}
+                    Some(Phase::Completed) | Some(Phase::Failed) => {}
                     _ => {
                         // Running, Pending, or no status — this is the active one.
                         if active_init_job.is_none() {
@@ -187,10 +191,7 @@ impl ReconcileSnapshot {
                 }
                 let phase = job.status.as_ref().and_then(|s| s.phase.as_ref());
                 match phase {
-                    Some(Phase::Completed) => {
-                        db_init_from_jobs = true;
-                    }
-                    Some(Phase::Failed) => {}
+                    Some(Phase::Completed) | Some(Phase::Failed) => {}
                     _ => {
                         if active_restore_job.is_none() {
                             restore_job_active = true;
@@ -440,6 +441,7 @@ async fn resolve_job_status(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransitionAction {
     MarkDbInitialized,
+    MarkDbUninitialized,
     CompleteInitJob,
     FailInitJob,
     CompleteRestoreJob,
@@ -473,6 +475,17 @@ pub async fn execute_action(
             let name = instance.name_any();
             let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
             let patch = json!({"status": {"dbInitialized": true}});
+            api.patch_status(
+                &name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await?;
+        }
+        MarkDbUninitialized => {
+            let name = instance.name_any();
+            let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+            let patch = json!({"status": {"dbInitialized": false}});
             api.patch_status(
                 &name,
                 &PatchParams::apply(FIELD_MANAGER),
@@ -1029,12 +1042,19 @@ pub static TRANSITIONS: &[Transition] = &[
             TransitionAction::MarkDbInitialized,
         ],
     },
+    // Failed restore: leave pods down and treat the instance as uninitialized.
+    // The restore script drops the target DB on any failure, so db_initialized
+    // accurately reflects reality. Bringing pods back up after a failed restore
+    // risks serving traffic against a half-restored or un-neutralized DB.
     Transition {
         from: Restoring,
-        to: Starting,
+        to: Uninitialized,
         guard: |_, s| s.restore_job == Failed,
         guard_name: "restore_job failed",
-        actions: &[TransitionAction::FailRestoreJob],
+        actions: &[
+            TransitionAction::FailRestoreJob,
+            TransitionAction::MarkDbUninitialized,
+        ],
     },
     // Orphaned: restore job CR deleted while in Restoring.
     Transition {

--- a/src/controller/states/uninitialized.rs
+++ b/src/controller/states/uninitialized.rs
@@ -8,7 +8,7 @@ use crate::crd::odoo_instance::OdooInstance;
 use crate::error::Result;
 
 use super::{Context, ReconcileSnapshot, State};
-use crate::controller::helpers::controller_owner_ref;
+use crate::controller::helpers::{controller_owner_ref, cron_depl_name};
 use crate::controller::state_machine::{scale_deployment, JobStatus};
 
 /// Uninitialized: waiting for an OdooInitJob or OdooRestoreJob to be created.
@@ -30,6 +30,7 @@ impl State for Uninitialized {
         let ns = instance.namespace().unwrap_or_default();
         let name = instance.name_any();
         scale_deployment(&ctx.client, &name, &ns, 0).await?;
+        scale_deployment(&ctx.client, cron_depl_name(instance).as_str(), &ns, 0).await?;
 
         // Auto-create an OdooInitJob if auto-init is enabled and no job exists yet.
         let init_spec = &instance.spec.init;

--- a/tests/integration/restore_job.rs
+++ b/tests/integration/restore_job.rs
@@ -82,3 +82,69 @@ async fn restore_job_lifecycle() -> anyhow::Result<()> {
     ready_handle.abort();
     Ok(())
 }
+
+/// A failed restore must NOT bring pods back up. The instance drops back to
+/// Uninitialized with dbInitialized=false so the next init or restore job is
+/// required before traffic can be served again.
+#[tokio::test]
+async fn failed_restore_transitions_to_uninitialized() -> anyhow::Result<()> {
+    let ctx = TestContext::new("test-restore-fail").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    // Bring the instance to Running first so dbInitialized=true, web+cron up.
+    let ready_handle = fast_track_to_running(&ctx, "test-restore-fail-init").await;
+
+    let restore_api: Api<OdooRestoreJob> = Api::namespaced(c.clone(), ns);
+    let restore_job: OdooRestoreJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooRestoreJob",
+        "metadata": { "name": "test-restore-fail-job", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "test-restore-fail" },
+            "source": {
+                "type": "s3",
+                "s3": {
+                    "bucket": "test-bucket",
+                    "objectKey": "test-key",
+                    "endpoint": "http://localhost:9000",
+                },
+            },
+        }
+    }))
+    .unwrap();
+    restore_api
+        .create(&PostParams::default(), &restore_job)
+        .await
+        .expect("failed to create OdooRestoreJob");
+
+    assert!(
+        wait_for_phase(c, ns, "test-restore-fail", OdooInstancePhase::Restoring).await,
+        "expected Restoring after restore job created"
+    );
+
+    let k8s_job = wait_for_k8s_job_name::<OdooRestoreJob>(c, ns, "test-restore-fail-job").await;
+    fake_job_failed(c, ns, &k8s_job).await;
+
+    assert!(
+        wait_for_phase(c, ns, "test-restore-fail", OdooInstancePhase::Uninitialized).await,
+        "expected Uninitialized after restore job failed"
+    );
+
+    // Both deployments must remain at 0 — no pods come back up.
+    check_deployment_scale(c, ns, "test-restore-fail", 0).await?;
+    check_deployment_scale(c, ns, "test-restore-fail-cron", 0).await?;
+
+    // dbInitialized must be flipped back to false so a subsequent restart
+    // cannot transition Provisioning → Starting against a dropped DB.
+    let instances: Api<odoo_operator::crd::odoo_instance::OdooInstance> =
+        Api::namespaced(c.clone(), ns);
+    let inst = instances.get("test-restore-fail").await?;
+    assert_eq!(
+        inst.status.map(|s| s.db_initialized),
+        Some(false),
+        "dbInitialized must be false after failed restore"
+    );
+
+    ready_handle.abort();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes an incident where a failed restore left a staging server running against a half-restored, un-neutralized production DB — causing it to fetch/send emails from real accounts.

Two independent defects combined to cause the incident:

1. **State machine treated failed restores as recoverable.** `Restoring → Starting` (on `restore_job == Failed`) scaled pods back up against whatever state the DB had been left in.
2. **`restore.sh` could leave a fully-restored, un-neutralized DB.** `set -e` + `odoo --stop-after-init` verification would exit on registry-load errors or neutralize failures, but the partially-restored DB was never cleaned up.

## Fix

**State machine**
- `Restoring → Uninitialized` on `restore_job == Failed`
- New `MarkDbUninitialized` action to flip `status.dbInitialized=false`
- Removed snapshot override that promoted `db_initialized=true` from historical Completed init/restore CRs (was clobbering explicit patches)
- `Uninitialized` now scales both web and cron deployments to 0

**restore.sh rewrite**
- `set -euo pipefail` + single `EXIT` trap that `dropdb --force`s the target on any non-zero exit after the DB has been touched
- Dropped the registry-load verification gate (false positive on any schema drift — the actual motivation for the incident)
- Unified pipeline for all three formats (zip, dump, sql) funnelling into: load → reinit params → neutralize → verify neutralize flag → verify no active mail servers → filestore merge
- `pg_restore --no-owner --no-acl --exit-on-error` for custom format
- `sed` filter + `psql -v ON_ERROR_STOP=1` for plain SQL (including unpacked zip); filter patterns anchored to same-line terminator so multi-line statements are never partially deleted
- Zip extraction via Python `zipfile` (no `unzip` in odoo image)
- Filestore merge via Python `shutil.copytree(dirs_exist_ok=True)` — additive, safe because filestore is content-addressable (no `rsync` in odoo image)
- Mail-server verification allows Odoo's standard neutralize sentinel (`smtp_host='invalid'`) but flags any real host that survives
- Tagged dollar quoting (`\$body\$`) for the DO block — `\$\$` inside quoted heredocs gets mangled by dash

## Testing

**envtest:**
- Existing `restore_job_lifecycle` (success path) still passes
- New `failed_restore_transitions_to_uninitialized` confirms Uninitialized transition, both deployments at 0, `dbInitialized=false`

**Live minikube cluster with real verajet zip from bemade minio:**
- Success path: 10-stage pipeline executed cleanly, instance reached Starting with `dbInitialized=true`
- Mangled-SQL failure path: `psql` aborted on garbage, trap dropped the partial DB (verified gone from `pg_database`), restore job → Failed, instance → Uninitialized, `dbInitialized=false`, both deployments remained at 0