### PR TITLE
fix(filestore): reconcile PVC storage size on spec changes

### DIFF
--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -34,7 +34,9 @@ use gateway_api::apis::standard::httproutes::{
 
 use crate::crd::odoo_instance::{DeploymentStrategyType, GatewayRef, OdooInstance};
 use crate::error::Result;
-use crate::helpers::{build_odoo_conf, db_name, generate_password, odoo_username, sha256_hex};
+use crate::helpers::{
+    build_odoo_conf, db_name, generate_password, odoo_username, parse_quantity, sha256_hex,
+};
 use crate::postgres::PostgresClusterConfig;
 
 use super::helpers::{
@@ -285,8 +287,48 @@ pub async fn ensure_filestore_pvc(
         .and_then(|f| f.storage_class.as_deref())
         .unwrap_or(&ctx.defaults.storage_class);
 
-    // Only create if it doesn't exist (PVCs are immutable after creation).
-    if pvcs.get(&pvc_name).await.is_ok() {
+    // If the PVC already exists, reconcile its storage request: expand if the
+    // spec asks for more than what's currently requested. Storage class changes
+    // and shrinks are out of scope here (handled by the migration phases /
+    // rejected by the webhook).
+    if let Ok(existing) = pvcs.get(&pvc_name).await {
+        let current_size = existing
+            .spec
+            .as_ref()
+            .and_then(|s| s.resources.as_ref())
+            .and_then(|r| r.requests.as_ref())
+            .and_then(|m| m.get("storage"))
+            .map(|q| q.0.clone())
+            .unwrap_or_default();
+
+        let desired_bytes = parse_quantity(storage_size).unwrap_or(0);
+        let current_bytes = parse_quantity(&current_size).unwrap_or(0);
+
+        if desired_bytes > current_bytes {
+            tracing::info!(
+                pvc = %pvc_name,
+                from = %current_size,
+                to = %storage_size,
+                "expanding filestore PVC",
+            );
+            let patch = json!({
+                "spec": {
+                    "resources": {
+                        "requests": { "storage": storage_size }
+                    }
+                }
+            });
+            pvcs.patch(&pvc_name, &PatchParams::default(), &Patch::Merge(&patch))
+                .await?;
+        } else if desired_bytes < current_bytes && desired_bytes > 0 {
+            tracing::warn!(
+                pvc = %pvc_name,
+                current = %current_size,
+                desired = %storage_size,
+                "spec.filestore.storageSize is smaller than the existing PVC; \
+                 PVCs cannot shrink — ignoring",
+            );
+        }
         return Ok(());
     }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -177,3 +177,36 @@ pub fn build_odoo_conf(
 
     out
 }
+
+/// Parse a Kubernetes resource quantity string into bytes.
+/// Supports: Ki, Mi, Gi, Ti (binary) and k, M, G, T (decimal).
+pub fn parse_quantity(s: &str) -> Result<u64, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty quantity".to_string());
+    }
+
+    let num_end = s
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(s.len());
+    let (num_str, suffix) = s.split_at(num_end);
+
+    let num: f64 = num_str
+        .parse()
+        .map_err(|e| format!("invalid number {num_str:?}: {e}"))?;
+
+    let multiplier: u64 = match suffix {
+        "" => 1,
+        "Ki" => 1024,
+        "Mi" => 1024 * 1024,
+        "Gi" => 1024 * 1024 * 1024,
+        "Ti" => 1024 * 1024 * 1024 * 1024,
+        "k" => 1000,
+        "M" => 1_000_000,
+        "G" => 1_000_000_000,
+        "T" => 1_000_000_000_000,
+        other => return Err(format!("unknown suffix {other:?}")),
+    };
+
+    Ok((num * multiplier as f64) as u64)
+}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -12,6 +12,7 @@ use tracing::{info, warn};
 use warp::Filter;
 
 use crate::crd::odoo_instance::OdooInstance;
+use crate::helpers::parse_quantity;
 
 /// Start the validating webhook server on the given address.
 /// Returns a future that runs the HTTPS server forever.
@@ -172,40 +173,6 @@ fn compare_quantities(old: &str, new: &str) -> Result<(), String> {
         ));
     }
     Ok(())
-}
-
-/// Parse a Kubernetes resource quantity string into bytes.
-/// Supports: Ki, Mi, Gi, Ti (binary) and k, M, G, T (decimal).
-fn parse_quantity(s: &str) -> Result<u64, String> {
-    let s = s.trim();
-    if s.is_empty() {
-        return Err("empty quantity".to_string());
-    }
-
-    // Find where the numeric part ends.
-    let num_end = s
-        .find(|c: char| !c.is_ascii_digit() && c != '.')
-        .unwrap_or(s.len());
-    let (num_str, suffix) = s.split_at(num_end);
-
-    let num: f64 = num_str
-        .parse()
-        .map_err(|e| format!("invalid number {num_str:?}: {e}"))?;
-
-    let multiplier: u64 = match suffix {
-        "" => 1,
-        "Ki" => 1024,
-        "Mi" => 1024 * 1024,
-        "Gi" => 1024 * 1024 * 1024,
-        "Ti" => 1024 * 1024 * 1024 * 1024,
-        "k" => 1000,
-        "M" => 1_000_000,
-        "G" => 1_000_000_000,
-        "T" => 1_000_000_000_000,
-        other => return Err(format!("unknown suffix {other:?}")),
-    };
-
-    Ok((num * multiplier as f64) as u64)
 }
 
 #[cfg(test)]

--- a/tests/integration/child_resources.rs
+++ b/tests/integration/child_resources.rs
@@ -1,8 +1,8 @@
 use gateway_api::apis::standard::httproutes::HTTPRoute;
 use k8s_openapi::api::apps::v1::Deployment;
-use k8s_openapi::api::core::v1::{ConfigMap, Secret, Service};
+use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Secret, Service};
 use k8s_openapi::api::networking::v1::Ingress;
-use kube::api::{Api, PostParams};
+use kube::api::{Api, Patch, PatchParams, PostParams};
 use serde_json::json;
 
 use super::common::*;
@@ -157,4 +157,147 @@ async fn reconcile_creates_http_route_when_gateway_ref_set() {
         ings.get("test-gw").await.is_err(),
         "Ingress should not exist when gatewayRef is set"
     );
+}
+
+/// envtest has no PV controller and no StorageClasses, so PVCs never bind and
+/// the API server rejects resize attempts. Create an expansion-enabled
+/// StorageClass and fake the PVC into a bound state.
+async fn fake_pvc_bound(c: &kube::Client, ns: &str, name: &str, capacity: &str) {
+    use k8s_openapi::api::storage::v1::StorageClass;
+    let scs: Api<StorageClass> = Api::all(c.clone());
+    let sc: StorageClass = serde_json::from_value(json!({
+        "apiVersion": "storage.k8s.io/v1",
+        "kind": "StorageClass",
+        "metadata": { "name": "standard" },
+        "provisioner": "k8s.io/test-provisioner",
+        "allowVolumeExpansion": true,
+    }))
+    .unwrap();
+    let _ = scs.create(&PostParams::default(), &sc).await;
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(c.clone(), ns);
+    let spec_patch = json!({ "spec": { "volumeName": format!("pv-{name}") } });
+    pvcs.patch(name, &PatchParams::default(), &Patch::Merge(&spec_patch))
+        .await
+        .expect("failed to set volumeName");
+    let status_patch = json!({
+        "status": { "phase": "Bound", "capacity": { "storage": capacity } }
+    });
+    pvcs.patch_status(name, &PatchParams::default(), &Patch::Merge(&status_patch))
+        .await
+        .expect("failed to patch PVC status");
+}
+
+/// Increasing spec.filestore.storageSize should expand the existing PVC's
+/// storage request (PVC expansion in place — no migration phase).
+#[tokio::test]
+async fn pvc_storage_size_expands_in_place() {
+    let ctx = TestContext::new("test-pvc-grow").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    assert!(
+        wait_for_phase(c, ns, "test-pvc-grow", OdooInstancePhase::Uninitialized).await,
+        "expected Uninitialized"
+    );
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(c.clone(), ns);
+    let pvc_name = "test-pvc-grow-filestore-pvc";
+
+    // Initial size from TestContext default — capture it.
+    let initial = pvcs
+        .get(pvc_name)
+        .await
+        .expect("filestore PVC missing")
+        .spec
+        .and_then(|s| s.resources)
+        .and_then(|r| r.requests)
+        .and_then(|m| m.get("storage").cloned())
+        .expect("PVC has no storage request")
+        .0;
+    assert_ne!(initial, "10Gi", "test relies on initial size != 10Gi");
+
+    // The API server only allows resizing bound PVCs. envtest has no
+    // PV controller, so simulate binding by setting volumeName + status.
+    fake_pvc_bound(c, ns, pvc_name, &initial).await;
+
+    // Bump the spec to 10Gi.
+    patch_instance_spec(
+        c,
+        ns,
+        "test-pvc-grow",
+        json!({ "filestore": { "storageSize": "10Gi" } }),
+    )
+    .await;
+
+    // Wait for the operator to patch the PVC.
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let pvcs = pvcs.clone();
+            async move {
+                match pvcs.get(pvc_name).await {
+                    Ok(pvc) => pvc
+                        .spec
+                        .and_then(|s| s.resources)
+                        .and_then(|r| r.requests)
+                        .and_then(|m| m.get("storage").cloned())
+                        .map(|q| q.0 == "10Gi")
+                        .unwrap_or(false),
+                    Err(_) => false,
+                }
+            }
+        })
+        .await,
+        "expected filestore PVC storage request to be expanded to 10Gi"
+    );
+}
+
+/// Decreasing the storage size should be a no-op on the PVC (the webhook would
+/// normally reject this, but in-process tests bypass the webhook). Verifies the
+/// operator does not attempt to shrink.
+#[tokio::test]
+async fn pvc_storage_size_shrink_is_noop() {
+    let ctx = TestContext::new("test-pvc-shrink").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    assert!(
+        wait_for_phase(c, ns, "test-pvc-shrink", OdooInstancePhase::Uninitialized).await,
+        "expected Uninitialized"
+    );
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(c.clone(), ns);
+    let pvc_name = "test-pvc-shrink-filestore-pvc";
+    let initial = pvcs
+        .get(pvc_name)
+        .await
+        .expect("filestore PVC missing")
+        .spec
+        .and_then(|s| s.resources)
+        .and_then(|r| r.requests)
+        .and_then(|m| m.get("storage").cloned())
+        .expect("PVC has no storage request")
+        .0;
+
+    fake_pvc_bound(c, ns, pvc_name, &initial).await;
+
+    patch_instance_spec(
+        c,
+        ns,
+        "test-pvc-shrink",
+        json!({ "filestore": { "storageSize": "1Mi" } }),
+    )
+    .await;
+
+    // Give the operator several reconciles to (not) act, then assert unchanged.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    let after = pvcs
+        .get(pvc_name)
+        .await
+        .unwrap()
+        .spec
+        .and_then(|s| s.resources)
+        .and_then(|r| r.requests)
+        .and_then(|m| m.get("storage").cloned())
+        .unwrap()
+        .0;
+    assert_eq!(after, initial, "PVC should not shrink");
 }


### PR DESCRIPTION
## Summary
- `ensure_filestore_pvc` early-returned when the PVC existed, so `spec.filestore.storageSize` increases were silently ignored. It now patches the PVC's `spec.resources.requests.storage` when the desired size grows, and logs+skips on shrink. Storage class changes are unaffected (still handled by the migration phases).
- Moved `parse_quantity` from `webhook.rs` into `helpers.rs` so the controller can reuse it.
- Added two integration tests covering grow and shrink-noop. Verified end-to-end on minikube against the `standard-v2` SC.

Live `pneumac-staging` will self-heal to 60Gi on the next reconcile after this releases.