### PR TITLE
fix(backup): split package and upload to drop apk dependency

### DIFF
--- a/scripts/backup-package.sh
+++ b/scripts/backup-package.sh
@@ -1,23 +1,20 @@
 #!/bin/sh
-# Packages the dump (and filestore for zip format) and uploads to S3.
-# Runs in quay.io/minio/mc (alpine-based); installs `zip` on demand for zip format.
+# Packages the dump (and filestore for zip format) into the final artifact at
+# /workspace/$FILENAME.  Runs in alpine; installs `zip` on demand for zip format.
 #
 # For zip format the filestore PVC is read directly into the archive via a
 # symlink — no intermediate copy.
 #
 # Required env vars:
 #   BACKUP_FORMAT, INSTANCE_NAME, DB_NAME
-#   S3_ENDPOINT, S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 # Optional env vars:
 #   LOCAL_FILENAME — output filename (extension appended if missing)
-#   S3_KEY         — destination object key (defaults to LOCAL_FILENAME)
-#   S3_INSECURE    — "true" to skip TLS verification
-#   MC_CONFIG_DIR  — defaults to /tmp/.mc
 #   BACKUP_WITH_FILESTORE — "false" to omit filestore from zip (default true)
+#
+# Writes the resolved artifact path and filename to /workspace/.artifact-meta
+# so the upload container can pick them up without recomputing.
 
 set -ex
-MC_CONFIG_DIR="${MC_CONFIG_DIR:-/tmp/.mc}"
-mkdir -p "$MC_CONFIG_DIR"
 
 case "$BACKUP_FORMAT" in
     zip) apk add --no-cache zip > /dev/null ;;
@@ -51,13 +48,5 @@ case "$BACKUP_FORMAT" in
 esac
 
 ls -lh "$ARTIFACT"
-
-DEST_KEY="${S3_KEY:-$FILENAME}"
-[ -n "$S3_BUCKET" ] && [ -n "$S3_ENDPOINT" ] || { echo "S3 config missing" >&2; exit 1; }
-
-MC_INSECURE=""
-[ "${S3_INSECURE}" = "true" ] && MC_INSECURE="--insecure"
-
-mc $MC_INSECURE alias set dest "$S3_ENDPOINT" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
-mc $MC_INSECURE cp "$ARTIFACT" "dest/$S3_BUCKET/$DEST_KEY"
-echo "=== Upload complete: dest/$S3_BUCKET/$DEST_KEY ==="
+printf 'ARTIFACT=%s\nFILENAME=%s\n' "$ARTIFACT" "$FILENAME" > /workspace/.artifact-meta
+echo "=== Package complete: $ARTIFACT ==="

--- a/scripts/backup-upload.sh
+++ b/scripts/backup-upload.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Uploads the packaged backup artifact to S3.  Runs in quay.io/minio/mc which
+# no longer ships with apk — keep this script free of package installs.
+#
+# Required env vars:
+#   S3_ENDPOINT, S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# Optional env vars:
+#   S3_KEY        — destination object key (defaults to packaged filename)
+#   S3_INSECURE   — "true" to skip TLS verification
+#   MC_CONFIG_DIR — defaults to /tmp/.mc
+#
+# Reads ARTIFACT and FILENAME from /workspace/.artifact-meta written by the
+# package init container.
+
+set -ex
+MC_CONFIG_DIR="${MC_CONFIG_DIR:-/tmp/.mc}"
+mkdir -p "$MC_CONFIG_DIR"
+
+[ -f /workspace/.artifact-meta ] || { echo "missing /workspace/.artifact-meta from package step" >&2; exit 1; }
+. /workspace/.artifact-meta
+
+[ -n "$ARTIFACT" ] && [ -f "$ARTIFACT" ] || { echo "artifact not found: $ARTIFACT" >&2; exit 1; }
+ls -lh "$ARTIFACT"
+
+DEST_KEY="${S3_KEY:-$FILENAME}"
+[ -n "$S3_BUCKET" ] && [ -n "$S3_ENDPOINT" ] || { echo "S3 config missing" >&2; exit 1; }
+
+MC_INSECURE=""
+[ "${S3_INSECURE}" = "true" ] && MC_INSECURE="--insecure"
+
+mc $MC_INSECURE alias set dest "$S3_ENDPOINT" "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY"
+mc $MC_INSECURE cp "$ARTIFACT" "dest/$S3_BUCKET/$DEST_KEY"
+echo "=== Upload complete: dest/$S3_BUCKET/$DEST_KEY ==="

--- a/src/controller/states/backing_up.rs
+++ b/src/controller/states/backing_up.rs
@@ -23,7 +23,8 @@ use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{cm_env, env, pg_tools_image, OdooJobBuilder, FIELD_MANAGER};
 
 const DUMP_SCRIPT: &str = include_str!("../../../scripts/backup-dump.sh");
-const PACKAGE_UPLOAD_SCRIPT: &str = include_str!("../../../scripts/backup-package-upload.sh");
+const PACKAGE_SCRIPT: &str = include_str!("../../../scripts/backup-package.sh");
+const UPLOAD_SCRIPT: &str = include_str!("../../../scripts/backup-upload.sh");
 
 /// BackingUp: backup job running, deployment stays up (non-disruptive).
 ///
@@ -99,13 +100,16 @@ impl State for BackingUp {
             env("BACKUP_FORMAT", format),
         ];
 
-        let insecure = if dest.insecure { "true" } else { "false" };
-        let mut package_env = vec![
+        let package_env = vec![
             env("INSTANCE_NAME", instance_name.clone()),
             env("DB_NAME", db.clone()),
             env("BACKUP_FORMAT", format),
             env("BACKUP_WITH_FILESTORE", with_filestore),
             env("LOCAL_FILENAME", local_filename),
+        ];
+
+        let insecure = if dest.insecure { "true" } else { "false" };
+        let mut upload_env = vec![
             env("S3_BUCKET", dest.bucket.clone()),
             env("S3_KEY", dest.object_key.clone()),
             env("S3_ENDPOINT", dest.endpoint.clone()),
@@ -118,8 +122,8 @@ impl State for BackingUp {
             let secret_name = secret_ref.name.as_deref().unwrap_or_default();
             if let Ok((ak, sk)) = notify::read_s3_credentials(client, secret_name, secret_ns).await
             {
-                package_env.push(env("AWS_ACCESS_KEY_ID", ak));
-                package_env.push(env("AWS_SECRET_ACCESS_KEY", sk));
+                upload_env.push(env("AWS_ACCESS_KEY_ID", ak));
+                upload_env.push(env("AWS_SECRET_ACCESS_KEY", sk));
             }
         }
 
@@ -150,8 +154,8 @@ impl State for BackingUp {
             ..Default::default()
         };
 
-        // package-upload runs `apk add zip` which needs root.  Override the
-        // pod-level non-root user for this container only.
+        // The package init container runs `apk add zip` (zip format only)
+        // which needs root.  The upload container stays non-root.
         let root_sc = SecurityContext {
             run_as_user: Some(0),
             ..Default::default()
@@ -179,25 +183,31 @@ impl State for BackingUp {
             .without_standard_volumes()
             .extra_volumes(vec![workspace_vol, filestore_vol])
             .affinity(pod_affinity)
-            .init_containers(vec![Container {
-                name: "dump".into(),
-                image: Some(dump_image),
-                command: Some(vec!["/bin/sh".into(), "-c".into(), DUMP_SCRIPT.into()]),
-                env: Some(dump_env),
-                volume_mounts: Some(vec![workspace_mount.clone()]),
-                ..Default::default()
-            }])
+            .init_containers(vec![
+                Container {
+                    name: "dump".into(),
+                    image: Some(dump_image),
+                    command: Some(vec!["/bin/sh".into(), "-c".into(), DUMP_SCRIPT.into()]),
+                    env: Some(dump_env),
+                    volume_mounts: Some(vec![workspace_mount.clone()]),
+                    ..Default::default()
+                },
+                Container {
+                    name: "package".into(),
+                    image: Some("alpine:latest".into()),
+                    command: Some(vec!["/bin/sh".into(), "-c".into(), PACKAGE_SCRIPT.into()]),
+                    env: Some(package_env),
+                    volume_mounts: Some(vec![workspace_mount.clone(), filestore_mount_ro]),
+                    security_context: Some(root_sc),
+                    ..Default::default()
+                },
+            ])
             .containers(vec![Container {
-                name: "package-upload".into(),
+                name: "upload".into(),
                 image: Some("quay.io/minio/mc:latest".into()),
-                command: Some(vec![
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    PACKAGE_UPLOAD_SCRIPT.into(),
-                ]),
-                env: Some(package_env),
-                volume_mounts: Some(vec![workspace_mount, filestore_mount_ro]),
-                security_context: Some(root_sc),
+                command: Some(vec!["/bin/sh".into(), "-c".into(), UPLOAD_SCRIPT.into()]),
+                env: Some(upload_env),
+                volume_mounts: Some(vec![workspace_mount]),
                 ..Default::default()
             }])
             .build();

--- a/src/controller/states/restoring.rs
+++ b/src/controller/states/restoring.rs
@@ -185,7 +185,7 @@ impl State for Restoring {
             }
         }
 
-        // package-upload-style helpers run `apk add ...` which needs root.
+        // The extract container runs `apk add unzip` which needs root.
         let root_sc = SecurityContext {
             run_as_user: Some(0),
             ..Default::default()


### PR DESCRIPTION
The package-upload container ran in quay.io/minio/mc:latest and used
`apk add zip` to install zip on demand.  Recent versions of the minio/mc
image are no longer alpine-based, so apk is missing and zip-format
backups fail.

Split the work into two containers, mirroring the restore flow:
- `package` init container on alpine:latest installs zip and produces
  the artifact (zip / dump / sql) in /workspace
- `upload` main container on minio/mc just runs `mc cp`, no package
  install needed

The package step writes the artifact path and filename to
/workspace/.artifact-meta so the upload step can pick them up without
recomputing.  Only the package container needs root (for apk); the
upload container runs as the pod's non-root user.