### PR TITLE
feat(ci): publish multi-arch operator image (amd64 + arm64)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,13 +54,28 @@ jobs:
             echo "tag_name=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
+  # Build each architecture on a native runner and push it by digest.
+  # The per-arch images are stitched into one manifest list by `merge`.
   build-and-publish:
-    runs-on: ubuntu-latest
     needs: resolve-ref
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-ref.outputs.tag_name }}
+
+      - name: Prepare platform name
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -68,6 +83,62 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+        env:
+          digest: ${{ steps.build.outputs.digest }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest list.
+  merge:
+    runs-on: ubuntu-latest
+    needs: [resolve-ref, build-and-publish]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta
@@ -78,17 +149,21 @@ jobs:
             type=raw,value=latest
             type=raw,value=${{ needs.resolve-ref.outputs.tag_name }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.resolve-ref.outputs.tag_name }}
 
   release-chart:
     runs-on: ubuntu-latest
-    needs: [resolve-ref, build-and-publish]
+    needs: [resolve-ref, merge]
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Closes #115.

Rebuilds the `build-and-publish` release job as a **native build matrix** — `amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm` — each pushed by digest, then stitched into one manifest list by a `merge` job. No `Dockerfile` change; both base images (`rust:1.88-bookworm`, `gcr.io/distroless/cc-debian12`) already publish both arches.

## Both approaches were built and measured on a fork

| | QEMU ×3 | Native matrix (this PR) |
|---|---|---|
| Platforms | amd64 + arm64 + ppc64le | amd64 + arm64 |
| Runners | 1× `ubuntu-latest` + QEMU | `ubuntu-latest` + `ubuntu-24.04-arm` |
| `arm64` build | ~147 min (emulated) | 187 s |
| `ppc64le` build | ~166 min (emulated) | — |
| **Total release build** | **2 h 47 m** | **4 m 41 s** |

QEMU-emulated `arm64` is the killer (~2.5 h on its own); native `arm64` runners (`ubuntu-24.04-arm`, free for public repos) build it in ~3 min — the same ballpark as `amd64`.

## Why `ppc64le` is omitted

`ppc64le` is the third architecture the official Odoo image ships, so it's a fair question. It's **deliberately left out**: no native GitHub runner exists for it, so it can only be QEMU-emulated — which would push every release build back to ~3 h, for an architecture with effectively no Kubernetes-operator user base. If you want it, it's a one-line addition to the `platforms` list (accepting the emulated build time).

## Alternative

If you'd rather ship all three architectures and accept the ~2h47m release build, the complete QEMU-×3 implementation is ready on branch [`feat/multi-arch-image-qemu`](https://github.com/macroscoop/odoo-operator/tree/feat/multi-arch-image-qemu) — say the word and I'll retarget this PR to it.

Both implementations were proved green on a fork: the multi-arch manifest builds and pushes correctly.
