### PR TITLE
fix(state-machine): avoid phase flap with queued backup jobs

### DIFF
--- a/STATE_MACHINE.md
+++ b/STATE_MACHINE.md
@@ -43,6 +43,8 @@ stateDiagram-v2
     Degraded --> Running : [ready >= desired]
     Degraded --> Starting : [ready == 0]
 
+    BackingUp --> BackingUp : [backup succeeded && another pending] / CompleteBackupJob
+    BackingUp --> BackingUp : [backup failed && another pending] / FailBackupJob
     BackingUp --> Stopped : [backup succeeded && replicas == 0] / CompleteBackupJob
     BackingUp --> Stopped : [backup failed && replicas == 0] / FailBackupJob
     BackingUp --> Running : [backup succeeded && ready >= desired] / CompleteBackupJob

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -86,6 +86,12 @@ pub struct ReconcileSnapshot {
     pub active_upgrade_job: Option<OdooUpgradeJob>,
     pub active_backup_job: Option<OdooBackupJob>,
 
+    // Count of non-terminal OdooBackupJob CRs for the instance.  Used to
+    // detect the "queued-behind" scenario where one backup completes while
+    // another is still pending; we need to stay in BackingUp until all of
+    // them finish, else the phase flaps BackingUp → Running → BackingUp.
+    pub pending_backup_jobs: usize,
+
     // ── Filestore migration ─────────────────────────────────────────────
     pub storage_class_mismatch: bool,
     pub actual_storage_class: Option<String>,
@@ -226,6 +232,7 @@ impl ReconcileSnapshot {
         // ── Backup jobs ─────────────────────────────────────────────────
         let mut active_backup_job: Option<OdooBackupJob> = None;
         let mut backup_job_active = false;
+        let mut pending_backup_jobs: usize = 0;
         {
             let backups: Api<OdooBackupJob> = Api::namespaced(client.clone(), ns);
             for job in backups.list(&ListParams::default()).await?.items {
@@ -236,6 +243,7 @@ impl ReconcileSnapshot {
                 match phase {
                     Some(Phase::Completed) | Some(Phase::Failed) => {}
                     _ => {
+                        pending_backup_jobs += 1;
                         if active_backup_job.is_none() {
                             backup_job_active = true;
                             active_backup_job = Some(job);
@@ -383,6 +391,7 @@ impl ReconcileSnapshot {
             active_restore_job,
             active_upgrade_job,
             active_backup_job,
+            pending_backup_jobs,
             storage_class_mismatch,
             actual_storage_class,
             migration_job,
@@ -902,6 +911,28 @@ pub static TRANSITIONS: &[Transition] = &[
         actions: &[],
     },
     // ── BackingUp ───────────────────────────────────────────
+    //
+    // Self-loops for queued-behind backup jobs.  When one OdooBackupJob's
+    // K8s Job completes but another non-terminal OdooBackupJob CR still
+    // exists for the same instance, we complete the finished CR (so the
+    // next reconcile picks up the next one) but STAY in BackingUp.  Without
+    // this the phase flaps BackingUp → Running → BackingUp between the two
+    // jobs.  Placed first so the exit transitions below don't steal the
+    // edge when pending_backup_jobs > 1.
+    Transition {
+        from: BackingUp,
+        to: BackingUp,
+        guard: |_, s| s.backup_job == Succeeded && s.pending_backup_jobs > 1,
+        guard_name: "backup succeeded && another pending",
+        actions: &[TransitionAction::CompleteBackupJob],
+    },
+    Transition {
+        from: BackingUp,
+        to: BackingUp,
+        guard: |_, s| s.backup_job == Failed && s.pending_backup_jobs > 1,
+        guard_name: "backup failed && another pending",
+        actions: &[TransitionAction::FailBackupJob],
+    },
     Transition {
         from: BackingUp,
         to: Stopped,

--- a/tests/integration/backup_job.rs
+++ b/tests/integration/backup_job.rs
@@ -49,3 +49,73 @@ async fn backup_job_lifecycle() {
 
     ready_handle.abort();
 }
+
+/// Two OdooBackupJobs queued at nearly the same time must not cause the
+/// OdooInstance phase to flap BackingUp → Running → BackingUp as the first
+/// one completes and the reconciler picks up the second.  Regression test
+/// for the concurrent-backup phase-flap bug.
+#[tokio::test]
+async fn concurrent_backups_do_not_flap_phase() {
+    let ctx = TestContext::new("test-backup-flap").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let ready_handle = fast_track_to_running(&ctx, "test-backup-flap-init").await;
+
+    let backup_api: Api<OdooBackupJob> = Api::namespaced(c.clone(), ns);
+    for name in ["test-backup-flap-a", "test-backup-flap-b"] {
+        let spec: OdooBackupJob = serde_json::from_value(json!({
+            "apiVersion": "bemade.org/v1alpha1",
+            "kind": "OdooBackupJob",
+            "metadata": { "name": name, "namespace": ns },
+            "spec": {
+                "odooInstanceRef": { "name": "test-backup-flap" },
+                "destination": {
+                    "bucket": "test-bucket",
+                    "objectKey": format!("test-key-{name}"),
+                    "endpoint": "http://localhost:9000",
+                },
+            }
+        }))
+        .unwrap();
+        backup_api
+            .create(&PostParams::default(), &spec)
+            .await
+            .expect("failed to create OdooBackupJob");
+    }
+
+    assert!(
+        wait_for_phase(c, ns, "test-backup-flap", OdooInstancePhase::BackingUp).await,
+        "expected BackingUp after first backup job created"
+    );
+
+    // Complete the first K8s Job (whichever the snapshot picked first).
+    let k8s_job_a = wait_for_k8s_job_name::<OdooBackupJob>(c, ns, "test-backup-flap-a").await;
+    fake_job_succeeded(c, ns, &k8s_job_a).await;
+
+    // Give the reconciler enough time to process the completion.  Without
+    // the fix, the phase would transition BackingUp → Running at this point
+    // and then flap back to BackingUp when the second CR is picked up.
+    // With the fix, the phase must stay in BackingUp throughout.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let instances: Api<odoo_operator::crd::odoo_instance::OdooInstance> =
+        Api::namespaced(c.clone(), ns);
+    let inst = instances.get("test-backup-flap").await.unwrap();
+    let phase = inst.status.and_then(|s| s.phase);
+    assert_eq!(
+        phase,
+        Some(OdooInstancePhase::BackingUp),
+        "phase must stay in BackingUp while another backup job is still pending (got {phase:?})"
+    );
+
+    // Now complete the second — instance should transition to Running.
+    let k8s_job_b = wait_for_k8s_job_name::<OdooBackupJob>(c, ns, "test-backup-flap-b").await;
+    fake_job_succeeded(c, ns, &k8s_job_b).await;
+
+    assert!(
+        wait_for_phase(c, ns, "test-backup-flap", OdooInstancePhase::Running).await,
+        "expected Running after the last pending backup completes"
+    );
+
+    ready_handle.abort();
+}


### PR DESCRIPTION
## Summary

Fixes #74.

When two `OdooBackupJob` CRs target the same `OdooInstance` in quick succession (e.g., a `dump` + a `zip+filestore` pair from one scheduler tick), the phase flapped `BackingUp → Running → BackingUp` as the first K8s Job completed and the reconciler picked up the second.

### Root cause

`ReconcileSnapshot::gather` picks the first non-terminal `OdooBackupJob` CR as `active_backup_job`. On the tick where the first K8s Job succeeds, the snapshot resolves that CR's status to `Succeeded` and the state machine fires `BackingUp → Running` along with `CompleteBackupJob`. The next tick picks the second CR, which was never terminal, and transitions `Running → BackingUp` — the flap.

### Fix

- Add `pending_backup_jobs: usize` to `ReconcileSnapshot` (count of non-terminal backup CRs for the instance).
- Add two `BackingUp → BackingUp` self-loop transitions placed ahead of the existing exit transitions: fire when `backup_job` is `Succeeded`/`Failed` **and** `pending_backup_jobs > 1`. Their actions (`CompleteBackupJob`/`FailBackupJob`) patch the finishing CR's status while the phase stays in `BackingUp`. Next reconcile picks up the next pending CR normally.
- With only one pending CR the behaviour is unchanged.

### Test

New integration test `concurrent_backups_do_not_flap_phase` queues two backup jobs on the same instance, completes the first K8s Job, asserts the phase stays in `BackingUp` for 5s, then completes the second and asserts the normal `BackingUp → Running` transition fires.