### PR TITLE
fix(scripts): strip COMMENT ON EXTENSION from pg_dump stream

### DIFF
--- a/scripts/clone-db.sh
+++ b/scripts/clone-db.sh
@@ -65,6 +65,7 @@ PGPASSWORD=$SRC_PASSWORD pg_dump \
 sed -E \
     -e '/^SET transaction_timeout /d' \
     -e '/^ALTER [A-Z ]+[^;]*OWNER TO [^;]*;$/d' \
+    -e '/^COMMENT ON EXTENSION [^;]*;$/d' \
     -e '/^GRANT [^;]*;$/d' \
     -e '/^REVOKE [^;]*;$/d' \
     -e '/^REASSIGN OWNED BY [^;]*;$/d' | \

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -91,6 +91,7 @@ load_sql() {
     # simply won't fire, instead of surgically corrupting a multi-line stmt.
     sed -E \
         -e '/^ALTER [A-Z ]+[^;]*OWNER TO [^;]*;$/d' \
+        -e '/^COMMENT ON EXTENSION [^;]*;$/d' \
         -e '/^GRANT [^;]*;$/d' \
         -e '/^REVOKE [^;]*;$/d' \
         -e '/^REASSIGN OWNED BY [^;]*;$/d' \


### PR DESCRIPTION
## Summary

`pg_dump` emits `COMMENT ON EXTENSION <ext> IS '...';` for every installed extension with a comment. Only the extension's owner can modify the comment, and on CloudNativePG clusters extensions like `vector` are owned by the superuser (`postgres`) role — not the Odoo role running the restore. This halted `pg_dump | psql` streams with `ERROR: must be owner of extension vector` and `ON_ERROR_STOP=1` exiting the pipe.

Adds the pattern to the existing sed filter in both scripts:

- `scripts/clone-db.sh` — used by `OdooStagingRefreshJob` reconcile for staging refreshes.
- `scripts/restore.sh` — used by `OdooRestoreJob` reconcile for S3 restores.

## Repro

Seen live on the bemade-staging clone attempt after the odoo_herd UI rollout — source prod DB has pgvector installed. The DB sub-job (`bemade-staging-auto-refresh-db-*`) hit BackoffLimitExceeded with:

```
NOTICE:  database "..._refresh_6b4f1ce9" does not exist, skipping
DROP DATABASE
=== Streaming pg_dump | psql ===
 set_config
------------

(1 row)

ERROR:  must be owner of extension vector
=== Clone failed (rc=3) — dropping temp DB ... ===
```

## Test plan

- [ ] Re-run the bemade-staging clone on an operator image built from this branch; DB job completes, refresh phase progresses past CloningFromSource.
- [ ] Confirm no regression on non-extension source DBs (no-op for them).