### PR TITLE
ci(release): add workflow_dispatch to republish image and chart for an existing tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,12 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing git tag to (re)publish image and chart for, e.g. v1.10.6"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,6 +21,7 @@ env:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -27,12 +34,33 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build-and-publish:
+  resolve-ref:
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      always() &&
+      (
+        (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    outputs:
+      tag_name: ${{ steps.pick.outputs.tag_name }}
+    steps:
+      - id: pick
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag_name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_name=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-and-publish:
+    runs-on: ubuntu-latest
+    needs: resolve-ref
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-ref.outputs.tag_name }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -48,7 +76,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
-            type=raw,value=${{ needs.release-please.outputs.tag_name }}
+            type=raw,value=${{ needs.resolve-ref.outputs.tag_name }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -60,14 +88,14 @@ jobs:
 
   release-chart:
     runs-on: ubuntu-latest
-    needs: [release-please, build-and-publish]
-    if: needs.release-please.outputs.release_created == 'true'
+    needs: [resolve-ref, build-and-publish]
     permissions:
       contents: write
       packages: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ needs.resolve-ref.outputs.tag_name }}
           fetch-depth: 0
 
       - name: Configure Git


### PR DESCRIPTION
## Summary
- Adds a manual \`workflow_dispatch\` to \`release-please.yml\` with a required \`tag\` input.
- Splits tag resolution into a \`resolve-ref\` job so \`build-and-publish\` and \`release-chart\` work for both \`push\` (release-please output) and manual dispatch (input).
- Both downstream jobs now check out the resolved tag explicitly so the manual path republishes from the exact tag state.

## Why
The release-please run for v1.10.6 failed at the very end (after tagging + creating the GitHub release) which silently skipped the image and chart publish jobs. With this change, when that happens again we can manually trigger Actions → Release Please → Run workflow with the tag (e.g. \`v1.10.6\`) and republish without recreating the release. \`helm/chart-releaser-action\` already has \`skip_existing: true\`, so re-running against an already-published release/index entry is a no-op.