### PR TITLE
feat(mail): staging instances auto-redirect SMTP to Mailpit (BREAKING)

### DIFF
--- a/charts/odoo-operator/templates/deployment/operator.yaml
+++ b/charts/odoo-operator/templates/deployment/operator.yaml
@@ -50,6 +50,11 @@ spec:
             {{- if .Values.defaults.gatewayRefNamespace }}
             - --default-gateway-ref-namespace={{ .Values.defaults.gatewayRefNamespace }}
             {{- end }}
+            {{- if .Values.defaults.mail.stagingSmtpHost }}
+            - --default-staging-smtp-host={{ .Values.defaults.mail.stagingSmtpHost }}
+            - --default-staging-smtp-port={{ .Values.defaults.mail.stagingSmtpPort | default 1025 }}
+            - --default-staging-smtp-encryption={{ .Values.defaults.mail.stagingSmtpEncryption | default "none" }}
+            {{- end }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
           env:

--- a/charts/odoo-operator/templates/preflight.yaml
+++ b/charts/odoo-operator/templates/preflight.yaml
@@ -1,0 +1,27 @@
+{{/*
+Pre-flight migration gate for the 1.9.x environment-aware release.
+
+Starting with this version the operator consumes spec.environment on
+OdooInstance and rewrites the ir_mail_server sentinel to point at the
+configured Mailpit sink during staging-refresh / restore flows.
+
+Every pre-1.9 OdooInstance has no environment field and defaults to
+Staging on read — so a subsequent staging-refresh or restore would
+rewrite outbound mail for any genuinely-production instance that
+hasn't been tagged yet.  This guard forces the admin to acknowledge
+the migration has been done.
+
+To unblock the upgrade:
+
+ 1. Tag every production OdooInstance:
+
+      kubectl patch odooinstance NAME -n NAMESPACE --type=merge \
+        -p (single-quote){"spec":{"environment":"Production"}}(single-quote)
+
+ 2. Re-run helm upgrade with:
+
+      --set productionInstancesIdentified=true
+*/}}
+{{- if not .Values.productionInstancesIdentified }}
+{{- fail "\nUpgrade blocked: productionInstancesIdentified must be set to true.\n\nThis release consumes spec.environment (Staging | Production) on OdooInstances.  Every OdooInstance missing an explicit environment field is treated as Staging — which, after a staging-refresh or restore, rewrites its ir_mail_server to Mailpit (or disables it entirely).\n\nBefore installing this version, tag every production OdooInstance with spec.environment: Production (kubectl patch), then re-run helm with --set productionInstancesIdentified=true to acknowledge.\n" -}}
+{{- end }}

--- a/charts/odoo-operator/values.yaml
+++ b/charts/odoo-operator/values.yaml
@@ -25,6 +25,18 @@ imagePullSecrets:
     password: password
 
 
+# ── Pre-flight migration gate (1.9.0) ─────────────────────────────────────────
+# Starting with 1.9.0 the operator consumes `spec.environment` on OdooInstances
+# and rewrites `ir_mail_server` on staging refreshes / restores.  Every
+# pre-1.9 OdooInstance has no environment field and will be treated as
+# Staging by default — which means their ir_mail_server gets rewritten to
+# Mailpit (or disabled) on the next refresh/restore.
+#
+# Set this to `true` after you've explicitly tagged every production
+# OdooInstance with `spec.environment: Production`.  See
+# charts/odoo-operator/templates/_preflight.tpl for a migration script.
+productionInstancesIdentified: false
+
 # Default configuration applied by the operator when an OdooInstance does not
 # specify these fields. These are cluster-specific values that vary per installation.
 defaults:

--- a/scripts/neutralize.sh
+++ b/scripts/neutralize.sh
@@ -94,4 +94,29 @@ else
     echo "fetchmail_server table absent (module not installed) — skipping"
 fi
 
+# Staging mail redirect: the operator sets MAIL_SMTP_HOST (and port /
+# encryption) when the instance is tagged `environment: Staging` and a
+# cluster-wide Mailpit (or any SMTP sink) has been configured via
+# --default-staging-smtp-host.  After neutralize there is exactly one
+# active ir_mail_server row with smtp_host='invalid' — we rewrite it in
+# place to point at the sink.  Production instances and operators with
+# no sink configured skip this block entirely (env var empty).
+if [ -n "${MAIL_SMTP_HOST:-}" ]; then
+    echo "=== Rewriting neutralize sentinel → $MAIL_SMTP_HOST:${MAIL_SMTP_PORT:-1025} (${MAIL_SMTP_ENCRYPTION:-none}) ==="
+    # psql's :'var' interpolation only works when reading from stdin,
+    # not with -c, so we use a heredoc.
+    psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+         -v ON_ERROR_STOP=1 \
+         -v mail_host="$MAIL_SMTP_HOST" \
+         -v mail_port="${MAIL_SMTP_PORT:-1025}" \
+         -v mail_enc="${MAIL_SMTP_ENCRYPTION:-none}" <<'EOSQL'
+UPDATE ir_mail_server
+SET smtp_host = :'mail_host',
+    smtp_port = :'mail_port'::integer,
+    smtp_encryption = :'mail_enc',
+    name = 'Mailpit (operator-injected for staging)'
+WHERE active AND smtp_host = 'invalid';
+EOSQL
+fi
+
 echo "=== Neutralize complete ==="

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -228,6 +228,31 @@ if [ "$NEUTRALIZE" = "True" ]; then
         -d "$DB_NAME"
     verify_neutralization
     verify_no_active_mail_servers
+
+    # Staging mail redirect: the operator sets MAIL_SMTP_HOST (and port /
+    # encryption) when the instance is tagged `environment: Staging` and a
+    # cluster-wide Mailpit (or any SMTP sink) has been configured via
+    # --default-staging-smtp-host.  After neutralize there is exactly one
+    # active ir_mail_server row with smtp_host='invalid' — we rewrite it
+    # in place to point at the sink.  Production instances and operators
+    # with no sink configured skip this block entirely.
+    if [ -n "${MAIL_SMTP_HOST:-}" ]; then
+        echo "=== Rewriting neutralize sentinel → $MAIL_SMTP_HOST:${MAIL_SMTP_PORT:-1025} (${MAIL_SMTP_ENCRYPTION:-none}) ==="
+        # psql's :'var' interpolation only works when reading from stdin,
+        # not with -c, so we use a heredoc.
+        psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
+             -v ON_ERROR_STOP=1 \
+             -v mail_host="$MAIL_SMTP_HOST" \
+             -v mail_port="${MAIL_SMTP_PORT:-1025}" \
+             -v mail_enc="${MAIL_SMTP_ENCRYPTION:-none}" <<'EOSQL'
+UPDATE ir_mail_server
+SET smtp_host = :'mail_host',
+    smtp_port = :'mail_port'::integer,
+    smtp_encryption = :'mail_enc',
+    name = 'Mailpit (operator-injected for staging)'
+WHERE active AND smtp_host = 'invalid';
+EOSQL
+    fi
 else
     echo "Skipping neutralization (NEUTRALIZE=$NEUTRALIZE)"
 fi

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -42,6 +42,33 @@ pub fn instance_labels(instance: &OdooInstance) -> std::collections::BTreeMap<St
     m
 }
 
+/// Env vars injected into post-neutralize Job pods for staging instances
+/// when the operator was configured with a staging SMTP sink (Mailpit).
+///
+/// Returns empty when either:
+/// - the instance is `Production` (leave real SMTP config alone), or
+/// - the operator has no `staging_smtp_host` configured (keep the
+///   neutralize sentinel, i.e. `smtp_host=invalid` — no outbound mail).
+///
+/// Consumed by `restore.sh` and `neutralize.sh` via `MAIL_*` env vars.
+pub fn staging_mail_env_vars(
+    instance: &OdooInstance,
+    defaults: &crate::helpers::OperatorDefaults,
+) -> Vec<k8s_openapi::api::core::v1::EnvVar> {
+    use crate::crd::odoo_instance::Environment;
+    if instance.spec.environment != Environment::Staging || defaults.staging_smtp_host.is_empty() {
+        return vec![];
+    }
+    vec![
+        env("MAIL_SMTP_HOST", defaults.staging_smtp_host.clone()),
+        env("MAIL_SMTP_PORT", defaults.staging_smtp_port.to_string()),
+        env(
+            "MAIL_SMTP_ENCRYPTION",
+            defaults.staging_smtp_encryption.clone(),
+        ),
+    ]
+}
+
 /// Build a controller OwnerReference for any kube-rs `Resource`.
 ///
 /// This is generic over `K` — the compiler fills in `api_version()` and

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -13,7 +13,8 @@ use crate::error::{Error, Result};
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, cron_depl_name, env, odoo_volume_mounts, OdooJobBuilder, FIELD_MANAGER,
+    cm_env, cron_depl_name, env, odoo_volume_mounts, staging_mail_env_vars, OdooJobBuilder,
+    FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 
@@ -230,6 +231,7 @@ impl State for CloningFromSource {
                 refresh,
                 &target_conf,
                 &target_db,
+                &ctx.defaults,
             );
             let created = jobs_api.create(&PostParams::default(), &job).await?;
             let k8s_job_name = created.name_any();
@@ -405,6 +407,7 @@ fn build_filestore_clone_job(
         .build()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_neutralize_job(
     crd_name: &str,
     ns: &str,
@@ -413,14 +416,16 @@ fn build_neutralize_job(
     refresh: &OdooStagingRefreshJob,
     target_conf: &str,
     target_db: &str,
+    defaults: &crate::helpers::OperatorDefaults,
 ) -> Job {
-    let envs = vec![
+    let mut envs = vec![
         env("DB_NAME", target_db),
         cm_env("HOST", target_conf, "db_host"),
         cm_env("PORT", target_conf, "db_port"),
         cm_env("USER", target_conf, "db_user"),
         cm_env("PASSWORD", target_conf, "db_password"),
     ];
+    envs.extend(staging_mail_env_vars(instance, defaults));
     OdooJobBuilder::new(&format!("{crd_name}-neut-"), ns, refresh, instance)
         .active_deadline(1800)
         .containers(vec![Container {

--- a/src/controller/states/restoring.rs
+++ b/src/controller/states/restoring.rs
@@ -16,7 +16,8 @@ use crate::notify;
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, cron_depl_name, env, odoo_volume_mounts, OdooJobBuilder, FIELD_MANAGER,
+    cm_env, cron_depl_name, env, odoo_volume_mounts, staging_mail_env_vars, OdooJobBuilder,
+    FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 
@@ -83,7 +84,7 @@ impl State for Restoring {
             ..Default::default()
         };
 
-        let db_env = vec![
+        let mut db_env = vec![
             env("DB_NAME", db.clone()),
             env("NEUTRALIZE", neutralize),
             cm_env("HOST", &odoo_conf_name, "db_host"),
@@ -91,6 +92,7 @@ impl State for Restoring {
             cm_env("USER", &odoo_conf_name, "db_user"),
             cm_env("PASSWORD", &odoo_conf_name, "db_password"),
         ];
+        db_env.extend(staging_mail_env_vars(instance, &ctx.defaults));
 
         let mut init_containers = vec![];
         let src = &restore_job.spec.source;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -29,6 +29,15 @@ pub struct OperatorDefaults {
     pub resources: Option<ResourceRequirements>,
     pub affinity: Option<Affinity>,
     pub tolerations: Vec<Toleration>,
+
+    /// SMTP sink (typically a Mailpit service) that staging instances
+    /// get their `ir_mail_server` rewritten to point at after every
+    /// restore / staging-refresh.  Empty string = feature disabled
+    /// (staging instances stay on the `smtp_host=invalid` sentinel set
+    /// by `odoo neutralize`, i.e. no outbound mail).
+    pub staging_smtp_host: String,
+    pub staging_smtp_port: u16,
+    pub staging_smtp_encryption: String,
 }
 
 // ── Naming helpers ────────────────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,25 @@ struct Args {
     #[arg(long, default_value = "", env = "DEFAULT_GATEWAY_REF_NAMESPACE")]
     default_gateway_ref_namespace: String,
 
+    /// Hostname of the SMTP sink (e.g. Mailpit) that staging instances
+    /// should use for outbound mail.  When set, the operator rewrites
+    /// the neutralize-sentinel `ir_mail_server` row on every staging
+    /// restore / clone to point at this host.  Leave empty to keep the
+    /// sentinel (`smtp_host=invalid` — no outbound mail at all).
+    /// Only applies when the target OdooInstance has
+    /// `spec.environment: Staging`.
+    #[arg(long, default_value = "", env = "DEFAULT_STAGING_SMTP_HOST")]
+    default_staging_smtp_host: String,
+
+    /// Port for the staging SMTP sink.  Defaults to 1025 (Mailpit default).
+    #[arg(long, default_value = "1025", env = "DEFAULT_STAGING_SMTP_PORT")]
+    default_staging_smtp_port: u16,
+
+    /// Encryption for the staging SMTP sink: `none`, `ssl`, or `starttls`.
+    /// Defaults to `none` (Mailpit doesn't terminate TLS by default).
+    #[arg(long, default_value = "none", env = "DEFAULT_STAGING_SMTP_ENCRYPTION")]
+    default_staging_smtp_encryption: String,
+
     /// Name of the Secret containing postgres cluster configuration.
     #[arg(
         long,
@@ -126,6 +145,9 @@ async fn main() -> anyhow::Result<()> {
             ingress_issuer: args.default_ingress_issuer,
             gateway_ref_name: args.default_gateway_ref_name,
             gateway_ref_namespace: args.default_gateway_ref_namespace,
+            staging_smtp_host: args.default_staging_smtp_host,
+            staging_smtp_port: args.default_staging_smtp_port,
+            staging_smtp_encryption: args.default_staging_smtp_encryption,
             ..Default::default()
         },
         operator_namespace: args.operator_namespace,

--- a/testing/helm/values.yaml
+++ b/testing/helm/values.yaml
@@ -23,6 +23,9 @@ operator:
 # Image pull secrets for private registries
 imagePullSecrets: []
 
+# Pre-flight migration gate: acknowledged for local dev.
+productionInstancesIdentified: true
+
 defaults:
   odooImage: "odoo:18.0"
   storageClass: "standard"
@@ -38,6 +41,10 @@ defaults:
       memory: 4Gi
   affinity: {}
   tolerations: []
+  mail:
+    stagingSmtpHost: "mailpit.mailpit.svc.cluster.local"
+    stagingSmtpPort: 1025
+    stagingSmtpEncryption: "none"
 
 webhook:
   certIssuer: "selfsigned-cluster-issuer"

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -280,6 +280,9 @@ fn test_defaults() -> OperatorDefaults {
         resources: None,
         affinity: None,
         tolerations: vec![],
+        staging_smtp_host: String::new(),
+        staging_smtp_port: 1025,
+        staging_smtp_encryption: "none".into(),
     }
 }
 


### PR DESCRIPTION
## Summary

Consumes `spec.environment` introduced by #82 to make staging instances safe-by-default for outbound mail. When a staging OdooInstance is restored or refreshed, the post-neutralize `ir_mail_server` sentinel row is rewritten in place to point at the operator-configured SMTP sink (typically an in-cluster Mailpit).

**Breaking change**. A helm `fail` gate forces admins to explicitly tag their production instances before installing this version.

## Behavior

| Instance environment | Sink configured | Result |
|---|---|---|
| Staging | Yes | `ir_mail_server` rewritten to sink after every restore/refresh |
| Staging | No | Sentinel stays (`smtp_host='invalid'`, no outbound mail) |
| Production | Yes | Skipped — real SMTP config untouched |
| Production | No | Skipped — real SMTP config untouched |

## Data flow

```
helm values.defaults.mail.staging{SmtpHost,Port,Encryption}
  → operator Deployment --default-staging-smtp-* CLI flags
  → OperatorDefaults.staging_smtp_{host,port,encryption}
  → controller::helpers::staging_mail_env_vars()
  → MAIL_SMTP_HOST / MAIL_SMTP_PORT / MAIL_SMTP_ENCRYPTION env vars
    on restore + neutralize Job pods
  → restore.sh / neutralize.sh psql heredoc:
    UPDATE ir_mail_server
    SET smtp_host=:mail_host, smtp_port=:mail_port, ...
    WHERE active AND smtp_host = 'invalid';
```

Env vars are only injected when instance is Staging AND sink is configured — three guard clauses triple-verify before the SQL runs.

## Helm lockout (templates/preflight.yaml)

```yaml
productionInstancesIdentified: false   # default — blocks upgrade
```

Any `helm upgrade` to this version fails at render time with:

```
Upgrade blocked: productionInstancesIdentified must be set to true.
...
Before installing this version, tag every production OdooInstance
with spec.environment: Production (kubectl patch), then re-run helm
with --set productionInstancesIdentified=true to acknowledge.
```

Migration (script in the template comment):

```sh
for each production instance:
  kubectl patch odooinstance NAME -n NS --type=merge \
    -p '{"spec":{"environment":"Production"}}'

helm upgrade odoo-operator charts/odoo-operator \
  --set productionInstancesIdentified=true \
  -n odoo-operator
```

Once acknowledged, the value is persisted in the release and subsequent upgrades don't re-gate. Future breaking changes can introduce their own versioned gates (`productionInstancesIdentifiedForVX`).

## Tested on minikube end-to-end

Deployed Mailpit, created source (Production) + staging target, ran `OdooStagingRefreshJob`:

```
=== Rewriting neutralize sentinel → mailpit.mailpit.svc.cluster.local:1025 (none) ===
UPDATE 1
=== Neutralize complete ===
```

Refresh completed successfully; target instance's `ir_mail_server` now points at Mailpit.

## Tests

- All 33 integration tests pass (including the existing staging-refresh and restore suites, which exercise the Job env injection path)
- `cargo clippy --all-targets -- -D warnings` clean
- `helm template` verified: fails without ack, renders 19 manifests with `--set productionInstancesIdentified=true`

## Follow-ups noted

- `bemade.org/allowEmail` complementary label for finer-grained Calico rules
- Webhook validation tying `environment: Staging` ↔ source reference (pending Phase 3 of #75)
- Mail auto-config at init time (current scope is restore/refresh only — fresh inits don't have mail servers to rewrite yet)