### PR TITLE
feat(instance): productionInstanceRef auto-clones staging from prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ module. To skip auto-init (e.g. when restoring from a backup), set
 | `ingress.gatewayRef.namespace` | operator default | Gateway namespace for HTTPRoute |
 | `database.cluster` | secret default | Postgres cluster name from the pg-clusters secret |
 | `database.name` | auto-generated | Database name. Defaults to `odoo_<uid>` if unset |
-| `init.enabled` | `true` | Automatically initialize the database when the instance is first created |
+| `init.enabled` | `true` | Automatically initialize the database when the instance is first created (skipped when `productionInstanceRef` is set) |
 | `init.modules` | `["base"]` | Odoo modules to install during auto-initialization |
 | `init.webhook` | — | Webhook to notify on init job status changes |
+| `productionInstanceRef.name` | — | Name of a source production `OdooInstance` to clone from on first init. When set, the operator creates an `OdooStagingRefreshJob` instead of an `OdooInitJob`. Forbidden on `environment: Production`. See [Staging from production](#staging-from-production) |
+| `productionInstanceRef.namespace` | same as target | Reserved for a future cross-namespace phase; must equal (or omit) the target's namespace in v1 |
 | `filestore.storageSize` | `2Gi` | PVC size. Can only be increased, not decreased |
 | `filestore.storageClass` | operator default | StorageClass for the filestore PVC. Immutable after creation |
 | `resources` | operator default | CPU/memory requests and limits for web pods |
@@ -136,6 +138,44 @@ stale connections.
 
 You don't need to set `workers` or `max_cron_threads` in `configOptions` — the
 operator handles this automatically via the command-line flags on each deployment.
+
+### Staging from production
+
+Set `spec.productionInstanceRef` on a staging `OdooInstance` to declaratively
+tie it to a source-of-truth production instance. On first reconcile, the
+operator creates an `OdooStagingRefreshJob` (named `<instance>-auto-refresh`)
+that clones the prod DB + filestore into the new instance and runs
+`odoo neutralize` — in place of the normal `OdooInitJob` path:
+
+```yaml
+apiVersion: bemade.org/v1alpha1
+kind: OdooInstance
+metadata:
+  name: client-staging
+  namespace: client
+spec:
+  adminPassword: admin
+  image: odoo:18.0
+  ingress:
+    hosts: [client-staging.example.com]
+  filestore:
+    storageSize: 50Gi
+  environment: Staging
+  productionInstanceRef:
+    name: client-prod
+```
+
+Requirements and limits:
+
+- Forbidden on `environment: Production` (rejected at `kubectl apply` time
+  by a CRD CEL rule).
+- Same-namespace only in v1. `productionInstanceRef.namespace` is reserved
+  for a future cross-namespace phase.
+- Auto-refresh fires only on first initialization (when
+  `status.dbInitialized` is false). A user-created `OdooStagingRefreshJob`
+  pre-empts the auto-create — useful for tuning `filestoreMethod` or
+  `skipFilestore`, which the auto-create path leaves at CRD defaults
+  (`Auto` / `false`).
 
 ### Gateway API Support
 

--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -722,6 +722,20 @@ spec:
                     default: /web/health
                     type: string
                 type: object
+              productionInstanceRef:
+                description: 'When set on a staging instance, the operator clones the named source production `OdooInstance` into this one on first initialization (via an auto-created `OdooStagingRefreshJob`) instead of running the normal `OdooInitJob` path. Ignored once `status.dbInitialized == true`. Forbidden on `environment: Production`.'
+                nullable: true
+                properties:
+                  name:
+                    description: Name of the source `OdooInstance`.
+                    type: string
+                  namespace:
+                    description: Reserved for a future cross-namespace phase; must equal the target namespace (or be unset) in v1.
+                    nullable: true
+                    type: string
+                required:
+                - name
+                type: object
               replicas:
                 default: 1
                 format: int32
@@ -821,6 +835,9 @@ spec:
             - adminPassword
             - ingress
             type: object
+            x-kubernetes-validations:
+            - messageExpression: '''spec.productionInstanceRef is forbidden on production instances'''
+              rule: self.environment != 'Production' || !has(self.productionInstanceRef)
           status:
             description: OdooInstanceStatus defines the observed state of OdooInstance.
             nullable: true

--- a/src/controller/states/uninitialized.rs
+++ b/src/controller/states/uninitialized.rs
@@ -4,19 +4,26 @@ use serde_json::json;
 use tracing::info;
 
 use crate::crd::odoo_init_job::OdooInitJob;
-use crate::crd::odoo_instance::OdooInstance;
-use crate::error::Result;
+use crate::crd::odoo_instance::{Environment, OdooInstance};
+use crate::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
+use crate::error::{Error, Result};
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{controller_owner_ref, cron_depl_name};
 use crate::controller::state_machine::{scale_deployment, JobStatus};
 
-/// Uninitialized: waiting for an OdooInitJob or OdooRestoreJob to be created.
-/// Scale deployment to 0 (not yet initialized).
+/// Uninitialized: waiting for an OdooInitJob, OdooRestoreJob, or
+/// OdooStagingRefreshJob to be created. Scale deployment to 0 (not yet
+/// initialized).
 ///
-/// When `spec.init.enabled` is true (the default), automatically creates an
-/// OdooInitJob CR so the state machine can transition to Initializing without
-/// external intervention.
+/// Auto-creates one of:
+///   - `OdooStagingRefreshJob` when `spec.productionInstanceRef` is set
+///     (clones from the named source prod instance), OR
+///   - `OdooInitJob` when `spec.init.enabled` is true,
+///
+/// whichever applies — productionInstanceRef takes precedence because the
+/// refresh pipeline brings the DB up initialized and neutralized, replacing
+/// the init step. The branches are mutually exclusive.
 pub struct Uninitialized;
 
 #[async_trait]
@@ -32,9 +39,61 @@ impl State for Uninitialized {
         scale_deployment(&ctx.client, &name, &ns, 0).await?;
         scale_deployment(&ctx.client, cron_depl_name(instance).as_str(), &ns, 0).await?;
 
-        // Auto-create an OdooInitJob if auto-init is enabled and no job exists yet.
+        // Only auto-create when no job of any kind is already present and
+        // the DB hasn't been initialized yet.
+        if snap.db_initialized
+            || snap.init_job != JobStatus::Absent
+            || snap.refresh_job != JobStatus::Absent
+            || snap.restore_job != JobStatus::Absent
+        {
+            return Ok(());
+        }
+
+        if let Some(pref) = instance.spec.production_instance_ref.as_ref() {
+            // Reconciler-level guard — belt-and-suspenders with the CRD CEL
+            // rule that forbids productionInstanceRef on Production.
+            if instance.spec.environment == Environment::Production {
+                return Err(Error::Config(
+                    "spec.productionInstanceRef is forbidden on production instances".into(),
+                ));
+            }
+
+            let auto_refresh_name = format!("{name}-auto-refresh");
+            let mut source_spec = serde_json::json!({ "instanceName": &pref.name });
+            if let Some(src_ns) = pref.namespace.as_ref() {
+                source_spec["instanceNamespace"] = serde_json::Value::String(src_ns.clone());
+            }
+            let refresh: OdooStagingRefreshJob = serde_json::from_value(json!({
+                "apiVersion": "bemade.org/v1alpha1",
+                "kind": "OdooStagingRefreshJob",
+                "metadata": {
+                    "name": &auto_refresh_name,
+                    "namespace": &ns,
+                    "ownerReferences": [controller_owner_ref(instance)],
+                    "labels": { "bemade.org/auto-refresh": "true" },
+                },
+                "spec": {
+                    "odooInstanceRef": { "name": &name },
+                    "source": source_spec,
+                    // filestoreMethod, skipFilestore, neutralize all fall
+                    // back to their CRD defaults (Auto / false / true).
+                }
+            }))?;
+
+            let api: Api<OdooStagingRefreshJob> = Api::namespaced(ctx.client.clone(), &ns);
+            api.create(&PostParams::default(), &refresh).await?;
+            info!(
+                %name,
+                %auto_refresh_name,
+                source = %pref.name,
+                "auto-created OdooStagingRefreshJob from spec.productionInstanceRef"
+            );
+            return Ok(());
+        }
+
+        // Fall back to the normal auto-init path.
         let init_spec = &instance.spec.init;
-        if init_spec.enabled && snap.init_job == JobStatus::Absent && !snap.db_initialized {
+        if init_spec.enabled {
             let auto_init_name = format!("{name}-auto-init");
             let init_job: OdooInitJob = serde_json::from_value(json!({
                 "apiVersion": "bemade.org/v1alpha1",

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -1,5 +1,5 @@
 use k8s_openapi::api::core::v1::{Affinity, ResourceRequirements, Toleration};
-use kube::CustomResource;
+use kube::{CELSchema, CustomResource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -72,6 +72,26 @@ impl Environment {
             Environment::Production => "production",
         }
     }
+}
+
+/// ProductionInstanceRef declares the source-of-truth production
+/// `OdooInstance` that a staging instance should be cloned from on first
+/// initialization. When set, the operator auto-creates an
+/// `OdooStagingRefreshJob` in place of the normal auto-init path so the
+/// staging comes up pre-populated from prod in a single manifest apply.
+///
+/// Only meaningful when `environment == Staging`. Same-namespace only in
+/// v1 (matches the same-ns constraint already enforced by
+/// `OdooStagingRefreshJob` reconciliation).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProductionInstanceRef {
+    /// Name of the source `OdooInstance`.
+    pub name: String,
+    /// Reserved for a future cross-namespace phase; must equal the
+    /// target namespace (or be unset) in v1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
 }
 
 /// DeploymentStrategyType specifies the update strategy for the Odoo Deployment.
@@ -193,7 +213,13 @@ fn default_init_modules() -> Vec<String> {
 // ── CRD ───────────────────────────────────────────────────────────────────────
 
 /// OdooInstance is the Schema for the odooinstances API.
-#[derive(CustomResource, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(CustomResource, Clone, Debug, Serialize, Deserialize, CELSchema)]
+#[cel_validate(
+    rule = Rule::new("self.environment != 'Production' || !has(self.productionInstanceRef)")
+        .message(Message::Expression(
+            "'spec.productionInstanceRef is forbidden on production instances'".into()
+        ))
+)]
 #[kube(
     group = "bemade.org",
     version = "v1alpha1",
@@ -246,6 +272,15 @@ pub struct OdooInstanceSpec {
     /// policies and future mail-server auto-configuration key on this.
     #[serde(default)]
     pub environment: Environment,
+
+    /// When set on a staging instance, the operator clones the named
+    /// source production `OdooInstance` into this one on first
+    /// initialization (via an auto-created `OdooStagingRefreshJob`)
+    /// instead of running the normal `OdooInitJob` path. Ignored once
+    /// `status.dbInitialized == true`. Forbidden on
+    /// `environment: Production`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub production_instance_ref: Option<ProductionInstanceRef>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strategy: Option<StrategySpec>,

--- a/tests/controller_helpers_test.rs
+++ b/tests/controller_helpers_test.rs
@@ -37,6 +37,7 @@ fn test_instance(name: &str, pull_secret: Option<&str>) -> OdooInstance {
             database: None,
             init: Default::default(),
             environment: Default::default(),
+            production_instance_ref: None,
             strategy: None,
             webhook: None,
             probes: None,

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -132,6 +132,7 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
             }),
             init: Default::default(),
             environment: Default::default(),
+            production_instance_ref: None,
             strategy: None,
             webhook: None,
             probes: None,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod init_job;
 mod migrate_database;
 mod migrate_filestore;
 mod orphaned_jobs;
+mod production_instance_ref;
 mod restore_job;
 mod scaling;
 mod staging_refresh;

--- a/tests/integration/production_instance_ref.rs
+++ b/tests/integration/production_instance_ref.rs
@@ -1,0 +1,148 @@
+use kube::api::{Api, PostParams};
+use serde_json::json;
+
+use super::common::*;
+use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
+use odoo_operator::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
+
+/// Happy path: a staging `OdooInstance` with `spec.productionInstanceRef`
+/// set makes the operator auto-create an `OdooStagingRefreshJob` whose
+/// spec points at the referenced source, and the target transitions from
+/// Uninitialized to CloningFromSource on the next reconcile.
+///
+/// Unlike `staging_refresh::staging_refresh_happy_path`, this test drives
+/// the flow end-to-end from a single `OdooInstance` manifest — no
+/// hand-created refresh CR.
+#[tokio::test]
+async fn auto_refresh_created_from_production_instance_ref() -> anyhow::Result<()> {
+    // Source production instance up to Running (typical pre-condition
+    // users will hit in the field — the source is a live prod).
+    let ctx = TestContext::new("source-inst").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let source_ready = fast_track_to_running(&ctx, "source-init").await;
+
+    // Staging target with productionInstanceRef. Init stays default
+    // (enabled=true) — the operator should pick the refresh branch over
+    // the init branch because productionInstanceRef is set.
+    let target_name = "staging-inst";
+    let target: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": target_name, "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["staging.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "standard" },
+            "environment": "Staging",
+            "productionInstanceRef": { "name": "source-inst" },
+        }
+    }))
+    .unwrap();
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances.create(&PostParams::default(), &target).await?;
+
+    // The operator auto-creates "{target}-auto-refresh".
+    let auto_refresh_name = format!("{target_name}-auto-refresh");
+    let refresh_api: Api<OdooStagingRefreshJob> = Api::namespaced(c.clone(), ns);
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let api = refresh_api.clone();
+            let n = auto_refresh_name.clone();
+            async move { api.get(&n).await.is_ok() }
+        })
+        .await,
+        "operator never auto-created OdooStagingRefreshJob"
+    );
+
+    // Verify spec + owner-reference shape.
+    let refresh = refresh_api.get(&auto_refresh_name).await?;
+    assert_eq!(refresh.spec.odoo_instance_ref.name, target_name);
+    assert_eq!(refresh.spec.source.instance_name, "source-inst");
+    let orefs = refresh.metadata.owner_references.as_ref().unwrap();
+    assert_eq!(orefs.len(), 1);
+    assert_eq!(orefs[0].kind, "OdooInstance");
+    assert_eq!(orefs[0].name, target_name);
+    assert_eq!(orefs[0].controller, Some(true));
+    assert_eq!(
+        refresh
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get("bemade.org/auto-refresh"))
+            .map(String::as_str),
+        Some("true"),
+        "auto-refresh marker label missing"
+    );
+
+    // No OdooInitJob should have been created — the refresh path
+    // replaces the init path entirely.
+    let init_name = format!("{target_name}-auto-init");
+    let init_api: Api<odoo_operator::crd::odoo_init_job::OdooInitJob> =
+        Api::namespaced(c.clone(), ns);
+    assert!(
+        init_api.get(&init_name).await.is_err(),
+        "OdooInitJob {init_name} was created unexpectedly — the refresh \
+         path should preempt the init path"
+    );
+
+    // Target transitions into CloningFromSource.
+    assert!(
+        wait_for_phase(c, ns, target_name, OdooInstancePhase::CloningFromSource).await,
+        "expected target CloningFromSource after auto-created refresh"
+    );
+
+    source_ready.abort();
+    Ok(())
+}
+
+/// Applying an OdooInstance with `environment: Production` AND
+/// `productionInstanceRef` set must fail at admission time thanks to the
+/// CRD CEL rule. The api-server returns an Invalid error; the reconciler
+/// guard is belt-and-suspenders.
+#[tokio::test]
+async fn production_instance_ref_rejected_on_production() -> anyhow::Result<()> {
+    let ctx = TestContext::new_ns().await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let bad: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": "bad-prod", "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["bad.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "standard" },
+            "environment": "Production",
+            "productionInstanceRef": { "name": "anywhere" },
+        }
+    }))
+    .unwrap();
+
+    let err = instances
+        .create(&PostParams::default(), &bad)
+        .await
+        .expect_err("apply should have been rejected by CEL validation");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("productionInstanceRef")
+            || msg.contains("Production")
+            || msg.contains("Invalid"),
+        "unexpected rejection message: {msg}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `spec.productionInstanceRef` on `OdooInstance` so a staging instance can declaratively bind to a source production instance. First reconcile auto-creates an `OdooStagingRefreshJob` (`<instance>-auto-refresh`) in place of the normal `OdooInitJob`, collapsing the previous two-step flow into a single `kubectl apply`.
- Validation layered: CRD CEL rule forbids the field on `environment: Production` at admission time; reconciler guard is a belt-and-suspenders fallback.
- Mutually exclusive with the init path — `OdooInitJob` is not created when `productionInstanceRef` is set. Uses the existing `Uninitialized → CloningFromSource` transition.

Prerequisite for Odoo task #3527 (odoo_herd UI mirroring). Odoo task: https://odoo.bemade.org/odoo/project/18/tasks/3528

## Usage

```yaml
apiVersion: bemade.org/v1alpha1
kind: OdooInstance
metadata:
  name: client-staging
spec:
  adminPassword: admin
  image: odoo:18.0
  ingress:
    hosts: [client-staging.example.com]
  filestore:
    storageSize: 50Gi
  environment: Staging
  productionInstanceRef:
    name: client-prod
```

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean
- [x] `cargo test --lib` passes
- [x] New integration tests compile (`production_instance_ref.rs`)
- [x] Manual minikube test — CEL rejection on `environment: Production + productionInstanceRef`: apply rejected with `"spec.productionInstanceRef is forbidden on production instances"`
- [x] Manual minikube test — happy path: staging manifest with `productionInstanceRef` produced `staging-copy-auto-refresh` OdooStagingRefreshJob (correct odooInstanceRef + source, owner ref with controller=true, `bemade.org/auto-refresh=true` label), no OdooInitJob, phase transitioned Uninitialized → CloningFromSource automatically
- [ ] Integration test suite on CI (envtest) — runs on PR

## Notes

- CHANGELOG: left to release-please (conventional-commit format used).
- README updated: new spec-table rows + "Staging from production" section with example manifest and limits.
- Pre-existing limitation (out of scope): when a refresh fails, the target lands in `InitFailed` which has no orphan-escape transition back to `Uninitialized`, so deleting the failed auto-refresh CR does not trigger a retry. Recovery today is to delete + recreate the `OdooInstance`. Same limitation applies to the existing manual refresh-job flow. Worth a separate task.