### PR TITLE
fix(postgres): reset role password on every ensure_role; surface real PG error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zip
       - name: Run shell-script tests
         run: make test-scripts
+
+  test-postgres:
+    name: Postgres integration tests
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run docker-backed postgres tests
+        run: make test-postgres

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-all test-cluster test-scripts crds helm-crds check fmt clippy \
+.PHONY: build test test-all test-cluster test-scripts test-postgres crds helm-crds check fmt clippy \
        docker-build docker-push docker-load state-machine \
        release-patch release-minor release-major
 
@@ -33,7 +33,7 @@ test:
 	cargo test
 
 ## All tests including cluster integration (requires running k8s cluster)
-test-all: test test-scripts test-cluster
+test-all: test test-scripts test-postgres test-cluster
 
 ## Cluster integration tests only
 test-cluster:
@@ -45,6 +45,10 @@ test-scripts:
 		echo "=== $$t ==="; \
 		bash "$$t" || exit $$?; \
 	done
+
+## Docker-backed PostgreSQL integration tests for PgPostgresManager (requires docker)
+test-postgres:
+	cargo test --test postgres_harness -- --test-threads=1
 
 # ── Docker ────────────────────────────────────────────────────────────────────
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ pub enum Error {
     #[error("Kubernetes API error: {0}")]
     Kube(#[from] kube::Error),
 
-    #[error("PostgreSQL error: {0}")]
+    #[error("PostgreSQL error: {}", format_pg_error(.0))]
     Postgres(#[from] tokio_postgres::Error),
 
     #[error("Serialization error: {0}")]
@@ -40,5 +40,16 @@ impl Error {
     }
     pub fn config(msg: impl Into<String>) -> Self {
         Self::Config(msg.into())
+    }
+}
+
+/// Render a `tokio_postgres::Error` with the actual server-side message body
+/// when available — the default Display just emits "db error", which makes
+/// operator logs / events useless for diagnosing finalizer-blocked deletes.
+fn format_pg_error(e: &tokio_postgres::Error) -> String {
+    if let Some(db) = e.as_db_error() {
+        format!("{}: {}", db.severity(), db.message())
+    } else {
+        e.to_string()
     }
 }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -73,14 +73,17 @@ impl PostgresManager for PgPostgresManager {
             )
             .await?;
         let exists: bool = row.get(0);
+        let safe_user = quote_ident(username);
+        // Passwords are random per-instance Secrets; rotate to the current
+        // value whether the role is new or already present so a same-name
+        // re-create after a finalizer-blocked delete can authenticate with
+        // its fresh Secret (issue #119, part C).
         if exists {
+            let stmt = format!("ALTER ROLE {safe_user} WITH PASSWORD '{password}'");
+            client.execute(&stmt, &[]).await?;
             return Ok(());
         }
 
-        // tokio-postgres doesn't have Identifier.Sanitize() like pgx, so we
-        // use a simple allowlist check + quoting. In production you'd want a
-        // proper identifier escaper.
-        let safe_user = quote_ident(username);
         let stmt = format!("CREATE ROLE {safe_user} WITH PASSWORD '{password}' CREATEDB LOGIN");
         client.execute(&stmt, &[]).await?;
         info!(%username, "created postgres role");

--- a/tests/postgres_harness/delete_role_errors.rs
+++ b/tests/postgres_harness/delete_role_errors.rs
@@ -1,0 +1,73 @@
+//! Regression test for issue #119, part E.
+//!
+//! `delete_role` failures must surface the actual PostgreSQL error text in
+//! the returned `Error` (and therefore in operator logs / events). The
+//! production path currently bubbles `tokio_postgres::Error` through the
+//! `#[from]` impl on `Error::Postgres`, whose Display only emits "db error"
+//! — operators cannot diagnose why cleanup is stuck without manually
+//! connecting to the cluster.
+
+use odoo_operator::postgres::PostgresManager;
+
+use super::harness::{admin_client, cluster_config, pg_manager};
+
+async fn cleanup(username: &str, depdb: &str) {
+    let c = admin_client().await;
+    // The dependency arrangement requires unwinding before drop.
+    let _ = c
+        .simple_query(&format!(
+            r#"REVOKE ALL ON DATABASE "{depdb}" FROM "{username}""#
+        ))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{depdb}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{username}""#))
+        .await;
+}
+
+#[tokio::test]
+async fn delete_role_error_includes_real_postgres_message() -> anyhow::Result<()> {
+    let username = "odoo.test.delete_role_err";
+    let depdb = "odoo_test_delete_role_err_dep";
+    cleanup(username, depdb).await;
+
+    // Set up a role with privileges on a database it does NOT own — the
+    // delete_role code path drops owned databases first, so we need a
+    // dependency that survives that step. GRANT CONNECT on an admin-owned
+    // DB blocks the subsequent DROP ROLE with a dependency error.
+    let c = admin_client().await;
+    c.simple_query(&format!(
+        r#"CREATE ROLE "{username}" WITH PASSWORD 'x' LOGIN"#
+    ))
+    .await?;
+    c.simple_query(&format!(r#"CREATE DATABASE "{depdb}""#))
+        .await?;
+    c.simple_query(&format!(
+        r#"GRANT CONNECT ON DATABASE "{depdb}" TO "{username}""#
+    ))
+    .await?;
+
+    let cfg = cluster_config();
+    let result = pg_manager().delete_role(&cfg, username).await;
+    let err = match result {
+        Ok(()) => panic!("expected delete_role to fail due to dependent grant"),
+        Err(e) => e,
+    };
+
+    let msg = format!("{err}");
+    assert!(
+        // Postgres emits something like "role ... cannot be dropped because
+        // some objects depend on it". We don't pin the exact wording but do
+        // require *some* substring of the real PG message instead of the
+        // opaque tokio_postgres default ("db error").
+        msg.to_lowercase().contains("cannot be dropped")
+            || msg.to_lowercase().contains("depend")
+            || msg.to_lowercase().contains("grant"),
+        "expected error to surface the actual PostgreSQL message, got: {msg:?}"
+    );
+
+    cleanup(username, depdb).await;
+    Ok(())
+}

--- a/tests/postgres_harness/ensure_role.rs
+++ b/tests/postgres_harness/ensure_role.rs
@@ -1,0 +1,54 @@
+//! Regression test for issue #119, part C.
+//!
+//! When `ensure_role` is invoked for a role that already exists, the role's
+//! password must be reset to the supplied value. Today the production
+//! implementation early-returns when the role exists, so a same-name
+//! re-create after a finalizer-blocked deletion can't authenticate with
+//! its freshly-generated per-instance Secret.
+
+use odoo_operator::postgres::PostgresManager;
+
+use super::harness::{admin_client, cluster_config, pg_manager, try_connect_as};
+
+/// Drop the role if it exists from a prior test run (best-effort).
+async fn cleanup_role(username: &str) {
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{username}""#))
+        .await;
+}
+
+#[tokio::test]
+async fn ensure_role_resets_password_when_role_already_exists() -> anyhow::Result<()> {
+    let username = "odoo.test.ensure_role_reset";
+    cleanup_role(username).await;
+
+    let mgr = pg_manager();
+    let cfg = cluster_config();
+
+    // First call: creates the role with the initial password.
+    mgr.ensure_role(&cfg, username, "first-password")
+        .await
+        .expect("initial ensure_role failed");
+    try_connect_as(username, "first-password", "postgres")
+        .await
+        .expect("initial password should authenticate");
+
+    // Second call simulates the operator re-reconciling after a same-name
+    // re-create: same username, NEW password from a fresh Secret. Today
+    // this is a no-op (early return) — the role keeps the old password.
+    mgr.ensure_role(&cfg, username, "second-password")
+        .await
+        .expect("second ensure_role failed");
+
+    // After the fix, the new password authenticates.
+    try_connect_as(username, "second-password", "postgres")
+        .await
+        .expect(
+            "after ensure_role with a new password the new password must \
+             authenticate — the role's password was not reset",
+        );
+
+    cleanup_role(username).await;
+    Ok(())
+}

--- a/tests/postgres_harness/harness.rs
+++ b/tests/postgres_harness/harness.rs
@@ -1,0 +1,193 @@
+//! Docker-backed PostgreSQL test harness.
+//!
+//! Spawns a single `postgres:18` container per test binary on a random host
+//! port, waits for it to accept connections, and exposes a real
+//! `PgPostgresManager` + `PostgresClusterConfig` pointing at it.  The
+//! container is reaped on process exit (or via the explicit drop guard;
+//! `--rm` ensures docker cleans it up even on panic).
+
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use odoo_operator::postgres::{PgPostgresManager, PostgresClusterConfig};
+
+pub const ADMIN_USER: &str = "postgres";
+pub const ADMIN_PASSWORD: &str = "harness-pw";
+
+struct Harness {
+    port: u16,
+    container_id: String,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        // Best-effort cleanup; `--rm` makes this redundant unless the docker
+        // daemon was busy. Ignore errors.
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.container_id])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+static HARNESS: OnceLock<Harness> = OnceLock::new();
+
+fn ensure_docker_available() {
+    let ok = Command::new("docker")
+        .args(["version", "--format", "{{.Client.Version}}"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !ok {
+        panic!(
+            "docker is not available — the postgres_harness test binary \
+             requires docker. Install docker or skip with \
+             `cargo test --test integration` (envtest tests only)."
+        );
+    }
+}
+
+fn start_container() -> Harness {
+    ensure_docker_available();
+
+    // Use port 0 to ask the kernel for a free port, then read it back from
+    // `docker port`. Avoids races between parallel test binaries.
+    let out = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--rm",
+            "-e",
+            &format!("POSTGRES_PASSWORD={ADMIN_PASSWORD}"),
+            "-e",
+            &format!("POSTGRES_USER={ADMIN_USER}"),
+            "-p",
+            "127.0.0.1::5432",
+            "postgres:18",
+        ])
+        .output()
+        .expect("failed to spawn docker run");
+    assert!(
+        out.status.success(),
+        "docker run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let container_id = String::from_utf8(out.stdout).unwrap().trim().to_string();
+
+    let port_out = Command::new("docker")
+        .args(["port", &container_id, "5432/tcp"])
+        .output()
+        .expect("failed to spawn docker port");
+    let port_line = String::from_utf8_lossy(&port_out.stdout)
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    let port: u16 = port_line
+        .rsplit(':')
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse port from docker port: {port_line:?}"));
+
+    // Wait for the server to accept connections.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            // TCP open ≠ accepting queries; do one query to be sure.
+            let probe = std::process::Command::new("docker")
+                .args([
+                    "exec",
+                    &container_id,
+                    "pg_isready",
+                    "-U",
+                    ADMIN_USER,
+                    "-h",
+                    "127.0.0.1",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            if probe.map(|s| s.success()).unwrap_or(false) {
+                break;
+            }
+        }
+        if Instant::now() > deadline {
+            let logs = Command::new("docker")
+                .args(["logs", &container_id])
+                .output()
+                .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+                .unwrap_or_default();
+            panic!("postgres container never became ready. Logs:\n{logs}");
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    Harness { port, container_id }
+}
+
+fn harness() -> &'static Harness {
+    HARNESS.get_or_init(start_container)
+}
+
+/// Build a `PostgresClusterConfig` pointing at the harness container.
+pub fn cluster_config() -> PostgresClusterConfig {
+    let h = harness();
+    PostgresClusterConfig {
+        host: "127.0.0.1".to_string(),
+        port: h.port as i32,
+        admin_user: ADMIN_USER.to_string(),
+        admin_password: ADMIN_PASSWORD.to_string(),
+        default: true,
+    }
+}
+
+/// A `PgPostgresManager` (the real production impl) wired against the
+/// harness container.
+pub fn pg_manager() -> PgPostgresManager {
+    PgPostgresManager
+}
+
+/// Connect to the harness as the admin user. Useful for setup/assertion SQL.
+pub async fn admin_client() -> tokio_postgres::Client {
+    connect_as(ADMIN_USER, ADMIN_PASSWORD, "postgres").await
+}
+
+/// Connect to the harness as the given user.
+pub async fn connect_as(user: &str, password: &str, dbname: &str) -> tokio_postgres::Client {
+    let cfg = cluster_config();
+    let connstr = format!(
+        "host={} port={} user={} password={} dbname={}",
+        cfg.host, cfg.port, user, password, dbname
+    );
+    let (client, connection) = tokio_postgres::connect(&connstr, tokio_postgres::NoTls)
+        .await
+        .expect("failed to connect to harness postgres");
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+/// Try to connect — returns Err if auth fails, used to verify password changes.
+pub async fn try_connect_as(
+    user: &str,
+    password: &str,
+    dbname: &str,
+) -> Result<(), tokio_postgres::Error> {
+    let cfg = cluster_config();
+    let connstr = format!(
+        "host={} port={} user={} password={} dbname={}",
+        cfg.host, cfg.port, user, password, dbname
+    );
+    let (client, connection) = tokio_postgres::connect(&connstr, tokio_postgres::NoTls).await?;
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    // One trivial query to make sure the connection is actually authenticated.
+    client.simple_query("SELECT 1").await?;
+    Ok(())
+}

--- a/tests/postgres_harness/main.rs
+++ b/tests/postgres_harness/main.rs
@@ -1,0 +1,10 @@
+//! Docker-pg integration tests for `PgPostgresManager`.
+//!
+//! Run with: `cargo test --test postgres_harness -- --test-threads=1`
+//! Requires docker. The container is shared across tests in the binary;
+//! tests use unique role names to avoid collisions.
+
+mod harness;
+
+mod delete_role_errors;
+mod ensure_role;


### PR DESCRIPTION
## Summary

Parts C + E of #119, follow-up to #121 (part A).

### C — same-name re-create after orphan
\`PgPostgresManager::ensure_role\` early-returned when the role already existed, so a same-name OdooInstance re-create after a finalizer-blocked deletion couldn't authenticate with its freshly-generated per-instance Secret — the surviving role still held the old password. Always issue \`ALTER ROLE ... WITH PASSWORD '...'\` so the role tracks the current Secret regardless of whether it was just created. The DB itself uses a UUID-based name so there's no name collision; once the role's password is right, init proceeds normally.

### E — opaque error messages
\`Error::Postgres\` delegated Display to \`tokio_postgres::Error\`, whose default Display only emits \"db error\" without the actual server-side message. Operators couldn't diagnose why deletion was stuck (now visible thanks to part A) without manually connecting to the cluster. Format via \`DbError\` when available so severity + message body land in logs and Warning events.

## Test infrastructure

Adds \`tests/postgres_harness/\` — a docker-backed test harness that spawns a \`postgres:18\` container per test binary (shared across tests, port auto-assigned, container reaped on process exit via \`--rm\` + Drop guard). Tests run the **real** \`PgPostgresManager\` against it, so SQL behavior is actually validated.

Two failing-first tests cover this PR:
- \`ensure_role_resets_password_when_role_already_exists\` — calls \`ensure_role\` twice with different passwords, asserts the new password authenticates. Fails on master with \`password authentication failed for user \"...\"\`.
- \`delete_role_error_includes_real_postgres_message\` — sets up a role with a dependency (\`GRANT CONNECT ON DATABASE\`) so DROP ROLE fails, asserts the returned error string contains the actual PG message. Fails on master with \"PostgreSQL error: db error\".

The harness will be reused for the next part of #119 (part B: robust delete_role with REASSIGN OWNED / connection termination).

## Out of scope

Part D — flipping \`dbInitialized=false\` when the DB is observed missing. Has real risk of destructive auto-reinit and warrants a separate design discussion. **Same-name re-create after orphan is fully unblocked by C alone**, because new instances get UUID-based DB names that don't collide with any leftover DB.

## CI

- New \`test-postgres\` Makefile target (\`cargo test --test postgres_harness -- --test-threads=1\`)
- New \`test-postgres\` CI job (uses docker on the GitHub-hosted ubuntu-latest runner, no extra setup)
- Added to \`test-all\`

## Test plan

- [x] Red/green TDD on both fixes (docker-pg harness)
- [x] envtest integration suite 42/42 green (collateral check on Error::Postgres Display change)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] CI green