### PR TITLE
fix(finalizer): retain postgres-cleanup finalizer when delete_role fails

### DIFF
--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -519,7 +519,7 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
     let username = odoo_username(&ns, &name);
     if let Ok((cluster_name, pg_cluster)) = load_postgres_cluster(ctx, instance).await {
         if let Err(e) = ctx.postgres.delete_role(&pg_cluster, &username).await {
-            warn!(%name, %e, "failed to delete postgres role — removing finalizer anyway");
+            warn!(%name, %e, "failed to delete postgres role — retaining finalizer for retry");
             publish_event(
                 ctx,
                 instance,
@@ -529,6 +529,10 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
                 Some(format!("Failed to delete postgres role: {e}")),
             )
             .await;
+            // Return Err so the kube-rs finalizer helper keeps the finalizer
+            // in place and the controller requeues — otherwise we orphan the
+            // postgres role and block same-name re-create (issue #119).
+            return Err(e);
         }
 
         // If deleted mid-migration, also clean up the old cluster.
@@ -542,8 +546,20 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
                     if let Err(e) = ctx.postgres.delete_role(&old_pg, &username).await {
                         warn!(
                             %name, %old_cluster, %e,
-                            "failed to delete role on old cluster during cleanup"
+                            "failed to delete role on old cluster — retaining finalizer for retry"
                         );
+                        publish_event(
+                            ctx,
+                            instance,
+                            EventType::Warning,
+                            "CleanupFailed",
+                            "Finalize",
+                            Some(format!(
+                                "Failed to delete postgres role on old cluster {old_cluster}: {e}"
+                            )),
+                        )
+                        .await;
+                        return Err(e);
                     }
                 }
             }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -7,8 +7,9 @@
 //! There is no kubelet or scheduler in envtest, so Deployment status and Job
 //! completion must be faked by patching status subresources.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use envtest::Environment;
@@ -34,8 +35,9 @@ use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
 use odoo_operator::crd::odoo_restore_job::OdooRestoreJob;
 use odoo_operator::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
 use odoo_operator::crd::odoo_upgrade_job::OdooUpgradeJob;
+use odoo_operator::error::{Error, Result as PgResult};
 use odoo_operator::helpers::OperatorDefaults;
-use odoo_operator::postgres::NoopPostgresManager;
+use odoo_operator::postgres::{PostgresClusterConfig, PostgresManager};
 
 pub const TIMEOUT: Duration = Duration::from_secs(30);
 pub const POLL: Duration = Duration::from_millis(500);
@@ -327,13 +329,85 @@ fn test_context(client: Client) -> Arc<Context> {
         defaults: test_defaults(),
         operator_namespace: "default".into(),
         postgres_clusters_secret: "".into(),
-        postgres: Arc::new(NoopPostgresManager),
+        postgres: mock_pg(),
         http_client: reqwest::Client::new(),
         reporter: Reporter {
             controller: "odoo-operator-test".into(),
             instance: None,
         },
     })
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MockPostgresManager — succeeds by default, supports per-username fault
+// injection so tests can drive cleanup/provisioning failure paths.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[derive(Default)]
+pub struct MockPostgresManager {
+    // username -> error message to return from delete_role
+    delete_role_failures: RwLock<HashMap<String, String>>,
+}
+
+impl MockPostgresManager {
+    /// Configure delete_role to fail for the given username with the given
+    /// error message until `clear_delete_role_failure` is called.
+    pub fn fail_delete_role(&self, username: &str, msg: &str) {
+        self.delete_role_failures
+            .write()
+            .unwrap()
+            .insert(username.to_string(), msg.to_string());
+    }
+
+    #[allow(dead_code)]
+    pub fn clear_delete_role_failure(&self, username: &str) {
+        self.delete_role_failures.write().unwrap().remove(username);
+    }
+}
+
+#[async_trait::async_trait]
+impl PostgresManager for MockPostgresManager {
+    async fn ensure_role(&self, _: &PostgresClusterConfig, _: &str, _: &str) -> PgResult<()> {
+        Ok(())
+    }
+
+    async fn delete_role(&self, _: &PostgresClusterConfig, username: &str) -> PgResult<()> {
+        if let Some(msg) = self
+            .delete_role_failures
+            .read()
+            .unwrap()
+            .get(username)
+            .cloned()
+        {
+            return Err(Error::config(msg));
+        }
+        Ok(())
+    }
+
+    async fn ensure_report_url(
+        &self,
+        _: &PostgresClusterConfig,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> PgResult<()> {
+        Ok(())
+    }
+
+    async fn detect_server_major_version(&self, _: &PostgresClusterConfig) -> PgResult<u32> {
+        Ok(18)
+    }
+}
+
+static MOCK_PG: OnceLock<Arc<MockPostgresManager>> = OnceLock::new();
+
+/// Singleton mock postgres manager used by the shared test controller. Tests
+/// call this to configure fault injection (e.g. `mock_pg().fail_delete_role(...)`).
+pub fn mock_pg() -> Arc<MockPostgresManager> {
+    MOCK_PG
+        .get_or_init(|| Arc::new(MockPostgresManager::default()))
+        .clone()
 }
 
 /// Poll until a condition is true, or timeout.

--- a/tests/integration/finalizer_postgres_cleanup_failure.rs
+++ b/tests/integration/finalizer_postgres_cleanup_failure.rs
@@ -1,0 +1,93 @@
+//! Regression test for the orphan-role bug (issue #119).
+//!
+//! When `cleanup_instance` calls `delete_role` and it fails (e.g. the role
+//! still owns dependent objects or grants), the operator must NOT remove the
+//! `bemade.org/postgres-cleanup` finalizer.  Stripping the finalizer lets the
+//! API server delete the OdooInstance while postgres-side state lingers,
+//! orphaning the role and blocking same-name re-create.
+
+use kube::api::{Api, DeleteParams};
+
+use super::common::*;
+use odoo_operator::crd::odoo_instance::OdooInstance;
+use odoo_operator::helpers::odoo_username;
+
+const FINALIZER: &str = "bemade.org/postgres-cleanup";
+
+/// On `delete_role` failure the postgres-cleanup finalizer must remain on
+/// the OdooInstance and the object must continue to exist (deletionTimestamp
+/// set but not yet gone) so the controller keeps retrying.  Today the
+/// operator strips the finalizer regardless and the instance disappears.
+#[tokio::test]
+async fn finalizer_retained_when_delete_role_fails() -> anyhow::Result<()> {
+    let ctx = TestContext::new("test-cleanup-fail").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+
+    // Wait for the operator's first reconcile to add the postgres-cleanup
+    // finalizer to the instance.  Without this, a fast delete races the
+    // reconciler and kube tears the object down before we can assert
+    // anything meaningful.
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let api = instances.clone();
+            async move {
+                api.get("test-cleanup-fail")
+                    .await
+                    .ok()
+                    .and_then(|i| i.metadata.finalizers)
+                    .is_some_and(|f| f.iter().any(|s| s == FINALIZER))
+            }
+        })
+        .await,
+        "postgres-cleanup finalizer never appeared on the instance"
+    );
+
+    // Arm the mock so the controller's next cleanup attempt fails.
+    let username = odoo_username(ns, "test-cleanup-fail");
+    mock_pg().fail_delete_role(
+        &username,
+        "role still owns dependent grants in cluster (test injection)",
+    );
+
+    // Trigger deletion.  In the buggy code path the operator's cleanup
+    // handler logs the failure as a warn and returns Ok — the kube-rs
+    // finalizer helper then strips the finalizer and the API server
+    // removes the object.
+    instances
+        .delete("test-cleanup-fail", &DeleteParams::default())
+        .await
+        .expect("failed to issue delete");
+
+    // Give the controller enough time to attempt cleanup at least once.
+    // POLL is 500ms; sleeping ~3s leaves room for the watch event +
+    // reconcile + mock call.  We deliberately don't wait_for a positive
+    // signal here — we are asserting the *absence* of a (bad) transition.
+    tokio::time::sleep(TIMEOUT / 10).await;
+
+    // The instance must still exist — deletionTimestamp set, but the
+    // finalizer should be holding deletion open.
+    let still_there = instances.get_opt("test-cleanup-fail").await?;
+    let inst = still_there.expect(
+        "OdooInstance was deleted from the API server even though postgres-side \
+         cleanup failed — finalizer was incorrectly removed",
+    );
+
+    assert!(
+        inst.metadata.deletion_timestamp.is_some(),
+        "expected deletionTimestamp to be set after delete()"
+    );
+
+    let finalizers = inst.metadata.finalizers.unwrap_or_default();
+    assert!(
+        finalizers.iter().any(|s| s == FINALIZER),
+        "postgres-cleanup finalizer was stripped despite cleanup failure \
+         (finalizers now: {finalizers:?})"
+    );
+
+    // Clear the fault so the test's drop / parallel teardown doesn't leak
+    // a stuck instance into other tests.
+    mock_pg().clear_delete_role_failure(&username);
+
+    Ok(())
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod child_resources;
 mod degraded;
 mod environment_labels;
 mod finalizer;
+mod finalizer_postgres_cleanup_failure;
 mod init_job;
 mod migrate_database;
 mod migrate_filestore;


### PR DESCRIPTION
## Summary

Part 1 of #119.

`cleanup_instance` used to log a warning on `delete_role` failure and return `Ok`, which made the kube-rs finalizer helper strip the `bemade.org/postgres-cleanup` finalizer. The API server then removed the `OdooInstance` even though postgres-side cleanup never completed — orphaning the per-instance role and blocking same-name re-create.

This PR returns `Err` on `delete_role` failure for both current and old-cluster paths so the finalizer stays on the object and the controller requeues. A Warning event \`CleanupFailed\` is still published so the failure is visible.

## Behavior change

The failure mode changes from **silent orphan + opaque `InitFailed` on re-create** to **instance stuck in `Terminating` with `CleanupFailed` events**. Strict improvement: visible, retryable, no silent state divergence. Operators may need to investigate stuck-Terminating instances now, which they didn't before.

## Out of scope (follow-ups)

This addresses the silent-orphan root cause only. Still open from #119:

- **Robust teardown** — \`delete_role\` doesn't terminate connections (\`DROP DATABASE ... WITH (FORCE)\`) or \`REASSIGN OWNED\` / \`DROP OWNED\` before \`DROP ROLE\`, so it'll keep failing for the same reasons. Operator now retries forever instead of orphaning.
- **Re-provision convergence** — \`ensure_role\` early-returns if the role exists, so a same-name re-create after a pre-existing orphan still hits \`InitFailed\`. Also doesn't reset the role password.
- **Existing orphans** — pre-existing orphan roles from past silent failures still require manual \`DROP ROLE\` once.

## Test infrastructure

Adds \`MockPostgresManager\` to \`tests/integration/common.rs\` — a drop-in replacement for \`NoopPostgresManager\` with per-username fault injection via \`mock_pg().fail_delete_role(&username, &msg)\`. Default behavior is identical (succeed for everything) so the existing 41 tests pass unchanged.

## Test plan

- [x] Red/green TDD: new test \`finalizer_retained_when_delete_role_fails\` fails on master (instance is deleted, finalizer stripped) and passes with the fix (finalizer retained, instance kept around)
- [x] Full envtest integration suite: 42/42 green locally
- [ ] CI green