### PR TITLE
fix(staging-refresh): record sub-job phases to survive Job GC

### DIFF
--- a/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
@@ -146,8 +146,26 @@ spec:
                 description: batch/v1 Job name for the DB clone.
                 nullable: true
                 type: string
+              dbJobPhase:
+                description: Recorded terminal phase (`Completed`/`Failed`) of the DB clone Job. Persisted on first observation so that future reconciles remain correct after the underlying batch/v1 Job is garbage-collected by `ttlSecondsAfterFinished` while sibling sub-Jobs are still running.
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
+                nullable: true
+                type: string
               filestoreJobName:
                 description: batch/v1 Job name for the filestore copy/clone.
+                nullable: true
+                type: string
+              filestoreJobPhase:
+                description: Recorded terminal phase of the filestore clone Job.  See `dbJobPhase`.
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
                 nullable: true
                 type: string
               message:
@@ -155,6 +173,15 @@ spec:
                 type: string
               neutralizeJobName:
                 description: batch/v1 Job name for the neutralize step.
+                nullable: true
+                type: string
+              neutralizeJobPhase:
+                description: Recorded terminal phase of the neutralize Job.  See `dbJobPhase`.
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
                 nullable: true
                 type: string
               phase:

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -272,10 +272,16 @@ impl ReconcileSnapshot {
                     Some(Phase::Completed) | Some(Phase::Failed) => {}
                     _ => {
                         if active_refresh_job.is_none() {
+                            let crd_name = job.name_any();
                             let sub_statuses = [
-                                resolve_k8s_job_status(
+                                resolve_refresh_sub_job_status(
+                                    client,
+                                    ns,
+                                    &crd_name,
                                     &jobs_api,
                                     job.status.as_ref().and_then(|s| s.db_job_name.as_deref()),
+                                    job.status.as_ref().and_then(|s| s.db_job_phase.as_ref()),
+                                    "dbJobPhase",
                                 )
                                 .await,
                                 // Filestore sub-job is skipped when
@@ -284,19 +290,33 @@ impl ReconcileSnapshot {
                                 if job.spec.skip_filestore {
                                     JobStatus::Succeeded
                                 } else {
-                                    resolve_k8s_job_status(
+                                    resolve_refresh_sub_job_status(
+                                        client,
+                                        ns,
+                                        &crd_name,
                                         &jobs_api,
                                         job.status
                                             .as_ref()
                                             .and_then(|s| s.filestore_job_name.as_deref()),
+                                        job.status
+                                            .as_ref()
+                                            .and_then(|s| s.filestore_job_phase.as_ref()),
+                                        "filestoreJobPhase",
                                     )
                                     .await
                                 },
-                                resolve_k8s_job_status(
+                                resolve_refresh_sub_job_status(
+                                    client,
+                                    ns,
+                                    &crd_name,
                                     &jobs_api,
                                     job.status
                                         .as_ref()
                                         .and_then(|s| s.neutralize_job_name.as_deref()),
+                                    job.status
+                                        .as_ref()
+                                        .and_then(|s| s.neutralize_job_phase.as_ref()),
+                                    "neutralizeJobPhase",
                                 )
                                 .await,
                             ];
@@ -590,18 +610,43 @@ async fn gather_stuck_mount_pods(
     stuck
 }
 
-/// Resolve a single K8s Job's observed status by name.  Used by the
-/// staging-refresh aggregator which needs per-sub-job state, rather than
-/// the CR-centric view `resolve_job_status` gives.
+/// Resolve a staging-refresh sub-Job's status, preferring a previously
+/// recorded terminal phase on the parent CR over a live K8s lookup.
 ///
-/// Returns `Absent` when the job name is not yet populated (so the
-/// CloningFromSource state knows to create it), `Succeeded` / `Failed` /
-/// `Active` based on the K8s Job status.
-async fn resolve_k8s_job_status(jobs_api: &Api<Job>, job_name: Option<&str>) -> JobStatus {
+/// Why: the underlying batch/v1 Jobs carry `ttlSecondsAfterFinished`, so
+/// a sub-Job that finishes well ahead of its siblings (e.g. DB clone vs.
+/// a long rsync filestore copy) gets garbage-collected before the
+/// aggregate refresh completes.  A naive re-read then sees a 404 and
+/// would treat that as `Failed`, killing the in-flight refresh and
+/// orphaning the surviving sub-Jobs.
+///
+/// On first observation of a terminal K8s status, this function persists
+/// the outcome to `status.{field}` on the parent CR, so subsequent
+/// reconciles read the canonical record and never re-evaluate the
+/// (possibly GC'd) batch/v1 Job.  When neither a record nor a live Job
+/// is available (404 with no recording yet), we conservatively report
+/// `Active` rather than `Failed` — losing the terminal observation
+/// window only happens if the operator was offline across the TTL, and
+/// reporting `Failed` on missing evidence is worse than waiting for the
+/// sibling sub-Jobs' `activeDeadlineSeconds` to drive progress.
+async fn resolve_refresh_sub_job_status(
+    client: &Client,
+    ns: &str,
+    crd_name: &str,
+    jobs_api: &Api<Job>,
+    job_name: Option<&str>,
+    recorded_phase: Option<&Phase>,
+    sub_job_field: &str,
+) -> JobStatus {
+    match recorded_phase {
+        Some(Phase::Completed) => return JobStatus::Succeeded,
+        Some(Phase::Failed) => return JobStatus::Failed,
+        _ => {}
+    }
     let Some(name) = job_name else {
         return JobStatus::Absent;
     };
-    match jobs_api.get(name).await {
+    let live = match jobs_api.get(name).await {
         Ok(job) => {
             let succeeded = job.status.as_ref().and_then(|s| s.succeeded).unwrap_or(0) > 0;
             let failed = job.status.as_ref().and_then(|s| s.failed).unwrap_or(0) > 0;
@@ -613,9 +658,30 @@ async fn resolve_k8s_job_status(jobs_api: &Api<Job>, job_name: Option<&str>) -> 
                 JobStatus::Active
             }
         }
-        Err(kube::Error::Api(ref err)) if err.code == 404 => JobStatus::Failed,
+        Err(kube::Error::Api(ref err)) if err.code == 404 => JobStatus::Active,
         Err(_) => JobStatus::Active,
+    };
+    if matches!(live, JobStatus::Succeeded | JobStatus::Failed) {
+        let phase_str = if matches!(live, JobStatus::Succeeded) {
+            "Completed"
+        } else {
+            "Failed"
+        };
+        let patch = json!({"status": {sub_job_field: phase_str}});
+        let api: Api<OdooStagingRefreshJob> = Api::namespaced(client.clone(), ns);
+        if let Err(e) = api
+            .patch_status(
+                crd_name,
+                &PatchParams::apply(FIELD_MANAGER),
+                &Patch::Merge(&patch),
+            )
+            .await
+        {
+            tracing::warn!(%crd_name, %sub_job_field, error = %e,
+                "failed to record refresh sub-job terminal phase; will retry on next reconcile");
+        }
     }
+    live
 }
 
 /// Roll up the staging-refresh sub-Job statuses into a single JobStatus.

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use crate::crd::odoo_instance::OdooInstance;
 use crate::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
+use crate::crd::shared::Phase;
 use crate::error::{Error, Result};
 
 use super::{Context, ReconcileSnapshot, State};
@@ -197,21 +198,29 @@ impl State for CloningFromSource {
 
         // ── Step 3: neutralize (after DB + filestore succeed) ─────────
         let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
-        let db_done = job_succeeded(
+        let db_done = sub_job_succeeded(
             &jobs_api,
             refresh
                 .status
                 .as_ref()
                 .and_then(|s| s.db_job_name.as_deref()),
+            refresh
+                .status
+                .as_ref()
+                .and_then(|s| s.db_job_phase.as_ref()),
         )
         .await;
         let fs_done = refresh.spec.skip_filestore
-            || job_succeeded(
+            || sub_job_succeeded(
                 &jobs_api,
                 refresh
                     .status
                     .as_ref()
                     .and_then(|s| s.filestore_job_name.as_deref()),
+                refresh
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.filestore_job_phase.as_ref()),
             )
             .await;
         if db_done
@@ -275,7 +284,22 @@ impl State for CloningFromSource {
     }
 }
 
-async fn job_succeeded(jobs_api: &Api<Job>, name: Option<&str>) -> bool {
+/// Has a refresh sub-Job reached a successful terminal state?
+///
+/// Prefers the recorded `Phase::Completed` on the parent CR (set by the
+/// snapshot builder once a terminal status is observed) so this gate
+/// keeps returning `true` even after the underlying batch/v1 Job is
+/// garbage-collected by `ttlSecondsAfterFinished` while siblings are
+/// still in flight.  Falls back to a live K8s lookup when no record
+/// exists yet.
+async fn sub_job_succeeded(
+    jobs_api: &Api<Job>,
+    name: Option<&str>,
+    recorded_phase: Option<&Phase>,
+) -> bool {
+    if matches!(recorded_phase, Some(Phase::Completed)) {
+        return true;
+    }
     let Some(name) = name else {
         return false;
     };

--- a/src/crd/odoo_staging_refresh_job.rs
+++ b/src/crd/odoo_staging_refresh_job.rs
@@ -109,13 +109,28 @@ pub struct OdooStagingRefreshJobStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub db_job_name: Option<String>,
 
+    /// Recorded terminal phase (`Completed`/`Failed`) of the DB clone Job.
+    /// Persisted on first observation so that future reconciles remain
+    /// correct after the underlying batch/v1 Job is garbage-collected by
+    /// `ttlSecondsAfterFinished` while sibling sub-Jobs are still running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db_job_phase: Option<Phase>,
+
     /// batch/v1 Job name for the filestore copy/clone.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filestore_job_name: Option<String>,
 
+    /// Recorded terminal phase of the filestore clone Job.  See `dbJobPhase`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filestore_job_phase: Option<Phase>,
+
     /// batch/v1 Job name for the neutralize step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub neutralize_job_name: Option<String>,
+
+    /// Recorded terminal phase of the neutralize Job.  See `dbJobPhase`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub neutralize_job_phase: Option<Phase>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,

--- a/tests/integration/staging_refresh.rs
+++ b/tests/integration/staging_refresh.rs
@@ -1,11 +1,12 @@
 use k8s_openapi::api::batch::v1::Job;
-use kube::api::{Api, ListParams, Patch, PatchParams, PostParams};
+use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use serde_json::json;
 use std::time::{Duration, Instant};
 
 use super::common::*;
 use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
 use odoo_operator::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
+use odoo_operator::crd::shared::Phase;
 
 const TIMEOUT: Duration = Duration::from_secs(30);
 const POLL: Duration = Duration::from_millis(200);
@@ -218,6 +219,128 @@ async fn staging_refresh_db_failure_goes_to_init_failed() -> anyhow::Result<()> 
 
     // Discourage unused-result warnings from ListParams import.
     let _ = ListParams::default();
+    source_ready.abort();
+    Ok(())
+}
+
+/// Regression: a sub-Job that finishes and is then garbage-collected by
+/// `ttlSecondsAfterFinished` (or any other deletion path) must not flip
+/// the aggregate refresh into Failed while siblings are still running.
+///
+/// Production incident: durpro-staging refresh hit InitFailed at 30 min
+/// because the DB clone (~14 min) + 15 min TTL caused its batch/v1 Job
+/// to disappear while the filestore rsync was still in flight.  The
+/// snapshot builder saw 404 on the DB Job, returned `Failed`, and the
+/// state machine fired CloningFromSource → InitFailed.
+///
+/// Fix verified here: the operator records each sub-Job's terminal
+/// phase on the parent CR (`status.dbJobPhase` etc.) the first time it
+/// observes success; subsequent reconciles read that authoritative
+/// record instead of re-fetching the (now-deleted) Job.
+#[tokio::test]
+async fn staging_refresh_survives_subjob_gc() -> anyhow::Result<()> {
+    let ctx = TestContext::new("src-gc").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let source_ready = fast_track_to_running(&ctx, "src-gc-init").await;
+
+    let target: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": "tgt-gc", "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["tgt-gc.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "standard" },
+            "init": { "enabled": false },
+        }
+    }))
+    .unwrap();
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances.create(&PostParams::default(), &target).await?;
+
+    let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(c.clone(), ns);
+    let refresh: OdooStagingRefreshJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooStagingRefreshJob",
+        "metadata": { "name": "tgt-gc-refresh", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "tgt-gc" },
+            "source": { "instanceName": "src-gc" },
+        }
+    }))
+    .unwrap();
+    refreshes.create(&PostParams::default(), &refresh).await?;
+    assert!(
+        wait_for_phase(c, ns, "tgt-gc", OdooInstancePhase::CloningFromSource).await,
+        "expected CloningFromSource"
+    );
+
+    // Step 1: DB and filestore Jobs spawn in parallel; succeed only the DB.
+    let db_job = wait_for_refresh_sub_job(c, ns, "tgt-gc-refresh", "dbJobName").await;
+    let fs_job = wait_for_refresh_sub_job(c, ns, "tgt-gc-refresh", "filestoreJobName").await;
+    let jobs: Api<Job> = Api::namespaced(c.clone(), ns);
+    jobs.patch_status(
+        &db_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    // Step 2: wait for the operator to record the DB sub-Job's terminal
+    // phase on the parent CR.  This is the canonical record that survives
+    // GC of the underlying Job.
+    let start = Instant::now();
+    loop {
+        let r = refreshes.get("tgt-gc-refresh").await?;
+        if matches!(
+            r.status.as_ref().and_then(|s| s.db_job_phase.as_ref()),
+            Some(Phase::Completed)
+        ) {
+            break;
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "operator never recorded dbJobPhase=Completed"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+
+    // Step 3: simulate TTL-based GC by deleting the (succeeded) DB Job.
+    jobs.delete(&db_job, &DeleteParams::default()).await?;
+
+    // Step 4: succeed the filestore Job.  The operator must now consult
+    // the recorded dbJobPhase rather than re-fetching the deleted DB Job;
+    // otherwise the aggregate would roll up to Failed and the target would
+    // transition to InitFailed.
+    jobs.patch_status(
+        &fs_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    // Step 5: neutralize Job spawns iff db_done && fs_done held true,
+    // proving the recorded phase carried the DB clone's success forward.
+    let neut_job = wait_for_refresh_sub_job(c, ns, "tgt-gc-refresh", "neutralizeJobName").await;
+    jobs.patch_status(
+        &neut_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    assert!(
+        wait_for_phase(c, ns, "tgt-gc", OdooInstancePhase::Starting).await,
+        "expected Starting after refresh succeeded despite DB Job being GC'd"
+    );
+
     source_ready.abort();
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Refresh sub-Jobs (DB clone, filestore clone, neutralize) carry `ttlSecondsAfterFinished=900`. When the DB clone finishes well ahead of a long-running filestore rsync, its `batch/v1` Job is GC'd mid-refresh — the snapshot builder 404s on the DB Job, treats it as `Failed`, rolls the aggregate to `Failed`, and fires `CloningFromSource → InitFailed`. The surviving filestore Job is orphaned.
- Reproduced in production on `durpro-staging` at exactly DB-runtime + 15 min TTL.
- Fix: persist each sub-Job's terminal phase on `OdooStagingRefreshJobStatus` the first time it's observed, and prefer that record over re-fetching the (possibly GC'd) Job. 404 with no recorded phase now reports `Active` rather than `Failed`.

## Changes
- New status fields on `OdooStagingRefreshJob`: `dbJobPhase`, `filestoreJobPhase`, `neutralizeJobPhase`.
- `state_machine.rs`: replace `resolve_k8s_job_status` with `resolve_refresh_sub_job_status` — prefers recorded phase, falls back to live K8s lookup, persists outcome on first terminal observation.
- `cloning_from_source.rs`: rename `job_succeeded` → `sub_job_succeeded`; also reads recorded phase so neutralize still spawns after DB Job GC.
- Regenerated CRD YAML (`make helm-crds`).
- Regression test `staging_refresh_survives_subjob_gc`: succeed DB → wait for `dbJobPhase=Completed` → delete DB Job → succeed filestore → assert neutralize spawns and target reaches `Starting`.

## Test plan
- [x] \`cargo test --lib\` — 16 passed
- [x] \`cargo test --test integration\` — 36 passed (including the new regression test)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] Deploy to a staging cluster, kick a refresh where DB clone finishes >15 min before filestore, confirm refresh completes instead of flipping to InitFailed
- [ ] Recover live \`durpro-staging\`: delete orphaned \`durpro-staging-refresh-pzv6c-fs-j6d99\` Job, delete failed refresh CR, create a new refresh CR

## Recovery for the live incident
The in-flight \`durpro-staging-refresh-pzv6c-fs-j6d99\` filestore Job is currently orphaned. After this fix ships:
1. \`kubectl -n durpro delete job durpro-staging-refresh-pzv6c-fs-j6d99\`
2. \`kubectl -n durpro delete odoostagingrefreshjob durpro-staging-refresh-pzv6c\`
3. Create a new refresh CR (or let the auto-refresh from \`productionInstanceRef\` re-fire).