### PR TITLE
fix: bump filestore-migration deadline to 2h, drop neutralize to 5m

### DIFF
--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -615,7 +615,14 @@ fn build_neutralize_job(
     ];
     envs.extend(staging_mail_env_vars(instance, defaults));
     OdooJobBuilder::new(&format!("{crd_name}-neut-"), ns, refresh, instance)
-        .active_deadline(1800)
+        // Neutralize is a small set of SQL UPDATEs (disable cron jobs,
+        // swap ir_mail_server, blank API keys / passwords).  Realistic
+        // wall time is seconds; 5 min is generous headroom for a slow
+        // DB.  The previous 30 min was masking image-pull failures as
+        // long-running jobs instead of failing fast — fixed in concert
+        // with the neutralize-image-hash retry path so an image typo
+        // surfaces in 5 min instead of 30.
+        .active_deadline(300)
         // Allow K8s' built-in exponential backoff to absorb transient pod
         // failures (script crashes, OOM, network blips during DB connect).
         // ImagePullBackOff is *not* covered by backoffLimit (the Pod never

--- a/src/controller/states/migrating_filestore.rs
+++ b/src/controller/states/migrating_filestore.rs
@@ -215,7 +215,12 @@ fn build_rsync_job(inst_name: &str, ns: &str, instance: &OdooInstance) -> Job {
         },
         spec: Some(JobSpec {
             backoff_limit: Some(3),
-            active_deadline_seconds: Some(3600),
+            // 2h cushion: storage-class migrations rsync the entire
+            // filestore between PVCs.  On consumer-SSD-backed CephFS
+            // we observe ~3 min/GiB for small-file Odoo workloads, so
+            // an originally-1h budget tipped over for prod-sized data.
+            // Match the staging-refresh filestore deadline.
+            active_deadline_seconds: Some(7200),
             ttl_seconds_after_finished: Some(300),
             template: PodTemplateSpec {
                 metadata: Some(ObjectMeta {


### PR DESCRIPTION
## Summary

Two unrelated deadline tweaks driven by recent ops experience.

### MigratingFilestore: 3600 → 7200 (1h → 2h)

The migration job rsyncs the entire filestore between PVCs. On consumer-SSD-backed CephFS we observe ~3 min/GiB for small-file Odoo workloads (today: 130 min for 29 GiB on a contended cluster, 68 min on a clean one). The 1h budget tipped over for prod-sized data. Align with the staging-refresh filestore-copy deadline (7200) so the same data set works through either codepath.

### Neutralize: 1800 → 300 (30 min → 5 min)

Neutralize runs `odoo-bin neutralize`, which is a small set of SQL UPDATEs. Realistic wall time is seconds; 5 min is generous headroom for a slow DB. The previous 30 min meant an image-pull typo (no Pod ever exits) sat in `ImagePullBackOff` for half an hour before flipping to `DeadlineExceeded` — masking the failure as a long-running job. In concert with the neutralize-image-hash spec-drift retry path (#108, just merged), the operator now both fails fast (5 min) and auto-recovers when the user fixes the spec.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Next staging refresh on a corrected-typo scenario completes within ~5 min of the fix being applied.