### PR TITLE
fix(refresh): retry neutralize on image change; bump backoffLimit

### DIFF
--- a/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
@@ -180,6 +180,10 @@ spec:
               message:
                 nullable: true
                 type: string
+              neutralizeJobImageHash:
+                description: SHA-256 hex prefix of the OdooInstance image that the neutralize Job was created with.  When the neutralize step has terminally failed and the user corrects the image, the operator detects the hash mismatch, deletes the failed Job, clears the neutralize_* status fields, and recreates the Job with the corrected image.
+                nullable: true
+                type: string
               neutralizeJobName:
                 description: batch/v1 Job name for the neutralize step.
                 nullable: true

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -213,6 +213,7 @@ pub struct OdooJobBuilder {
     containers: Vec<Container>,
     init_containers: Option<Vec<Container>>,
     active_deadline: Option<i64>,
+    backoff_limit: Option<i32>,
     affinity: Option<Affinity>,
     labels: std::collections::BTreeMap<String, String>,
 }
@@ -240,6 +241,7 @@ impl OdooJobBuilder {
             containers: vec![],
             init_containers: None,
             active_deadline: None,
+            backoff_limit: None,
             affinity: None,
             labels: instance_labels(instance),
         }
@@ -281,6 +283,17 @@ impl OdooJobBuilder {
         self
     }
 
+    /// Set `spec.backoffLimit` on the Job.  Default (when unset) is 0 —
+    /// any pod failure terminates the Job.  Override to allow K8s' built-in
+    /// exponential backoff retries for transient failures (network blips,
+    /// DB connect, etc.).  Note: ImagePullBackOff is bounded by
+    /// `activeDeadlineSeconds`, not `backoffLimit`, because the Pod never
+    /// transitions to a terminal exit-code state under that condition.
+    pub fn backoff_limit(mut self, n: i32) -> Self {
+        self.backoff_limit = Some(n);
+        self
+    }
+
     /// Set pod affinity (e.g. co-locate with the instance deployment).
     pub fn affinity(mut self, affinity: Affinity) -> Self {
         self.affinity = Some(affinity);
@@ -302,7 +315,7 @@ impl OdooJobBuilder {
                 ..Default::default()
             },
             spec: Some(JobSpec {
-                backoff_limit: Some(0),
+                backoff_limit: Some(self.backoff_limit.unwrap_or(0)),
                 ttl_seconds_after_finished: Some(900),
                 active_deadline_seconds: self.active_deadline,
                 template: PodTemplateSpec {

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -24,10 +24,25 @@ use crate::controller::helpers::{
     staging_mail_env_vars, OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
+use crate::helpers::sha256_hex;
 
 const CLONE_DB_SCRIPT: &str = include_str!("../../../scripts/clone-db.sh");
 const CLONE_FILESTORE_SCRIPT: &str = include_str!("../../../scripts/clone-filestore.sh");
 const NEUTRALIZE_SCRIPT: &str = include_str!("../../../scripts/neutralize.sh");
+
+/// Number of hex characters of the image's sha256 we persist in the refresh
+/// CR's `neutralizeJobImageHash` to detect spec drift on retry.  16 chars
+/// (64 bits) is overkill for accidental-collision resistance but keeps the
+/// field readable in `kubectl get -o yaml`.
+const IMAGE_HASH_LEN: usize = 16;
+
+/// Compute the short hash recorded in `neutralizeJobImageHash`.  The
+/// neutralize retry path treats a mismatch between this and the live image
+/// as a signal to recreate the failed Job with the corrected spec.
+pub(crate) fn neutralize_image_hash(image: &str) -> String {
+    let full = sha256_hex(image);
+    full[..IMAGE_HASH_LEN.min(full.len())].to_string()
+}
 
 /// CloningFromSource: orchestrates the three-Job refresh pipeline.
 ///
@@ -403,6 +418,7 @@ impl State for CloningFromSource {
                 &json!({
                     "status": {
                         "neutralizeJobName": &k8s_job_name,
+                        "neutralizeJobImageHash": neutralize_image_hash(image),
                     }
                 }),
             )
@@ -596,6 +612,12 @@ fn build_neutralize_job(
     envs.extend(staging_mail_env_vars(instance, defaults));
     OdooJobBuilder::new(&format!("{crd_name}-neut-"), ns, refresh, instance)
         .active_deadline(1800)
+        // Allow K8s' built-in exponential backoff to absorb transient pod
+        // failures (script crashes, OOM, network blips during DB connect).
+        // ImagePullBackOff is *not* covered by backoffLimit (the Pod never
+        // exits) — that's the spec-drift retry path's responsibility, gated
+        // on `neutralizeJobImageHash`.
+        .backoff_limit(5)
         .containers(vec![Container {
             name: "neutralize".into(),
             image: Some(image.into()),
@@ -609,6 +631,121 @@ fn build_neutralize_job(
             ..Default::default()
         }])
         .build()
+}
+
+/// Spec-drift retry for the neutralize step.
+///
+/// When an OdooInstance is stuck in `InitFailed` because the staging refresh's
+/// neutralize Job hit a terminal failure (typically `ImagePullBackOff` →
+/// `DeadlineExceeded`), and the user has since corrected `spec.image`, this
+/// detects the drift via the `neutralizeJobImageHash` recorded on the
+/// failed refresh CR and resets it so the operator's normal recovery path
+/// (`InitFailed → CloningFromSource`) can re-create the neutralize Job with
+/// the corrected spec on the next reconcile tick.
+///
+/// Scope is intentionally narrow: only the neutralize sub-Job, only on a
+/// hash mismatch.  DB and filestore failures rely on `backoffLimit` for
+/// transient issues and require explicit user action otherwise.  This keeps
+/// the retry loop bounded — repeated reconciles with the same broken image
+/// don't churn (hash matches → nothing to do), only a real spec edit does.
+///
+/// Returns `true` if a reset was performed (caller may want to log).
+pub(crate) async fn maybe_retry_failed_neutralize(
+    instance: &OdooInstance,
+    ctx: &Context,
+) -> Result<bool> {
+    let ns = instance.namespace().unwrap_or_default();
+    let instance_name = instance.name_any();
+    let image = instance.spec.image.as_deref().unwrap_or("odoo:18.0");
+    let current_hash = neutralize_image_hash(image);
+
+    let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(ctx.client.clone(), &ns);
+    let list = refreshes.list(&kube::api::ListParams::default()).await?;
+
+    // The most recently-created Failed refresh job for this instance is the
+    // one that drove us into InitFailed.  Older Failed CRs are historical
+    // artefacts the user hasn't cleaned up; ignore them.
+    let candidate = list
+        .items
+        .into_iter()
+        .filter(|j| j.spec.odoo_instance_ref.name == instance_name)
+        .filter(|j| {
+            matches!(
+                j.status.as_ref().and_then(|s| s.phase.as_ref()),
+                Some(Phase::Failed)
+            )
+        })
+        .filter(|j| {
+            matches!(
+                j.status
+                    .as_ref()
+                    .and_then(|s| s.neutralize_job_phase.as_ref()),
+                Some(Phase::Failed)
+            )
+        })
+        .max_by(|a, b| a.creation_timestamp().cmp(&b.creation_timestamp()));
+
+    let Some(refresh) = candidate else {
+        return Ok(false);
+    };
+
+    let recorded_hash = refresh
+        .status
+        .as_ref()
+        .and_then(|s| s.neutralize_job_image_hash.as_deref());
+
+    if recorded_hash == Some(current_hash.as_str()) {
+        // Same image as the failed attempt — nothing changed, don't churn.
+        return Ok(false);
+    }
+
+    let crd_name = refresh.name_any();
+    let job_name = refresh
+        .status
+        .as_ref()
+        .and_then(|s| s.neutralize_job_name.as_deref());
+
+    // Best-effort cleanup of the underlying batch/v1 Job.  It's normally
+    // already gone (TTL or DeadlineExceeded), so 404 is the expected case.
+    if let Some(name) = job_name {
+        let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
+        match jobs_api.delete(name, &DeleteParams::background()).await {
+            Ok(_) => {}
+            Err(kube::Error::Api(ErrorResponse { code: 404, .. })) => {}
+            Err(e) => return Err(Error::Kube(e)),
+        }
+    }
+
+    // Clear the neutralize fields and reset the aggregate phase from
+    // Failed back to Running.  The snapshot rollup will then re-classify
+    // refresh_job as Active, the InitFailed → CloningFromSource transition
+    // fires, and the regular ensure() path creates a fresh neutralize Job
+    // from current spec.  The DB and filestore steps stay completed —
+    // we don't redo them.
+    patch_refresh_status(
+        &ctx.client,
+        &ns,
+        &crd_name,
+        &json!({
+            "status": {
+                "phase": Phase::Running,
+                "neutralizeJobName": Option::<String>::None,
+                "neutralizeJobPhase": Option::<Phase>::None,
+                "neutralizeJobImageHash": Option::<String>::None,
+                "message": "neutralize image changed; retrying with corrected spec",
+            }
+        }),
+    )
+    .await?;
+
+    info!(
+        crd_name = %crd_name,
+        new_image = %image,
+        new_hash = %current_hash,
+        old_hash = ?recorded_hash,
+        "neutralize spec-drift detected; cleared status to retry"
+    );
+    Ok(true)
 }
 
 fn can_refresh_with_snapshot(source_instance: &OdooInstance, dest_instance: &OdooInstance) -> bool {

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -117,7 +117,11 @@ impl State for CloningFromSource {
         let target_db = crate::helpers::db_name(instance);
         let source_conf = format!("{source_name}-odoo-conf");
         let target_conf = format!("{inst_name}-odoo-conf");
-        let image = instance.spec.image.as_deref().unwrap_or("odoo:18.0");
+        let image = instance
+            .spec
+            .image
+            .as_deref()
+            .unwrap_or(&ctx.defaults.odoo_image);
 
         // ── Step 2a: DB clone Job ─────────────────────────────────────
         if refresh
@@ -656,25 +660,31 @@ pub(crate) async fn maybe_retry_failed_neutralize(
 ) -> Result<bool> {
     let ns = instance.namespace().unwrap_or_default();
     let instance_name = instance.name_any();
-    let image = instance.spec.image.as_deref().unwrap_or("odoo:18.0");
+    let image = instance
+        .spec
+        .image
+        .as_deref()
+        .unwrap_or(&ctx.defaults.odoo_image);
     let current_hash = neutralize_image_hash(image);
 
     let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(ctx.client.clone(), &ns);
     let list = refreshes.list(&kube::api::ListParams::default()).await?;
 
-    // The most recently-created Failed refresh job for this instance is the
-    // one that drove us into InitFailed.  Older Failed CRs are historical
-    // artefacts the user hasn't cleaned up; ignore them.
+    // We only retry refresh jobs whose *neutralize* sub-step terminally
+    // failed — that's the only failure mode where (a) the DB and filestore
+    // work that preceded it is still good (so a retry doesn't redo the
+    // expensive clone) and (b) a spec.image edit is the realistic
+    // user-facing fix.  The aggregate `phase == Failed` is implied by the
+    // rollup whenever any sub-job is Failed, so we don't need to gate on
+    // it separately.
+    //
+    // Picking the most-recently-created candidate covers the case where
+    // the user has historical Failed refresh CRs lying around from
+    // previous attempts.
     let candidate = list
         .items
         .into_iter()
         .filter(|j| j.spec.odoo_instance_ref.name == instance_name)
-        .filter(|j| {
-            matches!(
-                j.status.as_ref().and_then(|s| s.phase.as_ref()),
-                Some(Phase::Failed)
-            )
-        })
         .filter(|j| {
             matches!(
                 j.status

--- a/src/controller/states/init_failed.rs
+++ b/src/controller/states/init_failed.rs
@@ -4,6 +4,7 @@ use kube::api::ResourceExt;
 use crate::crd::odoo_instance::OdooInstance;
 use crate::error::Result;
 
+use super::cloning_from_source::maybe_retry_failed_neutralize;
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::cron_depl_name;
 use crate::controller::state_machine::scale_deployment;
@@ -22,6 +23,13 @@ impl State for InitFailed {
         let ns = instance.namespace().unwrap_or_default();
         let name = instance.name_any();
         scale_deployment(&ctx.client, &name, &ns, 0).await?;
-        scale_deployment(&ctx.client, cron_depl_name(instance).as_str(), &ns, 0).await
+        scale_deployment(&ctx.client, cron_depl_name(instance).as_str(), &ns, 0).await?;
+        // Spec-drift retry: if the user corrected the OdooInstance image
+        // after a neutralize failure, clear the failed refresh CR's
+        // neutralize status so the InitFailed → CloningFromSource recovery
+        // transition fires on the next snapshot pass.  Idempotent: a no-op
+        // when the recorded hash already matches the live image.
+        let _ = maybe_retry_failed_neutralize(instance, ctx).await?;
+        Ok(())
     }
 }

--- a/src/crd/odoo_staging_refresh_job.rs
+++ b/src/crd/odoo_staging_refresh_job.rs
@@ -141,6 +141,14 @@ pub struct OdooStagingRefreshJobStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub neutralize_job_phase: Option<Phase>,
 
+    /// SHA-256 hex prefix of the OdooInstance image that the neutralize
+    /// Job was created with.  When the neutralize step has terminally
+    /// failed and the user corrects the image, the operator detects the
+    /// hash mismatch, deletes the failed Job, clears the neutralize_*
+    /// status fields, and recreates the Job with the corrected image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub neutralize_job_image_hash: Option<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
 


### PR DESCRIPTION
## Summary

Two complementary safety nets for `OdooStagingRefreshJob`'s neutralize step.

### What broke today

A `durpro-staging` instance was provisioned with a typo'd `spec.image`. The neutralize Job sat in `ImagePullBackOff` until `activeDeadlineSeconds` expired → batch/v1 Job failed → refresh CR `phase=Failed` → OdooInstance `InitFailed`. The user corrected `spec.image`, but the operator had no recovery path: the existing `InitFailed → CloningFromSource` transition guards on \"refresh_job is non-Absent\", but the snapshot rollup explicitly skips Failed refresh jobs (state_machine.rs:271-273), so `refresh_job=Absent` and the transition never fires.

### Fix 1 — backoffLimit: 5 on the neutralize Job

Lets K8s self-heal transient failures (script crashes, OOM, DB connect blips) using its built-in exponential backoff. **Does not cover ImagePullBackOff** (the Pod never exits) — that's Fix 2.

Plumbed via a new `OdooJobBuilder::backoff_limit()` setter; default stays at 0 so DB clone, filestore copy, init, restore, upgrade, and backup Jobs are unchanged.

### Fix 2 — spec-drift retry for neutralize

- New status field `OdooStagingRefreshJob.status.neutralizeJobImageHash` records a SHA-256 prefix of the image the neutralize Job was created with.
- On every `InitFailed` reconcile tick, the operator scans for the most recent Failed refresh job for this instance and compares its recorded hash against `sha256(spec.image)`.
- Mismatch (user fixed the spec) → delete the (likely already TTL-expired) Job, clear `neutralizeJobName` / `neutralizeJobPhase` / `neutralizeJobImageHash`, reset aggregate phase from `Failed` → `Running`.
- Next snapshot pass classifies `refresh_job` as Active, `InitFailed → CloningFromSource` transition fires, `CloningFromSource::ensure()` recreates the neutralize Job with the corrected image.
- **DB and filestore steps are not redone.** This recovers neutralize without losing the 2-hour CephFS clone we just paid for.

Idempotent: when the recorded hash matches the live image, the helper is a no-op — no churn from the `InitFailed` loop. Only a real spec edit triggers the reset.

### Scope

Intentionally narrow: only the neutralize sub-Job, only on image-hash mismatch. DB and filestore failures rely on `backoffLimit` for transient issues and require manual intervention otherwise. Same pattern can be extended to those substeps in a follow-up if it proves necessary.

## Test plan

- [x] `cargo build`, `cargo fmt`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (98 tests pass; one envtest flake on shared state, passes in isolation)
- [ ] Apply to staging cluster, reproduce typo scenario, fix typo, confirm neutralize re-runs without redoing the clone

## Follow-ups (not in this PR)

- Apply same spec-drift retry pattern to DB clone and filestore copy substeps if it proves needed.
- Apply same pattern to OdooInitJob, OdooRestoreJob, OdooUpgradeJob, OdooBackupJob — they have the same failure mode for image typos.