### PR TITLE
feat(instance): environment label (Staging default) for Calico policies

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -607,6 +607,13 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              environment:
+                default: Staging
+                description: Environment tag for this instance (`Staging` or `Production`). Default is `Staging` — the safer posture, since Calico network policies and future mail-server auto-configuration key on this.
+                enum:
+                - Staging
+                - Production
+                type: string
               filestore:
                 description: FilestoreSpec defines persistent storage for the Odoo filestore.
                 nullable: true

--- a/charts/odoo-operator/values.yaml
+++ b/charts/odoo-operator/values.yaml
@@ -58,6 +58,21 @@ defaults:
   # Default tolerations for Odoo pods.
   tolerations: []
 
+  # Mail server defaults injected into staging OdooInstances after neutralize.
+  # Staging instances get the `bemade.org/environment=staging` pod label,
+  # which a cluster NetworkPolicy (typically Calico) uses to deny egress to
+  # real SMTP/IMAP endpoints.  Pointing them at an in-cluster Mailpit gives
+  # developers a harmless place for mail to land.  Leave stagingSmtpHost
+  # empty to skip the auto-configuration — staging instances will then run
+  # with the neutralize sentinel (smtp_host=invalid, no outbound mail).
+  mail:
+    # Hostname of the Mailpit (or any SMTP sink) service staging instances
+    # should use for outbound mail.  Example:
+    # `mailpit.mailpit.svc.cluster.local`
+    stagingSmtpHost: ""
+    stagingSmtpPort: 1025
+    stagingSmtpEncryption: "none"   # "none" | "ssl" | "starttls"
+
 # Validating webhook configuration
 webhook: {}
 

--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -592,16 +592,22 @@ pub async fn ensure_deployment(
         }
     };
 
+    let mut depl_labels = BTreeMap::from([("app".to_string(), name.to_string())]);
+    depl_labels.extend(super::helpers::instance_labels(instance));
     let dep = Deployment {
         metadata: ObjectMeta {
             name: Some(name.to_string()),
             namespace: Some(ns.to_string()),
-            labels: Some(BTreeMap::from([("app".to_string(), name.to_string())])),
+            labels: Some(depl_labels.clone()),
             owner_references: Some(vec![oref.clone()]),
             ..Default::default()
         },
         spec: Some(DeploymentSpec {
             replicas: Some(replicas),
+            // NOTE: selector.matchLabels stays on `app` only — selectors are
+            // immutable on existing Deployments, so we can't add env labels
+            // here without breaking in-place upgrades.  The env labels are
+            // added to pod template labels below instead (which Calico keys on).
             selector: LabelSelector {
                 match_labels: Some(BTreeMap::from([("app".to_string(), name.to_string())])),
                 ..Default::default()
@@ -612,7 +618,7 @@ pub async fn ensure_deployment(
             }),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
-                    labels: Some(BTreeMap::from([("app".to_string(), name.to_string())])),
+                    labels: Some(depl_labels.clone()),
                     annotations: Some(BTreeMap::from([(
                         "bemade.org/odoo-conf-hash".to_string(),
                         conf_hash,
@@ -862,11 +868,15 @@ pub async fn ensure_cron_deployment(
         .unwrap_or("");
     let conf_hash = sha256_hex(conf_content);
 
+    let mut depl_labels = BTreeMap::from([("app".to_string(), depl_name.to_string())]);
+    depl_labels.extend(super::helpers::instance_labels(instance));
+    // Cron pods carry the same `app=<cron-depl>` for service/selector matching,
+    // plus the env labels for Calico (identical to web).
     let dep = Deployment {
         metadata: ObjectMeta {
             name: Some(depl_name.clone()),
             namespace: Some(ns.to_string()),
-            labels: Some(BTreeMap::from([("app".to_string(), name.to_string())])),
+            labels: Some(depl_labels.clone()),
             owner_references: Some(vec![oref.clone()]),
             ..Default::default()
         },
@@ -882,7 +892,7 @@ pub async fn ensure_cron_deployment(
             }),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {
-                    labels: Some(BTreeMap::from([("app".to_string(), depl_name.to_string())])),
+                    labels: Some(depl_labels.clone()),
                     annotations: Some(BTreeMap::from([(
                         "bemade.org/odoo-conf-hash".to_string(),
                         conf_hash,

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -21,6 +21,27 @@ use crate::crd::odoo_instance::OdooInstance;
 /// Field manager name used for server-side apply patches.
 pub const FIELD_MANAGER: &str = "odoo-operator";
 
+/// Standard pod labels applied to every Deployment, Job, and pod template
+/// owned by an OdooInstance.  Consumed by downstream systems:
+///   - `bemade.org/environment` — Calico network policies key on this to
+///     allow or deny egress to real mail servers and other sensitive
+///     services (production-only).
+///   - `bemade.org/instance` — identifies which OdooInstance this pod
+///     belongs to; useful for observability and ad-hoc kubectl queries.
+///
+/// These are ADDITIVE to the existing `app: <deployment-name>` selector
+/// label and must not be added to `spec.selector.matchLabels` on existing
+/// Deployments — the selector is immutable after creation.
+pub fn instance_labels(instance: &OdooInstance) -> std::collections::BTreeMap<String, String> {
+    let mut m = std::collections::BTreeMap::new();
+    m.insert(
+        "bemade.org/environment".to_string(),
+        instance.spec.environment.as_label().to_string(),
+    );
+    m.insert("bemade.org/instance".to_string(), instance.name_any());
+    m
+}
+
 /// Build a controller OwnerReference for any kube-rs `Resource`.
 ///
 /// This is generic over `K` — the compiler fills in `api_version()` and
@@ -159,6 +180,7 @@ pub struct OdooJobBuilder {
     init_containers: Option<Vec<Container>>,
     active_deadline: Option<i64>,
     affinity: Option<Affinity>,
+    labels: std::collections::BTreeMap<String, String>,
 }
 
 impl OdooJobBuilder {
@@ -185,6 +207,7 @@ impl OdooJobBuilder {
             init_containers: None,
             active_deadline: None,
             affinity: None,
+            labels: instance_labels(instance),
         }
     }
 
@@ -224,11 +247,16 @@ impl OdooJobBuilder {
 
     /// Consume the builder and produce a `batch/v1 Job`.
     pub fn build(self) -> Job {
+        let template_meta = ObjectMeta {
+            labels: Some(self.labels.clone()),
+            ..Default::default()
+        };
         Job {
             metadata: ObjectMeta {
                 generate_name: Some(self.generate_name),
                 namespace: Some(self.namespace),
                 owner_references: Some(vec![self.owner_ref]),
+                labels: Some(self.labels),
                 ..Default::default()
             },
             spec: Some(JobSpec {
@@ -236,6 +264,7 @@ impl OdooJobBuilder {
                 ttl_seconds_after_finished: Some(900),
                 active_deadline_seconds: self.active_deadline,
                 template: PodTemplateSpec {
+                    metadata: Some(template_meta),
                     spec: Some(PodSpec {
                         restart_policy: Some("Never".to_string()),
                         image_pull_secrets: self.pull_secrets,
@@ -246,7 +275,6 @@ impl OdooJobBuilder {
                         containers: self.containers,
                         ..Default::default()
                     }),
-                    ..Default::default()
                 },
                 ..Default::default()
             }),

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -46,6 +46,34 @@ pub struct DatabaseSpec {
     pub name: Option<String>,
 }
 
+/// Environment tags an OdooInstance as production or staging.  Used by:
+///   - The `bemade.org/environment` pod label, which Calico network
+///     policies key on to allow or deny egress to real mail servers,
+///     ERP integrations, etc.
+///   - Future: mail-server auto-configuration that points staging
+///     instances at Mailpit rather than real SMTP.
+///
+/// Default is `Staging` — the safer posture.  An accidental omission
+/// can't leak production credentials to a real mail server because a
+/// Staging-tagged instance is blocked by Calico and auto-reconfigured
+/// to Mailpit on neutralize.  Production must be set explicitly.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub enum Environment {
+    #[default]
+    Staging,
+    Production,
+}
+
+impl Environment {
+    /// Lowercase label value used in `bemade.org/environment`.
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Environment::Staging => "staging",
+            Environment::Production => "production",
+        }
+    }
+}
+
 /// DeploymentStrategyType specifies the update strategy for the Odoo Deployment.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub enum DeploymentStrategyType {
@@ -212,6 +240,12 @@ pub struct OdooInstanceSpec {
 
     #[serde(default)]
     pub init: InitSpec,
+
+    /// Environment tag for this instance (`Staging` or `Production`).
+    /// Default is `Staging` — the safer posture, since Calico network
+    /// policies and future mail-server auto-configuration key on this.
+    #[serde(default)]
+    pub environment: Environment,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strategy: Option<StrategySpec>,

--- a/tests/controller_helpers_test.rs
+++ b/tests/controller_helpers_test.rs
@@ -36,6 +36,7 @@ fn test_instance(name: &str, pull_secret: Option<&str>) -> OdooInstance {
             config_options: None,
             database: None,
             init: Default::default(),
+            environment: Default::default(),
             strategy: None,
             webhook: None,
             probes: None,

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -131,6 +131,7 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
                 name: Some(n.to_string()),
             }),
             init: Default::default(),
+            environment: Default::default(),
             strategy: None,
             webhook: None,
             probes: None,

--- a/tests/integration/environment_labels.rs
+++ b/tests/integration/environment_labels.rs
@@ -1,0 +1,116 @@
+use k8s_openapi::api::apps::v1::Deployment;
+use kube::api::{Api, Patch, PatchParams};
+use serde_json::json;
+use std::time::{Duration, Instant};
+
+use super::common::*;
+use odoo_operator::crd::odoo_instance::OdooInstance;
+
+const TIMEOUT: Duration = Duration::from_secs(15);
+const POLL: Duration = Duration::from_millis(200);
+
+/// Wait for a Deployment to exist and return its spec.template.metadata.labels.
+async fn wait_for_depl_pod_labels(
+    client: &kube::Client,
+    ns: &str,
+    name: &str,
+) -> std::collections::BTreeMap<String, String> {
+    let deps: Api<Deployment> = Api::namespaced(client.clone(), ns);
+    let start = Instant::now();
+    loop {
+        if let Ok(dep) = deps.get(name).await {
+            if let Some(labels) = dep
+                .spec
+                .and_then(|s| s.template.metadata)
+                .and_then(|m| m.labels)
+            {
+                return labels;
+            }
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "deployment {name} never got pod template labels"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+/// Default environment is Staging; web + cron Deployments' pod templates
+/// carry `bemade.org/environment=staging` and `bemade.org/instance=<name>`.
+#[tokio::test]
+async fn default_environment_is_staging() {
+    let ctx = TestContext::new("env-default").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let web_labels = wait_for_depl_pod_labels(c, ns, "env-default").await;
+    assert_eq!(
+        web_labels.get("bemade.org/environment").map(String::as_str),
+        Some("staging"),
+        "web pod template must carry environment=staging by default"
+    );
+    assert_eq!(
+        web_labels.get("bemade.org/instance").map(String::as_str),
+        Some("env-default")
+    );
+    assert_eq!(
+        web_labels.get("app").map(String::as_str),
+        Some("env-default"),
+        "existing app selector label must be preserved"
+    );
+
+    let cron_labels = wait_for_depl_pod_labels(c, ns, "env-default-cron").await;
+    assert_eq!(
+        cron_labels
+            .get("bemade.org/environment")
+            .map(String::as_str),
+        Some("staging"),
+        "cron pod template must carry environment=staging"
+    );
+}
+
+/// Explicit environment: Production → label is `production`.  Patches the
+/// created instance's spec.environment so we can reuse TestContext (which
+/// creates a default-staging instance, leaving us to flip it).
+#[tokio::test]
+async fn production_environment_sets_production_label() {
+    let ctx = TestContext::new("env-prod").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    // Flip to Production via a spec patch.  The reconcile loop will pick
+    // up the change and roll the Deployment's pod template labels.
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances
+        .patch(
+            "env-prod",
+            &PatchParams::apply("odoo-operator-test"),
+            &Patch::Merge(&json!({
+                "apiVersion": "bemade.org/v1alpha1",
+                "kind": "OdooInstance",
+                "spec": { "environment": "Production" }
+            })),
+        )
+        .await
+        .unwrap();
+
+    // Poll until the pod template reflects the production label.
+    let deps: Api<Deployment> = Api::namespaced(c.clone(), ns);
+    let start = Instant::now();
+    loop {
+        let labels = deps
+            .get("env-prod")
+            .await
+            .ok()
+            .and_then(|d| d.spec)
+            .and_then(|s| s.template.metadata)
+            .and_then(|m| m.labels)
+            .unwrap_or_default();
+        if labels.get("bemade.org/environment").map(String::as_str) == Some("production") {
+            return;
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "deployment did not pick up environment=production (saw {labels:?})"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod backup_job;
 mod bootstrap;
 mod child_resources;
 mod degraded;
+mod environment_labels;
 mod finalizer;
 mod init_job;
 mod migrate_database;


### PR DESCRIPTION
## Summary

Adds `spec.environment: Staging | Production` (default **Staging**) to `OdooInstance`, and propagates two labels to every pod the operator creates:

```
bemade.org/environment: staging | production
bemade.org/instance:    <instance-name>
```

Applied to:
- web `Deployment.metadata.labels` + pod template labels
- cron `Deployment.metadata.labels` + pod template labels
- every `Job` built via `OdooJobBuilder` (init, restore, backup, upgrade, filestore-migration, db-migration, and — once #81 merges — the staging-refresh sub-Jobs)

## Why

Calico network policies (being set up by a colleague) need a stable pod label to deny egress to real SMTP/IMAP endpoints for non-production pods. This provides that label with a safe default.

Default is **Staging** deliberately: the accidental-omission failure mode (an improperly-tagged staging instance leaking production credentials to real mail servers) is exactly what the restore-hardening + mail-server-verify work (#76) was protecting against. Defaulting to Staging makes the unsafe case unreachable by accident. Production has to be set explicitly.

## Selector immutability

Labels go on `metadata.labels` and `spec.template.metadata.labels`, **not** `spec.selector.matchLabels`. Deployment selectors are immutable after creation — adding env labels there would break in-place upgrades. The selector stays on `app` alone, which is sufficient since NetworkPolicy keys on pod labels, not selector labels.

## Backward compatibility

Existing `OdooInstance` CRs have no `environment` field; they deserialize to the default (`Staging`) on next reconcile. Production instances need an explicit `environment: Production` annotation after upgrade. Will document in release notes.

## Mail server (Mailpit) wiring

Helm chart adds placeholder values:
```yaml
defaults:
  mail:
    stagingSmtpHost: ""            # e.g. mailpit.mailpit.svc.cluster.local
    stagingSmtpPort: 1025
    stagingSmtpEncryption: "none"
```

The actual SQL tail that updates `ir_mail_server` to use Mailpit will land in a follow-up that can touch both `restore.sh` and the staging-refresh `neutralize.sh` — cleaner to do once #81 merges to avoid touching a file that exists on only one branch.

## Test

New `environment_labels` integration suite:
- `default_environment_is_staging` — create an instance with no `environment`, assert both `bemade.org/environment=staging` and `bemade.org/instance=<name>` on web + cron pod templates
- `production_environment_sets_production_label` — patch to `Production`, assert the label rolls through

All 31 pre-existing tests still pass. `cargo clippy -D warnings` clean.

## Follow-ups noted

- Mailpit SQL tail in `restore.sh` + `neutralize.sh` (post #81)
- Webhook validation tying `environment: Staging` to a source reference (future, when `OdooInstance.spec.cloneFrom` lands in Phase 3 of #75)