### PR TITLE
fix(chart): make imagePullSecrets a release-managed resource

### DIFF
--- a/charts/odoo-operator/templates/secrets/image-pull-secrets.yaml
+++ b/charts/odoo-operator/templates/secrets/image-pull-secrets.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: {{ .domain }}
   namespace: {{ $.Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
 type: kubernetes.io/dockerconfigjson
 stringData:
   .dockerconfigjson: |


### PR DESCRIPTION
## What

Removes the `helm.sh/hook: pre-install` / `helm.sh/hook-weight` annotations from `charts/odoo-operator/templates/secrets/image-pull-secrets.yaml`, turning the image pull Secrets into regular release-managed resources.

## Why

As a `pre-install` hook, these Secrets are created only by `helm install` and are excluded from the release manifest. They are never reconciled by `helm upgrade`:

- A deleted / missing Secret is not recreated on upgrade.
- A changed credential in `imagePullSecrets` values is not applied on upgrade.

When the Secret is absent the operator cannot copy it into tenant namespaces, and `OdooInstance` reconciliation stalls with `secrets "<domain>" not found` — while `helm upgrade` still reports success.

As a plain template the Secret is created/updated on every `helm upgrade` and removed on `helm uninstall`. Helm's default install ordering already applies `Secret` before `Deployment`, so the `hook-weight: "-5"` ordering is unnecessary.

## Migration note

For clusters already running the chart, the existing Secret was created as a hook resource and lacks the `app.kubernetes.io/managed-by: Helm` label / `meta.helm.sh/release-*` annotations. The first `helm upgrade` after this change may report an ownership conflict; that Secret must be deleted (or relabeled) once so Helm can adopt it. Worth a line in the release notes.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
