### PR TITLE
feat(refresh): snapshot/clone mode for staging filestore copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube-custom-resources-rs"
+version = "2024.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba3e0e4c19a14aff2f0834f24acb02f57ac2d05a1ee6367a0c4fc3036cfc9ea"
+dependencies = [
+ "k8s-openapi",
+ "kube",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kube-derive"
 version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1780,7 @@ dependencies = [
  "http-body-util",
  "k8s-openapi",
  "kube",
+ "kube-custom-resources-rs",
  "rand 0.8.5",
  "reqwest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ clap = { version = "4", features = ["derive", "env"] }
 
 # Webhook server
 warp = { version = "0.3", features = ["tls"] }
+kube-custom-resources-rs = { version = "2024.11.1", features = ["snapshot_storage_k8s_io"] }
 
 [dev-dependencies]
 tower-test = "0.4"

--- a/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
@@ -168,6 +168,15 @@ spec:
                 - Failed
                 nullable: true
                 type: string
+              filestorePhase:
+                description: Mode-agnostic phase for the filestore step.  Set to `Running` once either the rsync Job has been created or the snapshot/clone PVC recreate has been kicked off; transitions to `Completed`/`Failed` when the underlying Job terminates (Copy path) or the new PVC binds (Snapshot path).  Used as the start guard and completion gate for the filestore step regardless of `filestoreMethod`.
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
+                nullable: true
+                type: string
               message:
                 nullable: true
                 type: string

--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -11,7 +11,7 @@ use k8s_openapi::api::{
     core::v1::{
         ConfigMap, Container, ContainerPort, ExecAction, HTTPGetAction, PersistentVolumeClaim,
         PersistentVolumeClaimSpec, PodSpec, PodTemplateSpec, Probe, Secret, Service, ServicePort,
-        ServiceSpec, VolumeResourceRequirements,
+        ServiceSpec, TypedObjectReference, VolumeResourceRequirements,
     },
     networking::v1::{
         HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
@@ -32,7 +32,7 @@ use gateway_api::apis::standard::httproutes::{
     HTTPRouteRulesMatches, HTTPRouteRulesMatchesPath, HTTPRouteRulesMatchesPathType, HTTPRouteSpec,
 };
 
-use crate::crd::odoo_instance::{DeploymentStrategyType, GatewayRef, OdooInstance};
+use crate::crd::odoo_instance::{DeploymentStrategyType, Environment, GatewayRef, OdooInstance};
 use crate::error::Result;
 use crate::helpers::{
     build_odoo_conf, db_name, generate_password, odoo_username, parse_quantity, sha256_hex,
@@ -332,6 +332,8 @@ pub async fn ensure_filestore_pvc(
         return Ok(());
     }
 
+    // No existing PVC, so we fully construct it, possibly with a snapshot source
+    let source = get_pvc_source(client, ns, instance).await;
     let pvc = PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(pvc_name),
@@ -341,6 +343,7 @@ pub async fn ensure_filestore_pvc(
         },
         spec: Some(PersistentVolumeClaimSpec {
             access_modes: Some(vec!["ReadWriteMany".to_string()]),
+            data_source_ref: source,
             resources: Some(VolumeResourceRequirements {
                 requests: Some(BTreeMap::from([(
                     "storage".to_string(),
@@ -355,6 +358,46 @@ pub async fn ensure_filestore_pvc(
     };
     pvcs.create(&PostParams::default(), &pvc).await?;
     Ok(())
+}
+
+/// Make a snapshot from the production instance PVC if possible,
+/// returns a reference to be used in the PVC spec as a source_ref.
+async fn get_pvc_source(
+    client: &Client,
+    ns: &str,
+    instance: &OdooInstance,
+) -> Option<TypedObjectReference> {
+    let Environment::Staging = instance.spec.environment else {
+        return None;
+    };
+    let production_ref = instance.spec.production_instance_ref.as_ref()?;
+    let ns = production_ref.namespace.as_deref().unwrap_or(ns);
+    let production_name = production_ref.name.as_str();
+    let src_pvc_name = format!("{production_name}-filestore-pvc");
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
+    let prod_pvc = pvcs
+        .get(src_pvc_name.as_str())
+        .await
+        .map_err(|e| tracing::warn!(error = %e, pvc = %src_pvc_name, "prod PVC lookup failed"))
+        .ok()?;
+    let sc = instance
+        .spec
+        .filestore
+        .as_ref()
+        .and_then(|spec| spec.storage_class.as_deref());
+    let prod_sc = prod_pvc
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.storage_class_name.as_deref());
+    if sc != prod_sc {
+        return None;
+    }
+    Some(TypedObjectReference {
+        api_group: None,
+        kind: "PersistentVolumeClaim".to_string(),
+        name: src_pvc_name,
+        namespace: Some(ns.to_string()),
+    })
 }
 
 pub async fn ensure_config_map(

--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -367,19 +367,32 @@ async fn get_pvc_source(
     ns: &str,
     instance: &OdooInstance,
 ) -> Option<TypedObjectReference> {
+    let inst_name = instance.name_any();
     let Environment::Staging = instance.spec.environment else {
+        tracing::debug!(name = %inst_name, "get_pvc_source: not staging");
         return None;
     };
-    let production_ref = instance.spec.production_instance_ref.as_ref()?;
-    let ns = production_ref.namespace.as_deref().unwrap_or(ns);
+    let Some(production_ref) = instance.spec.production_instance_ref.as_ref() else {
+        tracing::debug!(name = %inst_name, "get_pvc_source: no production_instance_ref");
+        return None;
+    };
+    let prod_ns = production_ref.namespace.as_deref().unwrap_or(ns);
     let production_name = production_ref.name.as_str();
     let src_pvc_name = format!("{production_name}-filestore-pvc");
-    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
-    let prod_pvc = pvcs
-        .get(src_pvc_name.as_str())
-        .await
-        .map_err(|e| tracing::warn!(error = %e, pvc = %src_pvc_name, "prod PVC lookup failed"))
-        .ok()?;
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), prod_ns);
+    let prod_pvc = match pvcs.get(src_pvc_name.as_str()).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                name = %inst_name,
+                error = %e,
+                pvc = %src_pvc_name,
+                ns = %prod_ns,
+                "get_pvc_source: prod PVC lookup failed"
+            );
+            return None;
+        }
+    };
     let sc = instance
         .spec
         .filestore
@@ -390,13 +403,36 @@ async fn get_pvc_source(
         .as_ref()
         .and_then(|spec| spec.storage_class_name.as_deref());
     if sc != prod_sc {
+        tracing::info!(
+            name = %inst_name,
+            target_sc = ?sc,
+            prod_sc = ?prod_sc,
+            "get_pvc_source: storage class mismatch — falling back to copy"
+        );
         return None;
     }
+    tracing::info!(
+        name = %inst_name,
+        src_pvc = %src_pvc_name,
+        ns = %prod_ns,
+        "get_pvc_source: returning dataSourceRef for snapshot/clone"
+    );
+    // Only set `namespace` when the source PVC is actually in a different
+    // namespace.  Setting it for same-namespace clones triggers K8s'
+    // cross-namespace data-source path, which requires the alpha
+    // `CrossNamespaceVolumeDataSource` feature gate plus a ReferenceGrant
+    // — without those, the API server silently drops the entire
+    // `dataSourceRef` field and the PVC binds empty.
+    let namespace = if prod_ns == ns {
+        None
+    } else {
+        Some(prod_ns.to_string())
+    };
     Some(TypedObjectReference {
         api_group: None,
         kind: "PersistentVolumeClaim".to_string(),
         name: src_pvc_name,
-        namespace: Some(ns.to_string()),
+        namespace,
     })
 }
 

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -284,26 +284,41 @@ impl ReconcileSnapshot {
                                     "dbJobPhase",
                                 )
                                 .await,
-                                // Filestore sub-job is skipped when
-                                // skipFilestore is set; treat Absent as
-                                // "not applicable" = Succeeded for rollup.
+                                // Filestore step is mode-agnostic: prefer the
+                                // explicit `filestore_phase` field when set
+                                // (covers the snapshot path, which has no
+                                // underlying Job).  On the Copy path, fall
+                                // back to the Job-based observer so that
+                                // `filestore_job_phase` keeps being recorded
+                                // for GC durability.  skipFilestore short-
+                                // circuits to Succeeded.
                                 if job.spec.skip_filestore {
                                     JobStatus::Succeeded
                                 } else {
-                                    resolve_refresh_sub_job_status(
-                                        client,
-                                        ns,
-                                        &crd_name,
-                                        &jobs_api,
-                                        job.status
-                                            .as_ref()
-                                            .and_then(|s| s.filestore_job_name.as_deref()),
-                                        job.status
-                                            .as_ref()
-                                            .and_then(|s| s.filestore_job_phase.as_ref()),
-                                        "filestoreJobPhase",
-                                    )
-                                    .await
+                                    match job
+                                        .status
+                                        .as_ref()
+                                        .and_then(|s| s.filestore_phase.as_ref())
+                                    {
+                                        Some(Phase::Completed) => JobStatus::Succeeded,
+                                        Some(Phase::Failed) => JobStatus::Failed,
+                                        _ => {
+                                            resolve_refresh_sub_job_status(
+                                                client,
+                                                ns,
+                                                &crd_name,
+                                                &jobs_api,
+                                                job.status
+                                                    .as_ref()
+                                                    .and_then(|s| s.filestore_job_name.as_deref()),
+                                                job.status
+                                                    .as_ref()
+                                                    .and_then(|s| s.filestore_job_phase.as_ref()),
+                                                "filestoreJobPhase",
+                                            )
+                                            .await
+                                        }
+                                    }
                                 },
                                 resolve_refresh_sub_job_status(
                                     client,

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -1,21 +1,27 @@
 use async_trait::async_trait;
 use k8s_openapi::api::{
     batch::v1::Job,
-    core::v1::{Container, PersistentVolumeClaimVolumeSource, Volume, VolumeMount},
+    core::v1::{
+        Container, PersistentVolumeClaim, PersistentVolumeClaimVolumeSource, Volume, VolumeMount,
+    },
 };
-use kube::api::{Api, Patch, PatchParams, PostParams, ResourceExt};
+use kube::{
+    api::{Api, DeleteParams, Patch, PatchParams, PostParams, ResourceExt},
+    core::ErrorResponse,
+};
 use serde_json::json;
 use tracing::info;
 
-use crate::crd::odoo_instance::OdooInstance;
+use crate::crd::odoo_staging_refresh_job::FilestoreMethod;
 use crate::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
 use crate::crd::shared::Phase;
 use crate::error::{Error, Result};
+use crate::{controller::child_resources, crd::odoo_instance::OdooInstance};
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, cron_depl_name, env, odoo_volume_mounts, pg_tools_image, staging_mail_env_vars,
-    OdooJobBuilder, FIELD_MANAGER,
+    cm_env, controller_owner_ref, cron_depl_name, env, odoo_volume_mounts, pg_tools_image,
+    staging_mail_env_vars, OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 
@@ -175,44 +181,171 @@ impl State for CloningFromSource {
             .await?;
         }
 
-        // ── Step 2b: filestore clone Job (unless skipped) ─────────────
+        // ── Step 2b: filestore step (unless skipped) ──────────────────
+        // Mode-agnostic gate: the start guard and completion check both
+        // ride on `filestore_phase`, set to Running once kickoff succeeds
+        // and Completed/Failed when the underlying work terminates.
         if !refresh.spec.skip_filestore
             && refresh
                 .status
                 .as_ref()
-                .and_then(|s| s.filestore_job_name.as_deref())
+                .and_then(|s| s.filestore_phase.as_ref())
                 .is_none()
         {
             let source_pvc = format!("{source_name}-filestore-pvc");
-            let job = build_filestore_clone_job(
-                &refresh.name_any(),
-                &ns,
-                image,
-                instance,
-                refresh,
-                &source_pvc,
-                &source_db,
-                &target_db,
-            );
-            let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
-            let created = jobs_api.create(&PostParams::default(), &job).await?;
-            let k8s_job_name = created.name_any();
-            info!(
-                crd_name = %refresh.name_any(),
-                %k8s_job_name,
-                "created filestore clone job"
-            );
-            patch_refresh_status(
-                &ctx.client,
-                &ns,
-                &refresh.name_any(),
-                &json!({
-                    "status": {
-                        "filestoreJobName": &k8s_job_name,
+            let use_copy = refresh.spec.filestore_method == FilestoreMethod::Copy
+                || (refresh.spec.filestore_method == FilestoreMethod::Auto
+                    && !can_refresh_with_snapshot(&source_instance, instance));
+            if use_copy {
+                let job = build_filestore_clone_job(
+                    &refresh.name_any(),
+                    &ns,
+                    image,
+                    instance,
+                    refresh,
+                    &source_pvc,
+                    &source_db,
+                    &target_db,
+                );
+                let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
+                let created = jobs_api.create(&PostParams::default(), &job).await?;
+                let k8s_job_name = created.name_any();
+                info!(
+                    crd_name = %refresh.name_any(),
+                    %k8s_job_name,
+                    "created filestore clone job"
+                );
+                patch_refresh_status(
+                    &ctx.client,
+                    &ns,
+                    &refresh.name_any(),
+                    &json!({
+                        "status": {
+                            "filestoreJobName": &k8s_job_name,
+                            "filestorePhase": Phase::Running,
+                        }
+                    }),
+                )
+                .await?;
+            } else {
+                // Snapshot path: replace the staging PVC with one cloned
+                // from the source PVC's contents.  Done in two phases
+                // across reconciles to avoid racing the old PVC's deletion:
+                //   tick A: delete (idempotent on 404), then bail if the
+                //           PVC is still terminating — kubelet may take a
+                //           while to release the volume on a real CSI.
+                //   tick B: PVC is gone → recreate it, patch filestorePhase
+                //           Running.  Settle block then waits for Bound.
+                // Patching Running while the OLD PVC still lingers would
+                // let the settle block see its `phase: Bound` and prematurely
+                // mark the step Completed — racing neutralize against a PVC
+                // that's about to vanish.
+                let target_pvc = format!("{inst_name}-filestore-pvc");
+                let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), &ns);
+                // Background delete (the default): PVCs don't have
+                // OwnerReference dependents, so foreground propagation
+                // would only add a `foregroundDeletion` finalizer that
+                // kube-controller-manager has to strip — pointless on a
+                // real cluster and a deadlock in envtest, which has no
+                // GC controller.
+                if let Err(e) = pvcs
+                    .delete(target_pvc.as_str(), &DeleteParams::default())
+                    .await
+                {
+                    if !matches!(&e, kube::Error::Api(ErrorResponse { code: 404, .. })) {
+                        return Err(e.into());
                     }
-                }),
-            )
-            .await?;
+                }
+                match pvcs.get_opt(target_pvc.as_str()).await? {
+                    Some(existing) if existing.metadata.deletion_timestamp.is_some() => {
+                        info!(
+                            crd_name = %refresh.name_any(),
+                            pvc = %target_pvc,
+                            "old staging filestore PVC still terminating; waiting before recreate"
+                        );
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+                let oref = controller_owner_ref(instance);
+                child_resources::ensure_filestore_pvc(
+                    &ctx.client,
+                    &ns,
+                    &inst_name,
+                    instance,
+                    ctx,
+                    &oref,
+                )
+                .await?;
+                info!(
+                    crd_name = %refresh.name_any(),
+                    pvc = %target_pvc,
+                    "kicked off filestore snapshot/clone PVC recreate"
+                );
+                patch_refresh_status(
+                    &ctx.client,
+                    &ns,
+                    &refresh.name_any(),
+                    &json!({
+                        "status": {
+                            "filestorePhase": Phase::Running,
+                        }
+                    }),
+                )
+                .await?;
+            }
+        }
+
+        // ── Step 2c: settle filestore_phase from underlying signal ────
+        if matches!(
+            refresh
+                .status
+                .as_ref()
+                .and_then(|s| s.filestore_phase.as_ref()),
+            Some(Phase::Running)
+        ) {
+            let terminal = if refresh
+                .status
+                .as_ref()
+                .and_then(|s| s.filestore_job_name.as_deref())
+                .is_some()
+            {
+                // Copy path: mirror Job's recorded terminal phase.
+                match refresh
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.filestore_job_phase.as_ref())
+                {
+                    Some(Phase::Completed) => Some(Phase::Completed),
+                    Some(Phase::Failed) => Some(Phase::Failed),
+                    _ => None,
+                }
+            } else {
+                // Snapshot path: new PVC bound ⇒ Completed.  Defensively
+                // require no `deletionTimestamp` so a still-terminating
+                // old PVC can't masquerade as the recreated one.
+                let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), &ns);
+                let target_pvc = format!("{inst_name}-filestore-pvc");
+                match pvcs.get(target_pvc.as_str()).await {
+                    Ok(pvc)
+                        if pvc.metadata.deletion_timestamp.is_none()
+                            && pvc.status.as_ref().and_then(|s| s.phase.as_deref())
+                                == Some("Bound") =>
+                    {
+                        Some(Phase::Completed)
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(p) = terminal {
+                patch_refresh_status(
+                    &ctx.client,
+                    &ns,
+                    &refresh.name_any(),
+                    &json!({"status": {"filestorePhase": p}}),
+                )
+                .await?;
+            }
         }
 
         // ── Step 3: neutralize (after DB + filestore succeed) ─────────
@@ -230,18 +363,13 @@ impl State for CloningFromSource {
         )
         .await;
         let fs_done = refresh.spec.skip_filestore
-            || sub_job_succeeded(
-                &jobs_api,
+            || matches!(
                 refresh
                     .status
                     .as_ref()
-                    .and_then(|s| s.filestore_job_name.as_deref()),
-                refresh
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.filestore_job_phase.as_ref()),
-            )
-            .await;
+                    .and_then(|s| s.filestore_phase.as_ref()),
+                Some(Phase::Completed)
+            );
         if db_done
             && fs_done
             && refresh
@@ -413,6 +541,7 @@ fn build_filestore_clone_job(
         }),
         ..Default::default()
     };
+
     let src_mount = VolumeMount {
         name: "source-filestore".into(),
         mount_path: "/src".into(),
@@ -480,4 +609,16 @@ fn build_neutralize_job(
             ..Default::default()
         }])
         .build()
+}
+
+fn can_refresh_with_snapshot(source_instance: &OdooInstance, dest_instance: &OdooInstance) -> bool {
+    sc(source_instance).is_some() && sc(source_instance) == sc(dest_instance)
+}
+
+fn sc(instance: &OdooInstance) -> Option<&str> {
+    instance
+        .spec
+        .filestore
+        .as_ref()
+        .and_then(|s| s.storage_class.as_deref())
 }

--- a/src/crd/odoo_staging_refresh_job.rs
+++ b/src/crd/odoo_staging_refresh_job.rs
@@ -124,6 +124,15 @@ pub struct OdooStagingRefreshJobStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filestore_job_phase: Option<Phase>,
 
+    /// Mode-agnostic phase for the filestore step.  Set to `Running` once
+    /// either the rsync Job has been created or the snapshot/clone PVC
+    /// recreate has been kicked off; transitions to `Completed`/`Failed`
+    /// when the underlying Job terminates (Copy path) or the new PVC binds
+    /// (Snapshot path).  Used as the start guard and completion gate for
+    /// the filestore step regardless of `filestoreMethod`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filestore_phase: Option<Phase>,
+
     /// batch/v1 Job name for the neutralize step.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub neutralize_job_name: Option<String>,

--- a/tests/integration/staging_refresh.rs
+++ b/tests/integration/staging_refresh.rs
@@ -1,4 +1,5 @@
 use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use serde_json::json;
 use std::time::{Duration, Instant};
@@ -92,6 +93,7 @@ async fn staging_refresh_happy_path() -> anyhow::Result<()> {
         "spec": {
             "odooInstanceRef": { "name": "target-inst" },
             "source": { "instanceName": "source-inst" },
+            "filestoreMethod": "copy",
         }
     }))
     .unwrap();
@@ -120,7 +122,13 @@ async fn staging_refresh_happy_path() -> anyhow::Result<()> {
         }
     };
     succeed(db_job).await;
+
+    // Copy path: filestore_phase should be Running before the Job succeeds
+    // (set when the Job was created), and walk to Completed once the Job's
+    // terminal phase is recorded and the settle block mirrors it forward.
+    wait_for_filestore_phase(c, ns, "target-refresh", Phase::Running).await;
     succeed(fs_job).await;
+    wait_for_filestore_phase(c, ns, "target-refresh", Phase::Completed).await;
 
     // Neutralize Job spawns after both succeed.
     let neut_job = wait_for_refresh_sub_job(c, ns, "target-refresh", "neutralizeJobName").await;
@@ -184,6 +192,7 @@ async fn staging_refresh_db_failure_goes_to_init_failed() -> anyhow::Result<()> 
         "spec": {
             "odooInstanceRef": { "name": "tgt-fail" },
             "source": { "instanceName": "src-fail" },
+            "filestoreMethod": "copy",
         }
     }))
     .unwrap();
@@ -273,6 +282,7 @@ async fn staging_refresh_survives_subjob_gc() -> anyhow::Result<()> {
         "spec": {
             "odooInstanceRef": { "name": "tgt-gc" },
             "source": { "instanceName": "src-gc" },
+            "filestoreMethod": "copy",
         }
     }))
     .unwrap();
@@ -340,6 +350,377 @@ async fn staging_refresh_survives_subjob_gc() -> anyhow::Result<()> {
         wait_for_phase(c, ns, "tgt-gc", OdooInstancePhase::Starting).await,
         "expected Starting after refresh succeeded despite DB Job being GC'd"
     );
+
+    source_ready.abort();
+    Ok(())
+}
+
+/// Wait until `status.filestorePhase` on the refresh CR matches `expected`.
+async fn wait_for_filestore_phase(
+    client: &kube::Client,
+    ns: &str,
+    crd_name: &str,
+    expected: Phase,
+) {
+    let api: Api<OdooStagingRefreshJob> = Api::namespaced(client.clone(), ns);
+    let start = Instant::now();
+    loop {
+        if let Ok(obj) = api.get(crd_name).await {
+            if obj.status.as_ref().and_then(|s| s.filestore_phase.as_ref()) == Some(&expected) {
+                return;
+            }
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "refresh CR {crd_name} never reached filestorePhase={expected:?}"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+}
+
+/// Patch a PVC's status to `Bound` so the operator's snapshot-path settle
+/// block can observe it.  envtest has no PV controller, so PVCs never bind
+/// on their own.  Also strips the `kubernetes.io/pvc-protection` finalizer
+/// — envtest's API server adds it automatically but has no pvc-protection-
+/// controller to strip it after pods detach, so a test PVC would otherwise
+/// linger forever in `Terminating` after `delete()`.
+async fn fake_pvc_bound(client: &kube::Client, ns: &str, name: &str) {
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
+    let start = Instant::now();
+    loop {
+        if pvcs.get_opt(name).await.ok().flatten().is_some() {
+            break;
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "PVC {name} never appeared so it could be marked Bound"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+    let mut current = pvcs.get(name).await.expect("get PVC");
+    if current.metadata.finalizers.is_some() {
+        current.metadata.finalizers = Some(vec![]);
+        pvcs.replace(name, &PostParams::default(), &current)
+            .await
+            .expect("strip pvc-protection finalizer");
+    }
+    let patch = json!({ "status": { "phase": "Bound" } });
+    pvcs.patch_status(name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("patch PVC status");
+}
+
+/// Snapshot path: when source and target share a StorageClass and
+/// `filestoreMethod: snapshot` is requested, the operator must NOT spawn a
+/// filestore Job.  Instead, it deletes the staging PVC, recreates it (which
+/// would clone from the source PVC in a real cluster), and waits for the
+/// new PVC to bind.  The settle block then patches `filestore_phase: Completed`
+/// — which is the gate that lets neutralize spawn.  Regression for the
+/// "fs_done never trips" stall in the snapshot path.
+#[tokio::test]
+async fn staging_refresh_snapshot_path_completes_via_pvc_bound() -> anyhow::Result<()> {
+    let ctx = TestContext::new("src-snap").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let source_ready = fast_track_to_running(&ctx, "src-snap-init").await;
+
+    let target: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": "tgt-snap", "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["tgt-snap.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "standard" },
+            "init": { "enabled": false },
+        }
+    }))
+    .unwrap();
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances.create(&PostParams::default(), &target).await?;
+    assert!(
+        wait_for_phase(c, ns, "tgt-snap", OdooInstancePhase::Uninitialized).await,
+        "expected Uninitialized"
+    );
+    // Strip pvc-protection on the existing staging PVC so the operator's
+    // snapshot-path delete can actually complete in envtest.
+    fake_pvc_bound(c, ns, "tgt-snap-filestore-pvc").await;
+
+    let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(c.clone(), ns);
+    let refresh: OdooStagingRefreshJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooStagingRefreshJob",
+        "metadata": { "name": "tgt-snap-refresh", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "tgt-snap" },
+            "source": { "instanceName": "src-snap" },
+            "filestoreMethod": "snapshot",
+        }
+    }))
+    .unwrap();
+    refreshes.create(&PostParams::default(), &refresh).await?;
+
+    assert!(
+        wait_for_phase(c, ns, "tgt-snap", OdooInstancePhase::CloningFromSource).await,
+        "expected CloningFromSource"
+    );
+
+    // DB Job runs as usual on the snapshot path.
+    let db_job = wait_for_refresh_sub_job(c, ns, "tgt-snap-refresh", "dbJobName").await;
+    let jobs: Api<Job> = Api::namespaced(c.clone(), ns);
+    jobs.patch_status(
+        &db_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    // filestorePhase should reach Running once the snapshot kickoff patches
+    // status (PVC delete + ensure_filestore_pvc complete).
+    wait_for_filestore_phase(c, ns, "tgt-snap-refresh", Phase::Running).await;
+
+    // No filestore Job exists on the snapshot path.
+    let after = refreshes.get("tgt-snap-refresh").await?;
+    assert!(
+        after
+            .status
+            .as_ref()
+            .and_then(|s| s.filestore_job_name.as_deref())
+            .is_none(),
+        "snapshot path must not create a filestore Job"
+    );
+
+    // Fake the recreated staging PVC into Bound; the settle block on the
+    // next reconcile flips filestorePhase to Completed.
+    fake_pvc_bound(c, ns, "tgt-snap-filestore-pvc").await;
+    wait_for_filestore_phase(c, ns, "tgt-snap-refresh", Phase::Completed).await;
+
+    // Neutralize spawns once both DB and filestore are Completed.
+    let neut_job = wait_for_refresh_sub_job(c, ns, "tgt-snap-refresh", "neutralizeJobName").await;
+    jobs.patch_status(
+        &neut_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    assert!(
+        wait_for_phase(c, ns, "tgt-snap", OdooInstancePhase::Starting).await,
+        "expected Starting after snapshot-path refresh succeeded"
+    );
+
+    source_ready.abort();
+    Ok(())
+}
+
+// Note: snapshot-path delete idempotency (operator's `delete()` returning 404
+// when the PVC is already gone) is exercised across multiple reconcile ticks
+// of `staging_refresh_snapshot_path_completes_via_pvc_bound` — the operator
+// re-enters the snapshot branch on every tick until `filestore_phase` is
+// Running, so the second tick already hits the 404 path with no error.
+// A standalone test was attempted but is fundamentally racy with the
+// operator's own ensure_filestore_pvc reconcile recreating the PVC under
+// the test's feet; not worth the flakiness for one swallowed error.
+
+/// Auto mode falls back to Copy when source and target StorageClasses
+/// differ — CSI volume cloning requires both PVCs to use the same SC, so
+/// snapshot is not viable.  Verifies the fallback creates a filestore Job
+/// (Copy path) instead of going through the snapshot branch.
+#[tokio::test]
+async fn staging_refresh_auto_falls_back_to_copy_on_sc_mismatch() -> anyhow::Result<()> {
+    // Use the standard test source (storageClass=standard) so
+    // fast_track_to_running works as in the other tests.
+    let ctx = TestContext::new("src-mix").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let source_ready = fast_track_to_running(&ctx, "src-mix-init").await;
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+
+    // Target with a different storageClass.
+    let target: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": "tgt-mix", "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["tgt-mix.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "fast-ssd" },
+            "init": { "enabled": false },
+        }
+    }))
+    .unwrap();
+    instances.create(&PostParams::default(), &target).await?;
+
+    let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(c.clone(), ns);
+    let refresh: OdooStagingRefreshJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooStagingRefreshJob",
+        "metadata": { "name": "tgt-mix-refresh", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "tgt-mix" },
+            "source": { "instanceName": "src-mix" },
+            // omit filestoreMethod → Auto (default)
+        }
+    }))
+    .unwrap();
+    refreshes.create(&PostParams::default(), &refresh).await?;
+
+    assert!(
+        wait_for_phase(c, ns, "tgt-mix", OdooInstancePhase::CloningFromSource).await,
+        "expected CloningFromSource"
+    );
+
+    // Auto + SC mismatch ⇒ Copy path ⇒ filestoreJobName is set.
+    let _fs_job = wait_for_refresh_sub_job(c, ns, "tgt-mix-refresh", "filestoreJobName").await;
+    wait_for_filestore_phase(c, ns, "tgt-mix-refresh", Phase::Running).await;
+
+    let _ = ListParams::default();
+    source_ready.abort();
+    Ok(())
+}
+
+/// Race regression: on a real cluster, foreground-deleting a PVC returns
+/// before the object actually disappears — pvc-protection and CSI
+/// finalizers keep it `Bound` with a `deletionTimestamp` until kubelet
+/// finishes unmounting consumer pods.  If the snapshot kickoff patches
+/// `filestorePhase: Running` while the OLD PVC still lingers `Bound`, the
+/// settle block on the next reconcile will see `phase: Bound`, prematurely
+/// flip `filestorePhase: Completed`, and let neutralize race against a
+/// PVC that's about to vanish.  Reproduced here by adding a custom
+/// finalizer to the staging PVC so it sticks around `Bound` after delete.
+#[tokio::test]
+async fn staging_refresh_snapshot_does_not_complete_while_old_pvc_terminates() -> anyhow::Result<()>
+{
+    let ctx = TestContext::new("src-snap3").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let source_ready = fast_track_to_running(&ctx, "src-snap3-init").await;
+
+    let target: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": "tgt-snap3", "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["tgt-snap3.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": { "storageSize": "1Gi", "storageClass": "standard" },
+            "init": { "enabled": false },
+        }
+    }))
+    .unwrap();
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances.create(&PostParams::default(), &target).await?;
+    assert!(
+        wait_for_phase(c, ns, "tgt-snap3", OdooInstancePhase::Uninitialized).await,
+        "expected Uninitialized"
+    );
+
+    // Wait for the operator to provision the staging PVC, then fake it
+    // Bound and pin a custom finalizer so a subsequent delete() leaves
+    // it lingering with deletionTimestamp set — the exact production
+    // condition we're guarding against.
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(c.clone(), ns);
+    let pvc_name = "tgt-snap3-filestore-pvc";
+    let start = Instant::now();
+    while pvcs.get_opt(pvc_name).await?.is_none() {
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "staging PVC {pvc_name} never appeared"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+    fake_pvc_bound(c, ns, pvc_name).await;
+    let finalizer_patch = json!({
+        "metadata": { "finalizers": ["odoo-operator-test/hold"] }
+    });
+    pvcs.patch(
+        pvc_name,
+        &PatchParams::default(),
+        &Patch::Merge(&finalizer_patch),
+    )
+    .await?;
+
+    let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(c.clone(), ns);
+    let refresh: OdooStagingRefreshJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooStagingRefreshJob",
+        "metadata": { "name": "tgt-snap3-refresh", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "tgt-snap3" },
+            "source": { "instanceName": "src-snap3" },
+            "filestoreMethod": "snapshot",
+        }
+    }))
+    .unwrap();
+    refreshes.create(&PostParams::default(), &refresh).await?;
+    assert!(
+        wait_for_phase(c, ns, "tgt-snap3", OdooInstancePhase::CloningFromSource).await,
+        "expected CloningFromSource"
+    );
+
+    // Succeed the DB Job so the refresh's only outstanding work is the
+    // filestore step — keeps the assertion focused.
+    let db_job = wait_for_refresh_sub_job(c, ns, "tgt-snap3-refresh", "dbJobName").await;
+    let jobs: Api<Job> = Api::namespaced(c.clone(), ns);
+    jobs.patch_status(
+        &db_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
+
+    // Critical assertion: while the old PVC has deletionTimestamp set
+    // and is still phase=Bound, filestorePhase MUST NOT reach Completed.
+    // Poll for several reconcile cycles to give the operator chances to
+    // misbehave.
+    let race_window = Duration::from_secs(5);
+    let race_start = Instant::now();
+    while race_start.elapsed() < race_window {
+        let r = refreshes.get("tgt-snap3-refresh").await?;
+        let fs_phase = r
+            .status
+            .as_ref()
+            .and_then(|s| s.filestore_phase.as_ref())
+            .cloned();
+        assert_ne!(
+            fs_phase,
+            Some(Phase::Completed),
+            "filestorePhase flipped to Completed while old PVC was still terminating \
+             (deletionTimestamp set, phase=Bound) — premature completion race"
+        );
+        // The PVC must still be present with a deletionTimestamp — proves
+        // the test setup is exercising the race window we care about.
+        let live = pvcs.get(pvc_name).await?;
+        assert!(
+            live.metadata.deletion_timestamp.is_some()
+                || live.status.as_ref().and_then(|s| s.phase.as_deref()) != Some("Bound"),
+            "test invariant: PVC should still be Bound+terminating during the race window"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+
+    // Recovery (PVC actually disappears, fresh one binds, filestorePhase
+    // → Completed) is covered by `staging_refresh_snapshot_path_completes_
+    // via_pvc_bound`.  envtest's finalizer-driven deletion path is flaky
+    // enough that simulating it here brings little extra coverage.
 
     source_ready.abort();
     Ok(())


### PR DESCRIPTION
## Summary
- Adds CSI volume-clone fast path for staging refresh and init: when source and target PVCs share a StorageClass, the staging PVC is provisioned with `dataSourceRef` pointing at the production PVC instead of running a multi-minute rsync Job.
- Selectable via `OdooStagingRefreshJob.spec.filestoreMethod`: `auto` (default; snapshot when SCs match, copy otherwise), `snapshot` (force), `copy` (force rsync Job).
- New mode-agnostic `status.filestorePhase` gates the orchestration; the rollup in `state_machine.rs` short-circuits to it while still observing the underlying Job on the Copy path for GC durability.

## Snapshot-path safety
- `delete()` uses background propagation (foreground was wrong for an object with no OwnerReference dependents and added a finalizer no controller would strip).
- 404 on delete is swallowed so retries are idempotent.
- Kickoff verifies the PVC is actually gone before recreating — if it lingers with `deletionTimestamp` (pvc-protection waiting on kubelet unmount), bail and let the next reconcile retry.
- Settle block requires `deletionTimestamp.is_none()` before flipping `Completed`, defense-in-depth against a stale Bound PVC masquerading as the new one.

## Tests
- New integration tests in `tests/integration/staging_refresh.rs`: snapshot happy path, snapshot does-not-complete-while-old-pvc-terminates race regression (TDD'd), Auto-mode SC-mismatch fallback to Copy.
- Existing tests pinned to `filestoreMethod: copy` (default `Auto` now picks Snapshot when SCs match).
- `fake_pvc_bound` strips `kubernetes.io/pvc-protection` since envtest has no controller to do so.
- Single-threaded full integration run: 41 passed.