### PR TITLE
fix(db-migration): use pg-tools image matching server major version

### DIFF
--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -182,6 +182,13 @@ pub fn cron_depl_name(instance: &OdooInstance) -> String {
     instance.name_any().to_string() + "-cron"
 }
 
+/// Image carrying pg client tools (`psql`, `pg_dump`, `pg_restore`, `createdb`)
+/// that match a server major version. pg_dump/pg_restore must be ≥ the server
+/// major on both ends of a pipe, so callers should pass `max(src_major, dst_major)`.
+pub fn pg_tools_image(major: u32) -> String {
+    format!("postgres:{major}-alpine")
+}
+
 // ── OdooJobBuilder ──────────────────────────────────────────────────────────
 
 /// Builder for batch/v1 `Job` resources used by the operator's job controllers.

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -267,6 +267,14 @@ impl OdooJobBuilder {
         self
     }
 
+    /// Drop the standard filestore PVC + odoo-conf volumes. Useful for jobs
+    /// that don't run odoo-bin and don't touch the filestore — skipping the
+    /// PVC mount avoids the fsGroup chown traversal at pod start.
+    pub fn without_standard_volumes(mut self) -> Self {
+        self.volumes.clear();
+        self
+    }
+
     /// Set `spec.activeDeadlineSeconds` on the Job.
     pub fn active_deadline(mut self, seconds: i64) -> Self {
         self.active_deadline = Some(seconds);

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -13,8 +13,8 @@ use crate::error::{Error, Result};
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, cron_depl_name, env, odoo_volume_mounts, staging_mail_env_vars, OdooJobBuilder,
-    FIELD_MANAGER,
+    cm_env, cron_depl_name, env, odoo_volume_mounts, pg_tools_image, staging_mail_env_vars,
+    OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 
@@ -119,10 +119,29 @@ impl State for CloningFromSource {
                 hex[..8].to_string()
             };
             let temp_db = format!("{target_db}_refresh_{short}");
+
+            // Detect PG server majors on both source and target clusters and
+            // run clone-db.sh with a pg client image whose tools are ≥ both
+            // server majors. Using the Odoo image's pg_dump (16.x) against a
+            // PG18 server fails outright. Failure to probe aborts the refresh
+            // — we can't clone a cluster we can't reach.
+            let (_, src_pg) =
+                super::super::odoo_instance::load_postgres_cluster(ctx, &source_instance).await?;
+            let (_, tgt_pg) =
+                super::super::odoo_instance::load_postgres_cluster(ctx, instance).await?;
+            let src_major = ctx.postgres.detect_server_major_version(&src_pg).await?;
+            let tgt_major = ctx.postgres.detect_server_major_version(&tgt_pg).await?;
+            let db_image = pg_tools_image(src_major.max(tgt_major));
+            info!(
+                crd_name = %refresh.name_any(),
+                src_major, tgt_major, %db_image,
+                "selected pg client image for staging refresh DB clone"
+            );
+
             let job = build_db_clone_job(
                 &refresh.name_any(),
                 &ns,
-                image,
+                &db_image,
                 instance,
                 refresh,
                 &source_conf,
@@ -338,16 +357,12 @@ fn build_db_clone_job(
     ];
     OdooJobBuilder::new(&format!("{crd_name}-db-"), ns, refresh, instance)
         .active_deadline(3600)
+        .without_standard_volumes()
         .containers(vec![Container {
             name: "clone-db".into(),
             image: Some(image.into()),
-            command: Some(vec![
-                "/bin/bash".into(),
-                "-c".into(),
-                CLONE_DB_SCRIPT.into(),
-            ]),
+            command: Some(vec!["/bin/sh".into(), "-c".into(), CLONE_DB_SCRIPT.into()]),
             env: Some(envs),
-            volume_mounts: Some(odoo_volume_mounts()),
             ..Default::default()
         }])
         .build()

--- a/src/controller/states/migrating_database.rs
+++ b/src/controller/states/migrating_database.rs
@@ -18,8 +18,7 @@ use crate::error::Result;
 use crate::postgres::PostgresClusterConfig;
 
 use super::super::helpers::{
-    cron_depl_name, env, image_pull_secrets, odoo_security_context, odoo_volume_mounts,
-    odoo_volumes, FIELD_MANAGER,
+    cron_depl_name, env, image_pull_secrets, odoo_security_context, pg_tools_image, FIELD_MANAGER,
 };
 use super::super::odoo_instance::{load_postgres_cluster_by_name, Context};
 use super::super::state_machine::{scale_deployment, ReconcileSnapshot};
@@ -80,9 +79,21 @@ pub async fn begin_database_migration(instance: &OdooInstance, ctx: &Context) ->
 
     let migration_env = build_migration_env(&old_pg, &new_pg, &odoo_conf_name, &db);
 
+    // Detect server major versions on both clusters and pick an image whose
+    // pg client tools satisfy `pg_dump/pg_restore >= server_major` on both ends.
+    // Failing this query aborts the transition — we can't migrate a cluster
+    // we can't reach.
+    let src_major = ctx.postgres.detect_server_major_version(&old_pg).await?;
+    let dst_major = ctx.postgres.detect_server_major_version(&new_pg).await?;
+    let tools_major = src_major.max(dst_major);
+    let image = pg_tools_image(tools_major);
+    info!(
+        %inst_name, src_major, dst_major, %image,
+        "selected pg client image for migration"
+    );
+
     // Build the migration Job.
-    let image = instance.spec.image.as_deref().unwrap_or("odoo:18.0");
-    let job = build_migration_job(&inst_name, &ns, instance, image, migration_env);
+    let job = build_migration_job(&inst_name, &ns, instance, &image, migration_env);
     let jobs: Api<Job> = Api::namespaced(client.clone(), &ns);
     let created = jobs.create(&PostParams::default(), &job).await?;
     let job_name = created.name_any();
@@ -225,10 +236,8 @@ fn build_migration_job(
                         command: Some(vec!["/bin/sh".to_string(), "-c".to_string()]),
                         args: Some(vec![MIGRATE_SCRIPT.to_string()]),
                         env: Some(env_vars),
-                        volume_mounts: Some(odoo_volume_mounts()),
                         ..Default::default()
                     }],
-                    volumes: Some(odoo_volumes(inst_name)),
                     ..Default::default()
                 }),
             },

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -39,6 +39,9 @@ pub trait PostgresManager: Send + Sync {
         db_name: &str,
         report_url: &str,
     ) -> Result<()>;
+
+    /// Query the running PostgreSQL server for its major version (e.g. 16, 17, 18).
+    async fn detect_server_major_version(&self, pg: &PostgresClusterConfig) -> Result<u32>;
 }
 
 /// Production implementation backed by tokio-postgres.
@@ -169,6 +172,26 @@ impl PostgresManager for PgPostgresManager {
         info!(%username, "deleted postgres role");
         Ok(())
     }
+
+    async fn detect_server_major_version(&self, pg: &PostgresClusterConfig) -> Result<u32> {
+        let connstr = format!(
+            "host={} port={} user={} password={} dbname=postgres",
+            pg.host, pg.port, pg.admin_user, pg.admin_password
+        );
+        let (client, connection) = tokio_postgres::connect(&connstr, NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                warn!("postgres connection error: {e}");
+            }
+        });
+
+        let row = client.query_one("SHOW server_version_num", &[]).await?;
+        let raw: String = row.get(0);
+        let n: u32 = raw.trim().parse().map_err(|e| {
+            crate::error::Error::config(format!("could not parse server_version_num {raw:?}: {e}"))
+        })?;
+        Ok(n / 10000)
+    }
 }
 
 /// Minimal SQL identifier quoting (double-quote wrapping + escape internal quotes).
@@ -196,5 +219,8 @@ impl PostgresManager for NoopPostgresManager {
         _: &str,
     ) -> Result<()> {
         Ok(())
+    }
+    async fn detect_server_major_version(&self, _: &PostgresClusterConfig) -> Result<u32> {
+        Ok(18)
     }
 }


### PR DESCRIPTION
## Summary

- Migration Job was using the Odoo image for `pg_dump|pg_restore`. Odoo 18 ships with pg client tools in the 16.x range, which cannot dump from a PostgreSQL 18 server (pg_dump must be ≥ server major version).
- `begin_database_migration` now probes both source and destination clusters with `SHOW server_version_num` (via a new `PostgresManager::detect_server_major_version` method so tests stay mockable), takes the max major, and runs the Job in `postgres:<major>-alpine`. Detection failure aborts the transition — we can't migrate a cluster we can't reach.
- Same fix applied to staging refresh DB clone (`clone-db.sh` had identical brittleness; the script's own header comment documents it). The filestore-clone and neutralize Jobs in that pipeline keep the Odoo image since they need odoo-bin / `clone-filestore.py`.
- Migration and staging-refresh DB-clone Jobs no longer mount the filestore PVC or odoo-conf ConfigMap — neither is read by the scripts, and skipping the `fsGroup` chown traversal speeds pod startup on large filestores. New `OdooJobBuilder::without_standard_volumes()` helper for that.

## Not in this PR

`backup.sh` (zip mode) and `restore.sh` have the same latent bug for any cluster on a PG major newer than the Odoo image, but they genuinely mix pg-tools and Odoo binaries (`odoo db dump`, `odoo neutralize`). Fixing them properly needs an initContainer + main container split sharing `/mnt/backup` — bigger refactor, deserves its own PR.