### PR TITLE
fix(restore): chown filestore to odoo uid after zip extract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,14 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --test integration -- --test-threads=1
+
+  test-scripts:
+    name: Script tests
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
+      - name: Run shell-script tests
+        run: make test-scripts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-all test-cluster crds helm-crds check fmt clippy \
+.PHONY: build test test-all test-cluster test-scripts crds helm-crds check fmt clippy \
        docker-build docker-push docker-load state-machine \
        release-patch release-minor release-major
 
@@ -33,11 +33,18 @@ test:
 	cargo test
 
 ## All tests including cluster integration (requires running k8s cluster)
-test-all: test test-cluster
+test-all: test test-scripts test-cluster
 
 ## Cluster integration tests only
 test-cluster:
 	cargo test --test integration_test -- --ignored
+
+## Shell-script contract tests for scripts/* (requires docker, zip)
+test-scripts:
+	@for t in scripts/tests/test-*.sh; do \
+		echo "=== $$t ==="; \
+		bash "$$t" || exit $$?; \
+	done
 
 # ── Docker ────────────────────────────────────────────────────────────────────
 

--- a/scripts/restore-extract.sh
+++ b/scripts/restore-extract.sh
@@ -33,4 +33,14 @@ if [ -n "${rc:-}" ] && [ "$rc" -ne 0 ] && [ "$rc" -ne 11 ]; then
 fi
 
 ls -l /workspace/dump.sql
+
+# The script runs as root so apk can install unzip, which means everything
+# unzip wrote — including the mkdir'd parent — is owned root.  The Odoo
+# container runs as uid 100 (odoo) and must be able to write here.  On
+# cephfs the CSI driver's fsGroupPolicy=File lets kubelet rescue this with
+# a recursive chown, but JuiceFS RWX volumes (fsGroupPolicy=ReadWriteOnceWithFSType)
+# skip fsGroup entirely.  Chown unconditionally so the script's output is
+# usable regardless of the underlying CSI driver.
+chown -R 100:101 "/var/lib/odoo/filestore/$DB_NAME"
+
 echo "=== Extract complete ==="

--- a/scripts/tests/test-restore-extract.sh
+++ b/scripts/tests/test-restore-extract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression test for restore-extract.sh.
+#
+# The script runs as root (apk add unzip needs it) inside the operator's
+# extract init container. Whatever it writes to the filestore PVC must be
+# usable by the Odoo container (uid 100, gid 101). On cephfs the CSI driver
+# honors fsGroup so kubelet papers over root-owned files; on JuiceFS RWX
+# volumes fsGroup is skipped (fsGroupPolicy=ReadWriteOnceWithFSType) and
+# root-owned files break Odoo with PermissionError.
+#
+# This test asserts the script's *contract*: after it runs, uid 100 must be
+# able to write under filestore/$DB_NAME — without any fsGroup rescue.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/restore-extract.sh"
+
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 1; }
+command -v docker >/dev/null || { echo "docker required" >&2; exit 1; }
+command -v zip    >/dev/null || { echo "zip required (apt install zip)" >&2; exit 1; }
+
+WORKDIR=$(mktemp -d)
+cleanup() {
+    # Files written by root-uid containers can't be removed by the test user;
+    # use a throwaway container to chown back before rm.
+    docker run --rm -u 0 -v "$WORKDIR:/w" alpine:3.20 \
+        sh -c "chown -R $(id -u):$(id -g) /w" 2>/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+DB_NAME=testdb
+
+# Build a fixture zip: dump.sql + filestore/<sharding>/<file>.
+FIX="$WORKDIR/fixture"
+mkdir -p "$FIX/filestore/aa" "$FIX/filestore/bb"
+echo "-- dump" > "$FIX/dump.sql"
+echo "content-a" > "$FIX/filestore/aa/file1"
+echo "content-b" > "$FIX/filestore/bb/file2"
+(cd "$FIX" && zip -qr "$WORKDIR/artifact.zip" dump.sql filestore)
+
+mkdir -p "$WORKDIR/workspace" "$WORKDIR/odoo"
+cp "$WORKDIR/artifact.zip" "$WORKDIR/workspace/artifact"
+
+echo "=== Running restore-extract.sh as root ==="
+docker run --rm \
+    -u 0 \
+    -v "$WORKDIR/workspace:/workspace" \
+    -v "$WORKDIR/odoo:/var/lib/odoo" \
+    -v "$SCRIPT:/restore-extract.sh:ro" \
+    -e DB_NAME="$DB_NAME" \
+    -e INPUT_FILE=/workspace/artifact \
+    alpine:3.20 sh /restore-extract.sh
+
+echo "=== Asserting uid 100 (odoo) can write to filestore ==="
+# Explicitly no fsGroup — we are testing the script's contract, not kubelet.
+docker run --rm \
+    -u 100:101 \
+    -v "$WORKDIR/odoo:/var/lib/odoo" \
+    alpine:3.20 sh -euxc "
+        # The DB subdirectory itself must accept new files.
+        touch /var/lib/odoo/filestore/$DB_NAME/.probe
+        # Sharded subdirs (created by unzip) must accept new files too.
+        touch /var/lib/odoo/filestore/$DB_NAME/aa/.probe
+        # Every file/dir must be owned by uid 100 (the only way to guarantee
+        # write access without leaning on fsGroup or world-write).
+        wrong=\$(find /var/lib/odoo/filestore/$DB_NAME ! -user 100)
+        if [ -n \"\$wrong\" ]; then
+            echo 'FAIL: paths not owned by uid 100:'
+            echo \"\$wrong\"
+            exit 1
+        fi
+    "
+
+echo "PASS: filestore usable by uid 100 without fsGroup"


### PR DESCRIPTION
## Summary
- restore-extract.sh runs as root (apk needs it) so files written by `unzip` were root-owned. On cephfs the CSI driver's `fsGroupPolicy=File` lets kubelet recursively chown the volume at mount time, which masked the issue. JuiceFS CSI ships with `fsGroupPolicy=ReadWriteOnceWithFSType`, so on RWX volumes fsGroup is skipped and the Odoo container (uid 100) hits `PermissionError` writing to its own filestore on fresh restores.
- Adds `chown -R 100:101 /var/lib/odoo/filestore/\$DB_NAME` at the end of the extract script so the output is usable regardless of CSI driver.
- Adds a docker-based contract test (`scripts/tests/test-restore-extract.sh`) that runs the script as root and asserts every path under filestore is owned uid 100 — without leaning on kubelet's fsGroup rescue. Catches the regression class on any CSI driver, present or future. Wired in via a new `make test-scripts` target and a `test-scripts` CI job.

## Reproducer
Caught on a fresh OdooInstance on the `juice` SC: filestore dirs ended up `root:odoo 0755`, Odoo (uid 100) couldn't write, app refused to serve assets.

## Test plan
- [x] Red/green TDD: confirmed `make test-scripts` fails on master (unfixed script) with `Permission denied`, passes with the chown
- [x] `make test-scripts` passes locally
- [ ] CI `test-scripts` job green
- [ ] CI `test` job (envtest integration) still green