### PR TITLE
fix(snapshot): skip filestore PVC reconcile during CloningFromSource

### DIFF
--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -329,11 +329,20 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
                 | &OdooInstancePhase::FinalizingFilestoreMigration
         )
     );
+    // CloningFromSource owns the filestore PVC lifecycle (delete + recreate
+    // with dataSourceRef pointing at the production snapshot/clone). The
+    // always-on path must not touch the PVC during that window — otherwise
+    // it races with the state handler and orphans in-flight CephFS clones,
+    // saturating mds_max_concurrent_clones.
+    let is_cloning_filestore = matches!(
+        current_phase_ref,
+        Some(&OdooInstancePhase::CloningFromSource)
+    );
     // Database migration doesn't need to skip child resource creation —
     // the state's ensure() handles scaling deployments to 0, and
     // ensure_deployment/ensure_config_map preserve current replicas and
     // update connection details (which is desirable for the switchover).
-    if !is_migrating_filestore {
+    if !is_migrating_filestore && !is_cloning_filestore {
         child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
     }
     child_resources::ensure_config_map(client, &ns, &name, instance, &pg_cluster, &oref).await?;


### PR DESCRIPTION
## Summary
- Add `CloningFromSource` to the phase exclusion that skips `ensure_filestore_pvc()` in the always-on reconcile path, alongside the existing `MigratingFilestore` / `FinalizingFilestoreMigration` guard.

## Why
The always-on path called `ensure_filestore_pvc()` on every reconcile tick, including while the `CloningFromSource` state handler was actively managing the same PVC (delete + recreate with `dataSourceRef` pointing at the production snapshot/clone). The two paths raced:

1. State handler recreates the PVC with `dataSourceRef`.
2. Next normal reconcile tick (~250 ms later) attempts to apply a spec without it (or with a different value).
3. `dataSourceRef` is immutable, so the divergence triggers a replace.
4. State handler re-enters its delete + recreate, and the cycle repeats.

Each iteration orphans an in-flight CephFS clone on the source snapshot. Observed in production today on `durpro-staging`: 4 orphan clones accumulated within ~6 seconds, saturating CephFS `mds_max_concurrent_clones=4` and starving the actual PVC's clone request indefinitely.

Same shape as the existing `MigratingFilestore` guard: PVC lifecycle during a clone refresh is owned by the state handler; the always-on path stays out.

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt` / `cargo clippy` pass (pre-commit)
- [ ] Deploy to cluster, trigger a staging refresh from production, confirm:
  - exactly one CephFS clone is created per refresh
  - PVC binds without `mds_max_concurrent_clones` saturation
  - no rapid-fire delete/recreate in operator logs
- [ ] Follow-up: integration test that drives a `CloningFromSource` cycle and asserts `ensure_filestore_pvc` is not called from the always-on path during that phase.