### PR TITLE
feat(refresh): use VolumeSnapshot intermediary for filestore clone

### DIFF
--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -263,6 +263,16 @@ pub async fn ensure_postgres_role(
     ctx.postgres.ensure_role(pg, &username, &password).await
 }
 
+/// Create the filestore PVC for an OdooInstance, expanding it in place if
+/// the spec requests a larger size than what's already provisioned.
+///
+/// `explicit_data_source` is an override used by the staging refresh's
+/// `CloningFromSource` state to inject a `VolumeSnapshot` reference (the
+/// universal path that works for both CephFS and JuiceFS CSI drivers).
+/// When `None`, the function falls back to the legacy auto-detection in
+/// `get_pvc_source` (PVC→PVC clone, only works on CephFS-class drivers).
+/// The always-on reconcile path always passes `None`; only the refresh
+/// state handler passes `Some`.
 pub async fn ensure_filestore_pvc(
     client: &Client,
     ns: &str,
@@ -270,6 +280,7 @@ pub async fn ensure_filestore_pvc(
     instance: &OdooInstance,
     ctx: &Context,
     oref: &OwnerReference,
+    explicit_data_source: Option<TypedObjectReference>,
 ) -> Result<()> {
     let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), ns);
     let pvc_name = format!("{name}-filestore-pvc");
@@ -332,8 +343,14 @@ pub async fn ensure_filestore_pvc(
         return Ok(());
     }
 
-    // No existing PVC, so we fully construct it, possibly with a snapshot source
-    let source = get_pvc_source(client, ns, instance).await;
+    // No existing PVC, so we fully construct it, possibly with a data source.
+    // Explicit caller-provided source wins (used by CloningFromSource's
+    // VolumeSnapshot path).  Otherwise fall back to the legacy
+    // PVC-to-PVC clone auto-detection.
+    let source = match explicit_data_source {
+        Some(s) => Some(s),
+        None => get_pvc_source(client, ns, instance).await,
+    };
     let pvc = PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(pvc_name),

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -343,7 +343,8 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
     // ensure_deployment/ensure_config_map preserve current replicas and
     // update connection details (which is desirable for the switchover).
     if !is_migrating_filestore && !is_cloning_filestore {
-        child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref).await?;
+        child_resources::ensure_filestore_pvc(client, &ns, &name, instance, ctx, &oref, None)
+            .await?;
     }
     child_resources::ensure_config_map(client, &ns, &name, instance, &pg_cluster, &oref).await?;
     child_resources::ensure_service(client, &ns, &name, &oref).await?;

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -892,6 +892,33 @@ pub async fn execute_action(
                     &Patch::Merge(&patch_val),
                 )
                 .await?;
+                // On success, drop the source VolumeSnapshot.  The dest
+                // PVC is fully cloned by this point — keeping the
+                // snapshot consumes metadata-engine state on JuiceFS and
+                // a reservation against the source PVC on CephFS, with
+                // no benefit (we never roll back via the *source*
+                // snapshot; that's what `rollback_snapshot` is for, a
+                // separate concern).  On failure we keep it for
+                // diagnostics.  Deletion is best-effort: 404s and CSI
+                // errors are logged but don't fail the action.
+                if matches!(action, CompleteRefreshJob) {
+                    if let Some(snap) = job
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.source_snapshot.as_deref())
+                    {
+                        if let Err(e) =
+                            crate::controller::states::delete_source_snapshot(ctx, &ns, snap).await
+                        {
+                            tracing::warn!(
+                                crd_name = %crd_name,
+                                snapshot = %snap,
+                                error = %e,
+                                "failed to delete source VolumeSnapshot post-refresh"
+                            );
+                        }
+                    }
+                }
                 if let Some(ref wh) = job.spec.webhook {
                     // All three sub-jobs share the same webhook payload
                     // shape as the other job CRDs.  We report whichever of

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -2,12 +2,16 @@ use async_trait::async_trait;
 use k8s_openapi::api::{
     batch::v1::Job,
     core::v1::{
-        Container, PersistentVolumeClaim, PersistentVolumeClaimVolumeSource, Volume, VolumeMount,
+        Container, PersistentVolumeClaim, PersistentVolumeClaimVolumeSource, TypedObjectReference,
+        Volume, VolumeMount,
     },
 };
 use kube::{
     api::{Api, DeleteParams, Patch, PatchParams, PostParams, ResourceExt},
     core::ErrorResponse,
+};
+use kube_custom_resources_rs::snapshot_storage_k8s_io::v1::volumesnapshots::{
+    VolumeSnapshot, VolumeSnapshotSource, VolumeSnapshotSpec,
 };
 use serde_json::json;
 use tracing::info;
@@ -42,6 +46,146 @@ const IMAGE_HASH_LEN: usize = 16;
 pub(crate) fn neutralize_image_hash(image: &str) -> String {
     let full = sha256_hex(image);
     full[..IMAGE_HASH_LEN.min(full.len())].to_string()
+}
+
+/// Outcome of `ensure_source_snapshot` — whether the dataSource is ready
+/// to be referenced by a new PVC.
+enum SourceSnapshotState {
+    /// Snapshot exists, `readyToUse: true` — safe to recreate the dest PVC
+    /// with `dataSourceRef → VolumeSnapshot/<name>`.
+    Ready { name: String },
+    /// Snapshot exists but `readyToUse` is `false` or `None` — caller should
+    /// requeue and check again next reconcile.  The CSI driver will mark
+    /// it ready when the underlying snapshot operation completes (instant
+    /// for CephFS / RBD, seconds-to-minutes for JuiceFS depending on
+    /// metadata engine + file count).
+    Pending { name: String },
+}
+
+/// Ensure a `VolumeSnapshot` of the source filestore PVC exists and report
+/// its readiness.
+///
+/// The snapshot is the **source of truth** for the staging refresh's
+/// filestore — it pins a point-in-time view of production at the moment
+/// the refresh started, so the new dest PVC can be cloned from it via
+/// `dataSourceRef → VolumeSnapshot`.  This is the universal path: CephFS
+/// CSI accepts both PVC-and snapshot dataSources for clones, but JuiceFS
+/// CSI accepts **only** VolumeSnapshot — so always going through a
+/// snapshot is the only way to support both backends with the same code
+/// path.
+///
+/// Snapshot naming is keyed on the refresh CR's name (one snapshot per
+/// refresh, persisted in `status.source_snapshot` for idempotency across
+/// reconciles).  The snapshot is owned by the refresh CR so K8s GC cleans
+/// it up if the refresh is deleted; on a successful refresh, the
+/// `CompleteRefreshJob` transition action deletes it explicitly.
+///
+/// `volumeSnapshotClassName` is left unset — the cluster's default
+/// snapshot class for the source PVC's CSI driver is used.  Each driver
+/// in the cluster should have exactly one default class (annotated
+/// `snapshot.storage.kubernetes.io/is-default-class: "true"`); without
+/// that the API server returns an error which surfaces in the CR
+/// `message` field for the user to fix.
+async fn ensure_source_snapshot(
+    ctx: &Context,
+    refresh: &OdooStagingRefreshJob,
+    source_pvc_name: &str,
+) -> Result<SourceSnapshotState> {
+    let ns = refresh.namespace().unwrap_or_default();
+    let snapshots: Api<VolumeSnapshot> = Api::namespaced(ctx.client.clone(), &ns);
+
+    let recorded = refresh
+        .status
+        .as_ref()
+        .and_then(|s| s.source_snapshot.as_deref());
+
+    let snap_name = match recorded {
+        Some(n) => n.to_string(),
+        None => {
+            // Convention: <refresh-crd>-src.  Stable per refresh CR;
+            // recreated fresh on each new refresh CR.
+            let name = format!("{}-src", refresh.name_any());
+            let snap = VolumeSnapshot {
+                metadata: kube::api::ObjectMeta {
+                    name: Some(name.clone()),
+                    namespace: Some(ns.clone()),
+                    owner_references: Some(vec![controller_owner_ref(refresh)]),
+                    ..Default::default()
+                },
+                spec: VolumeSnapshotSpec {
+                    source: VolumeSnapshotSource {
+                        persistent_volume_claim_name: Some(source_pvc_name.to_string()),
+                        volume_snapshot_content_name: None,
+                    },
+                    volume_snapshot_class_name: None,
+                },
+                status: None,
+            };
+            match snapshots.create(&PostParams::default(), &snap).await {
+                Ok(_) => {
+                    info!(
+                        crd_name = %refresh.name_any(),
+                        snapshot = %name,
+                        source_pvc = %source_pvc_name,
+                        "created source VolumeSnapshot for staging refresh"
+                    );
+                }
+                Err(kube::Error::Api(ErrorResponse { code: 409, .. })) => {
+                    // Pre-existing snapshot from a prior reconcile that
+                    // crashed before persisting status.source_snapshot.
+                    // Adopt it; idempotent.
+                }
+                Err(e) => return Err(Error::Kube(e)),
+            }
+            patch_refresh_status(
+                &ctx.client,
+                &ns,
+                &refresh.name_any(),
+                &json!({ "status": { "sourceSnapshot": &name } }),
+            )
+            .await?;
+            name
+        }
+    };
+
+    // Check readiness.  `readyToUse: true` means the CSI driver has
+    // finished snapshot creation; the snapshot can be referenced by a new
+    // PVC.  Anything else (None, false, missing object) → not ready,
+    // requeue.
+    match snapshots.get_opt(&snap_name).await? {
+        Some(s) => {
+            let ready = s
+                .status
+                .as_ref()
+                .and_then(|st| st.ready_to_use)
+                .unwrap_or(false);
+            if ready {
+                Ok(SourceSnapshotState::Ready { name: snap_name })
+            } else {
+                Ok(SourceSnapshotState::Pending { name: snap_name })
+            }
+        }
+        None => {
+            // Snapshot we just created is missing (e.g. cascading delete
+            // from the refresh CR being deleted while we were running).
+            // Treat as Pending — the next reconcile will recreate it.
+            Ok(SourceSnapshotState::Pending { name: snap_name })
+        }
+    }
+}
+
+/// Delete the source `VolumeSnapshot` recorded on a refresh CR's status.
+/// Best-effort — 404 is the expected case once K8s GC has run.
+pub async fn delete_source_snapshot(ctx: &Context, ns: &str, snapshot_name: &str) -> Result<()> {
+    let snapshots: Api<VolumeSnapshot> = Api::namespaced(ctx.client.clone(), ns);
+    match snapshots
+        .delete(snapshot_name, &DeleteParams::background())
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(kube::Error::Api(ErrorResponse { code: 404, .. })) => Ok(()),
+        Err(e) => Err(Error::Kube(e)),
+    }
 }
 
 /// CloningFromSource: orchestrates the three-Job refresh pipeline.
@@ -247,18 +391,45 @@ impl State for CloningFromSource {
                 )
                 .await?;
             } else {
-                // Snapshot path: replace the staging PVC with one cloned
-                // from the source PVC's contents.  Done in two phases
-                // across reconciles to avoid racing the old PVC's deletion:
-                //   tick A: delete (idempotent on 404), then bail if the
-                //           PVC is still terminating — kubelet may take a
-                //           while to release the volume on a real CSI.
-                //   tick B: PVC is gone → recreate it, patch filestorePhase
-                //           Running.  Settle block then waits for Bound.
-                // Patching Running while the OLD PVC still lingers would
-                // let the settle block see its `phase: Bound` and prematurely
-                // mark the step Completed — racing neutralize against a PVC
-                // that's about to vanish.
+                // Snapshot path: take a VolumeSnapshot of the source PVC,
+                // wait for it to be ready, then recreate the dest PVC with
+                // dataSourceRef → VolumeSnapshot.  Going via a snapshot is
+                // the universal CSI path: CephFS accepts both PVC and
+                // snapshot dataSources, but JuiceFS only accepts snapshot
+                // (`only VolumeSnapshot data source is supported, got
+                // PersistentVolumeClaim`), so PVC→PVC clone breaks JuiceFS
+                // refreshes outright.  Single code path → both backends.
+                //
+                // Done in three reconcile-amenable steps so we don't
+                // block the controller:
+                //   tick A: ensure source snapshot exists; if not Ready,
+                //           bail (next tick checks again).  Snapshot
+                //           creation is instant on CephFS, may take
+                //           seconds-to-minutes on JuiceFS depending on
+                //           file count and metadata engine speed.
+                //   tick B: snapshot Ready → delete the existing dest PVC.
+                //           If still terminating, bail.
+                //   tick C: dest PVC is gone → create it with
+                //           dataSourceRef → VolumeSnapshot, patch
+                //           filestorePhase Running.  Settle block then
+                //           waits for Bound.
+                // Patching Running before all three steps complete would
+                // let the settle block see a stale `Bound` and mark the
+                // step Completed before the new clone is actually live.
+                let source_pvc = format!("{source_name}-filestore-pvc");
+                let snap_state = ensure_source_snapshot(ctx, refresh, &source_pvc).await?;
+                let snap_name = match snap_state {
+                    SourceSnapshotState::Ready { name } => name,
+                    SourceSnapshotState::Pending { name } => {
+                        info!(
+                            crd_name = %refresh.name_any(),
+                            snapshot = %name,
+                            "source VolumeSnapshot not yet readyToUse; waiting"
+                        );
+                        return Ok(());
+                    }
+                };
+
                 let target_pvc = format!("{inst_name}-filestore-pvc");
                 let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), &ns);
                 // Background delete (the default): PVCs don't have
@@ -287,6 +458,12 @@ impl State for CloningFromSource {
                     _ => {}
                 }
                 let oref = controller_owner_ref(instance);
+                let snap_data_source = TypedObjectReference {
+                    api_group: Some("snapshot.storage.k8s.io".to_string()),
+                    kind: "VolumeSnapshot".to_string(),
+                    name: snap_name.clone(),
+                    namespace: None,
+                };
                 child_resources::ensure_filestore_pvc(
                     &ctx.client,
                     &ns,
@@ -294,11 +471,13 @@ impl State for CloningFromSource {
                     instance,
                     ctx,
                     &oref,
+                    Some(snap_data_source),
                 )
                 .await?;
                 info!(
                     crd_name = %refresh.name_any(),
                     pvc = %target_pvc,
+                    snapshot = %snap_name,
                     "kicked off filestore snapshot/clone PVC recreate"
                 );
                 patch_refresh_status(

--- a/src/controller/states/mod.rs
+++ b/src/controller/states/mod.rs
@@ -30,7 +30,7 @@ mod uninitialized;
 mod upgrading;
 
 pub use backing_up::BackingUp;
-pub use cloning_from_source::CloningFromSource;
+pub use cloning_from_source::{delete_source_snapshot, CloningFromSource};
 pub use degraded::Degraded;
 pub use error::Error;
 pub use finalizing_database_migration::FinalizingDatabaseMigration;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -24,6 +24,7 @@ use tokio::task::JoinHandle;
 use tracing_subscriber::EnvFilter;
 
 use gateway_api::apis::standard::httproutes::HTTPRoute;
+use kube_custom_resources_rs::snapshot_storage_k8s_io::v1::volumesnapshots::VolumeSnapshot;
 
 use odoo_operator::controller::helpers::FIELD_MANAGER;
 use odoo_operator::controller::odoo_instance::Context;
@@ -98,6 +99,40 @@ fn init_shared() -> SharedEnv {
                     "https://github.com/kubernetes-sigs/gateway-api/pull/1538".to_string(),
                 );
                 crds.push(httproute_crd);
+                // VolumeSnapshot CRD: needed by the staging refresh
+                // snapshot path so the operator can create VolumeSnapshots
+                // as the dataSource for the dest PVC.  The
+                // kube-custom-resources-rs CRD is generated with
+                // `#[kube(schema = "disabled")]`, but envtest's CRD
+                // validator rejects that — patch on a permissive schema
+                // (`x-kubernetes-preserve-unknown-fields: true`) and the
+                // api-approved annotation that protected groups require.
+                // envtest has no CSI controller, so the snapshot never
+                // becomes ready on its own — tests that exercise the
+                // snapshot path patch the snapshot's `readyToUse` status
+                // directly via the `fake_volume_snapshot_ready` helper.
+                let mut snap_crd = VolumeSnapshot::crd();
+                let snap_annotations = snap_crd
+                    .metadata
+                    .annotations
+                    .get_or_insert_with(Default::default);
+                snap_annotations.insert(
+                    "api-approved.kubernetes.io".to_string(),
+                    "https://github.com/kubernetes-csi/external-snapshotter/pull/665".to_string(),
+                );
+                for v in snap_crd.spec.versions.iter_mut() {
+                    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
+                        CustomResourceValidation, JSONSchemaProps,
+                    };
+                    v.schema = Some(CustomResourceValidation {
+                        open_api_v3_schema: Some(JSONSchemaProps {
+                            type_: Some("object".to_string()),
+                            x_kubernetes_preserve_unknown_fields: Some(true),
+                            ..Default::default()
+                        }),
+                    });
+                }
+                crds.push(snap_crd);
                 crds
             })
             .expect("failed to configure CRDs");

--- a/tests/integration/staging_refresh.rs
+++ b/tests/integration/staging_refresh.rs
@@ -410,6 +410,31 @@ async fn fake_pvc_bound(client: &kube::Client, ns: &str, name: &str) {
         .expect("patch PVC status");
 }
 
+/// Fake a `VolumeSnapshot.status.readyToUse: true` so the snapshot-path
+/// `ensure_source_snapshot` proceeds past the Pending gate.  envtest has no
+/// external-snapshotter, so without this the operator would loop forever
+/// waiting for the CSI driver to ack the snapshot.
+async fn fake_volume_snapshot_ready(client: &kube::Client, ns: &str, name: &str) {
+    use kube_custom_resources_rs::snapshot_storage_k8s_io::v1::volumesnapshots::VolumeSnapshot;
+    let snaps: Api<VolumeSnapshot> = Api::namespaced(client.clone(), ns);
+    let start = Instant::now();
+    loop {
+        if snaps.get_opt(name).await.ok().flatten().is_some() {
+            break;
+        }
+        assert!(
+            start.elapsed() < TIMEOUT,
+            "VolumeSnapshot {name} never appeared so it could be marked ready"
+        );
+        tokio::time::sleep(POLL).await;
+    }
+    let patch = json!({ "status": { "readyToUse": true } });
+    snaps
+        .patch_status(name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .expect("patch VolumeSnapshot status");
+}
+
 /// Snapshot path: when source and target share a StorageClass and
 /// `filestoreMethod: snapshot` is requested, the operator must NOT spawn a
 /// filestore Job.  Instead, it deletes the staging PVC, recreates it (which
@@ -480,6 +505,13 @@ async fn staging_refresh_snapshot_path_completes_via_pvc_bound() -> anyhow::Resu
         &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
     )
     .await?;
+
+    // Snapshot path: the operator first creates a VolumeSnapshot of the
+    // source PVC and gates on `readyToUse: true` before recreating the
+    // dest PVC.  envtest has no CSI snapshotter, so the test must mark
+    // it ready manually.  The snapshot is named `<refresh-crd>-src` per
+    // the operator's convention.
+    fake_volume_snapshot_ready(c, ns, "tgt-snap-refresh-src").await;
 
     // filestorePhase should reach Running once the snapshot kickoff patches
     // status (PVC delete + ensure_filestore_pvc complete).
@@ -686,6 +718,29 @@ async fn staging_refresh_snapshot_does_not_complete_while_old_pvc_terminates() -
         &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
     )
     .await?;
+
+    // Snapshot path requires a Ready VolumeSnapshot before the operator
+    // proceeds to the PVC delete-and-recreate dance that this test is
+    // really exercising.
+    fake_volume_snapshot_ready(c, ns, "tgt-snap3-refresh-src").await;
+
+    // Wait for the operator to have actually attempted the PVC delete
+    // (deletionTimestamp set) before starting the race assertion window —
+    // otherwise we'd be asserting on a PVC that's still Bound and
+    // pristine, which trips the test invariant before the operator has
+    // had a chance to misbehave.
+    let wait_start = Instant::now();
+    loop {
+        let live = pvcs.get(pvc_name).await?;
+        if live.metadata.deletion_timestamp.is_some() {
+            break;
+        }
+        assert!(
+            wait_start.elapsed() < TIMEOUT,
+            "operator never attempted to delete the staging PVC after snapshot ready"
+        );
+        tokio::time::sleep(POLL).await;
+    }
 
     // Critical assertion: while the old PVC has deletionTimestamp set
     // and is still phase=Bound, filestorePhase MUST NOT reach Completed.


### PR DESCRIPTION
## Summary

The staging-refresh snapshot path used PVC-to-PVC clone via `dataSource = PersistentVolumeClaim`. This works on CephFS but fails outright on JuiceFS:

```
error restoring data source: only VolumeSnapshot data source is supported, got PersistentVolumeClaim
```

The CRD's `status.sourceSnapshot` and `status.rollbackSnapshot` fields were already designed for this approach but never wired up — the original implementation took the PVC-clone shortcut. This PR moves to the intended design and unlocks JuiceFS support without per-backend branches.

## Flow per refresh cycle

1. `ensure_source_snapshot` creates a `VolumeSnapshot` named `<refresh-crd>-src` from the source filestore PVC, owner-ref'd to the refresh CR. Persisted in `status.sourceSnapshot` for idempotency across reconciles. `volumeSnapshotClassName` left `None` → uses the cluster's default class for the source PVC's CSI driver.
2. `CloningFromSource::ensure()` returns early until the snapshot has `readyToUse: true` (instant on CephFS, seconds-to-minutes on JuiceFS depending on metadata engine + file count).
3. Once ready, the dest PVC is deleted and recreated with `dataSourceRef → VolumeSnapshot/<source_snapshot>`.
4. On `CompleteRefreshJob`, the source snapshot is deleted explicitly (best-effort, 404 tolerated). On failure it's retained for diagnostics.

## Implementation notes

- `ensure_filestore_pvc` grows an `explicit_data_source` parameter so the refresh state can inject the `VolumeSnapshot` ref directly, bypassing the legacy auto-detection in `get_pvc_source`. The always-on reconcile path passes `None` and behavior is unchanged.
- Two staging-refresh integration tests fake a Ready snapshot via the new `fake_volume_snapshot_ready` helper (envtest has no CSI snapshotter). The 'old PVC still terminating' test additionally waits for the operator to attempt the PVC delete before asserting on the race window — the snapshot-readiness gate adds a tick before the delete that the test would otherwise miss.
- Test harness loads the upstream `VolumeSnapshot` CRD with a permissive schema (`x-kubernetes-preserve-unknown-fields`) and the `api-approved` annotation that protected API groups require.

## Out of scope

- Rollback snapshot of dest's pre-refresh filestore (`status.rollbackSnapshot` field). Separate concern.
- DB and filestore-Job-side `ensure_source_snapshot`-style retries. Not in this PR.
- Tunable `volumeSnapshotClassName` per refresh. Cluster-default lookup is sufficient for now.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all integration tests pass (one envtest shared-state flake unrelated to this PR; passes in isolation)
- [ ] Deploy and re-run a JuiceFS staging refresh end-to-end. Should succeed where it previously hit `only VolumeSnapshot data source is supported`.
- [ ] Re-run a CephFS staging refresh. Should also succeed (no regression — CephFS accepts both PVC and snapshot dataSources).