### PR TITLE
feat(database): missingPolicy for auto-recovery when DB is dropped out-of-band

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -603,6 +603,13 @@ spec:
                   cluster:
                     nullable: true
                     type: string
+                  missingPolicy:
+                    default: Ignore
+                    description: Reaction when the database is observed missing post-initialization. See `DatabaseMissingPolicy`. Default `Ignore`.
+                    enum:
+                    - Ignore
+                    - Recreate
+                    type: string
                   name:
                     nullable: true
                     type: string

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -31,7 +31,7 @@ use tracing::{debug, info, warn};
 
 use crate::crd::odoo_backup_job::OdooBackupJob;
 use crate::crd::odoo_init_job::OdooInitJob;
-use crate::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
+use crate::crd::odoo_instance::{DatabaseMissingPolicy, OdooInstance, OdooInstancePhase};
 use crate::crd::odoo_restore_job::OdooRestoreJob;
 use crate::crd::odoo_staging_refresh_job::OdooStagingRefreshJob;
 use crate::crd::odoo_upgrade_job::OdooUpgradeJob;
@@ -363,6 +363,67 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         &cluster_name,
     )
     .await?;
+
+    // Reality-check that the per-instance database still exists. If it was
+    // dropped out-of-band, react per spec.database.missingPolicy.
+    if snapshot.db_initialized && snapshot.init_job == super::state_machine::JobStatus::Absent {
+        let db = crate::helpers::db_name(instance);
+        match ctx.postgres.database_exists(&pg_cluster, &db).await {
+            Ok(false) => {
+                let policy = instance
+                    .spec
+                    .database
+                    .as_ref()
+                    .map(|d| d.missing_policy)
+                    .unwrap_or_default();
+                publish_event(
+                    ctx,
+                    instance,
+                    EventType::Warning,
+                    "DatabaseMissing",
+                    "Reconcile",
+                    Some(format!(
+                        "Database {db:?} not found on cluster {cluster_name:?} \
+                         (policy: {policy:?})"
+                    )),
+                )
+                .await;
+                if policy == DatabaseMissingPolicy::Recreate {
+                    // Flip dbInitialized so the state machine drives back to
+                    // Uninitialized, then delete the previous auto-init CR so
+                    // Uninitialized.ensure() can recreate it from spec.init.
+                    let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
+                    let patch = json!({"status": {"dbInitialized": false}});
+                    api.patch_status(
+                        &name,
+                        &PatchParams::apply(FIELD_MANAGER),
+                        &Patch::Merge(&patch),
+                    )
+                    .await?;
+                    let auto_init_name = format!("{name}-auto-init");
+                    let inits: Api<OdooInitJob> = Api::namespaced(client.clone(), &ns);
+                    if let Err(e) = inits
+                        .delete(&auto_init_name, &kube::api::DeleteParams::default())
+                        .await
+                    {
+                        // Already-gone is fine; anything else is logged but
+                        // not fatal — the flip is the important bit.
+                        if !e.to_string().contains("NotFound") {
+                            warn!(%name, %e, "failed to delete stale auto-init CR after dbInitialized flip");
+                        }
+                    }
+                    info!(%name, %db, "DB missing under Recreate policy — flipped dbInitialized=false");
+                    return Ok(Action::requeue(Duration::from_secs(0)));
+                }
+            }
+            Ok(true) => {}
+            Err(e) => {
+                // Don't act on probe failure — treat as "unknown" to avoid
+                // false flips during transient PG outages.
+                warn!(%name, %e, "database_exists probe failed; skipping missing-policy check");
+            }
+        }
+    }
 
     // Ensure report.url points to the in-cluster web service so cron workers
     // can reach the report rendering endpoint (wkhtmltopdf via HTTP).

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -36,6 +36,24 @@ pub struct FilestoreSpec {
     pub storage_class: Option<String>,
 }
 
+/// Policy for what to do when the per-instance database is observed
+/// missing (e.g. dropped out-of-band) while `status.dbInitialized == true`.
+///
+///   * `Ignore` (default) — publish a Warning event and let humans decide
+///     whether to restore the DB or trigger a re-init (manually flipping
+///     `status.dbInitialized` to false). Safe default: never wipes data
+///     during operator-external maintenance windows.
+///   * `Recreate` — automatically flip `status.dbInitialized` to false so
+///     the state machine drives back to `Uninitialized` and the
+///     `init.enabled` auto-init path recreates the DB. Opt in only when
+///     the operator is the exclusive owner of DB lifecycle.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub enum DatabaseMissingPolicy {
+    #[default]
+    Ignore,
+    Recreate,
+}
+
 /// DatabaseSpec identifies which PostgreSQL cluster to use for this instance.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -44,6 +62,10 @@ pub struct DatabaseSpec {
     pub cluster: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Reaction when the database is observed missing post-initialization.
+    /// See `DatabaseMissingPolicy`. Default `Ignore`.
+    #[serde(default)]
+    pub missing_policy: DatabaseMissingPolicy,
 }
 
 /// Environment tags an OdooInstance as production or staging.  Used by:

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -28,6 +28,12 @@ pub trait PostgresManager: Send + Sync {
 
     async fn delete_role(&self, pg: &PostgresClusterConfig, username: &str) -> Result<()>;
 
+    /// Returns whether a database with `db_name` exists on the cluster.
+    /// Distinguishes "definitely absent" (`Ok(false)`) from "cannot reach
+    /// cluster" (`Err(_)`) so callers can act on the former without
+    /// false-positive flips on transient outages.
+    async fn database_exists(&self, pg: &PostgresClusterConfig, db_name: &str) -> Result<bool>;
+
     /// Ensure the `report.url` system parameter in the Odoo database points to
     /// the in-cluster web service so that cron-triggered report generation can
     /// reach the wkhtmltopdf endpoint.
@@ -176,6 +182,26 @@ impl PostgresManager for PgPostgresManager {
         Ok(())
     }
 
+    async fn database_exists(&self, pg: &PostgresClusterConfig, db_name: &str) -> Result<bool> {
+        let connstr = format!(
+            "host={} port={} user={} password={} dbname=postgres",
+            pg.host, pg.port, pg.admin_user, pg.admin_password
+        );
+        let (client, connection) = tokio_postgres::connect(&connstr, NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                warn!("postgres connection error: {e}");
+            }
+        });
+        let row = client
+            .query_one(
+                "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+                &[&db_name],
+            )
+            .await?;
+        Ok(row.get(0))
+    }
+
     async fn detect_server_major_version(&self, pg: &PostgresClusterConfig) -> Result<u32> {
         let connstr = format!(
             "host={} port={} user={} password={} dbname=postgres",
@@ -212,6 +238,9 @@ impl PostgresManager for NoopPostgresManager {
     }
     async fn delete_role(&self, _: &PostgresClusterConfig, _: &str) -> Result<()> {
         Ok(())
+    }
+    async fn database_exists(&self, _: &PostgresClusterConfig, _: &str) -> Result<bool> {
+        Ok(true)
     }
     async fn ensure_report_url(
         &self,

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -129,6 +129,7 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
             database: db_name.map(|n| DatabaseSpec {
                 cluster: None,
                 name: Some(n.to_string()),
+                missing_policy: Default::default(),
             }),
             init: Default::default(),
             environment: Default::default(),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -347,6 +347,8 @@ fn test_context(client: Client) -> Arc<Context> {
 pub struct MockPostgresManager {
     // username -> error message to return from delete_role
     delete_role_failures: RwLock<HashMap<String, String>>,
+    // db_name -> "exists?" override. Absent → default behavior (exists=true).
+    database_exists_override: RwLock<HashMap<String, bool>>,
 }
 
 impl MockPostgresManager {
@@ -362,6 +364,24 @@ impl MockPostgresManager {
     #[allow(dead_code)]
     pub fn clear_delete_role_failure(&self, username: &str) {
         self.delete_role_failures.write().unwrap().remove(username);
+    }
+
+    /// Force `database_exists(db_name)` to return the supplied bool. Used by
+    /// tests that drive the operator's "DB missing" reaction without a real
+    /// PG cluster.
+    pub fn set_database_exists(&self, db_name: &str, exists: bool) {
+        self.database_exists_override
+            .write()
+            .unwrap()
+            .insert(db_name.to_string(), exists);
+    }
+
+    #[allow(dead_code)]
+    pub fn clear_database_exists_override(&self, db_name: &str) {
+        self.database_exists_override
+            .write()
+            .unwrap()
+            .remove(db_name);
     }
 }
 
@@ -382,6 +402,16 @@ impl PostgresManager for MockPostgresManager {
             return Err(Error::config(msg));
         }
         Ok(())
+    }
+
+    async fn database_exists(&self, _: &PostgresClusterConfig, db_name: &str) -> PgResult<bool> {
+        Ok(self
+            .database_exists_override
+            .read()
+            .unwrap()
+            .get(db_name)
+            .copied()
+            .unwrap_or(true))
     }
 
     async fn ensure_report_url(
@@ -548,6 +578,28 @@ pub async fn fake_job_failed(client: &Client, ns: &str, job_name: &str) {
     )
     .await
     .expect("failed to patch job status (failure)");
+}
+
+/// Patch a benign annotation on the OdooInstance to trigger a reconcile
+/// without changing meaningful state. Use in tests that need the
+/// controller to wake up after some out-of-band change (e.g. a mock fault
+/// injection) that wouldn't otherwise fire a watch event.
+pub async fn touch_instance(client: &Client, ns: &str, name: &str) {
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), ns);
+    let patch = json!({
+        "metadata": {
+            "annotations": {
+                "bemade.org/test-tick": chrono::Utc::now().to_rfc3339(),
+            }
+        }
+    });
+    api.patch(
+        name,
+        &PatchParams::apply(FIELD_MANAGER),
+        &Patch::Merge(&patch),
+    )
+    .await
+    .expect("failed to touch instance");
 }
 
 /// Patch the OdooInstance spec (e.g. replicas).

--- a/tests/integration/database_missing_policy.rs
+++ b/tests/integration/database_missing_policy.rs
@@ -1,0 +1,162 @@
+//! Issue #119, part D — when the per-instance database is observed missing
+//! while `status.dbInitialized == true`, the operator's reaction depends on
+//! `spec.database.missingPolicy`:
+//!
+//!   * `Recreate` — auto-flip `dbInitialized` to false so the state machine
+//!     drives back to Uninitialized and the auto-init path recreates the DB.
+//!   * `Ignore` (default) — publish a Warning event but do not flip; humans
+//!     decide whether to restore the DB or trigger a re-init.
+
+use kube::api::{Api, PostParams};
+use serde_json::json;
+
+use super::common::*;
+use odoo_operator::crd::odoo_init_job::OdooInitJob;
+use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
+
+/// Create an OdooInstance with auto-init enabled, an explicit db name (so
+/// the test doesn't need to derive it from the UID), and the requested
+/// missing-policy value.
+async fn create_instance(name: &str, ns: &str, client: &kube::Client, db_name: &str, policy: &str) {
+    let api: Api<OdooInstance> = Api::namespaced(client.clone(), ns);
+    let inst: OdooInstance = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooInstance",
+        "metadata": { "name": name, "namespace": ns },
+        "spec": {
+            "replicas": 1,
+            "cron": { "replicas": 1 },
+            "adminPassword": "admin",
+            "image": "odoo:18.0",
+            "ingress": {
+                "hosts": ["test.example.com"],
+                "issuer": "letsencrypt",
+                "class": "nginx",
+            },
+            "filestore": {
+                "storageSize": "1Gi",
+                "storageClass": "standard",
+            },
+            "database": {
+                "name": db_name,
+                "missingPolicy": policy,
+            },
+            "init": {
+                "modules": ["base"],
+            },
+        }
+    }))
+    .unwrap();
+    api.create(&PostParams::default(), &inst)
+        .await
+        .expect("failed to create OdooInstance");
+}
+
+/// Drive a freshly-created instance through init → Running with
+/// dbInitialized=true.
+async fn run_to_running(c: &kube::Client, ns: &str, name: &str) -> tokio::task::JoinHandle<()> {
+    let init_job_name = format!("{name}-auto-init");
+    let k8s_job = wait_for_k8s_job_name::<OdooInitJob>(c, ns, &init_job_name).await;
+    fake_job_succeeded(c, ns, &k8s_job).await;
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Starting).await,
+        "expected Starting after init job success"
+    );
+    fake_deployment_ready(c, ns, name, 1).await;
+    let handle = keep_deployment_ready(c.clone(), ns.into(), name.into(), 1);
+    assert!(
+        wait_for_phase(c, ns, name, OdooInstancePhase::Running).await,
+        "expected Running"
+    );
+    handle
+}
+
+/// `missingPolicy: Recreate` — once the operator observes the DB is gone,
+/// it must flip `status.dbInitialized` to false so the state machine
+/// auto-triggers a fresh init job.
+#[tokio::test]
+async fn recreate_policy_flips_db_initialized_when_database_missing() -> anyhow::Result<()> {
+    let ctx = TestContext::new_ns().await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let name = "test-dbmissing-recreate";
+    let db_name = "odoo_test_dbmissing_recreate";
+
+    create_instance(name, ns, c, db_name, "Recreate").await;
+    let _ready = run_to_running(c, ns, name).await;
+
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    assert_eq!(
+        instances
+            .get_status(name)
+            .await?
+            .status
+            .map(|s| s.db_initialized),
+        Some(true),
+        "precondition: dbInitialized should be true after init"
+    );
+
+    // Simulate the DB getting dropped out-of-band. In production a missing
+    // DB causes the Odoo pods to crash, which fires deployment-status
+    // watch events that wake the reconciler. envtest has no kubelet, so
+    // we manually nudge the controller via `touch_instance`.
+    mock_pg().set_database_exists(db_name, false);
+    touch_instance(c, ns, name).await;
+
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let api = instances.clone();
+            async move {
+                api.get_status(name)
+                    .await
+                    .ok()
+                    .and_then(|i| i.status)
+                    .map(|s| !s.db_initialized)
+                    .unwrap_or(false)
+            }
+        })
+        .await,
+        "expected status.dbInitialized to flip to false under Recreate policy"
+    );
+
+    // Restore the mock so the next reconcile doesn't keep flipping (and
+    // pollute the shared mock state if a later test reuses this db_name).
+    mock_pg().set_database_exists(db_name, true);
+    Ok(())
+}
+
+/// Default (`Ignore`) policy — the operator must NOT flip dbInitialized
+/// when the DB goes missing. Recovery is operator-external.
+#[tokio::test]
+async fn ignore_policy_does_not_flip_db_initialized_when_database_missing() -> anyhow::Result<()> {
+    let ctx = TestContext::new_ns().await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let name = "test-dbmissing-ignore";
+    let db_name = "odoo_test_dbmissing_ignore";
+
+    create_instance(name, ns, c, db_name, "Ignore").await;
+    let _ready = run_to_running(c, ns, name).await;
+
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+
+    mock_pg().set_database_exists(db_name, false);
+    touch_instance(c, ns, name).await;
+
+    // Poll for ~3s — long enough that a Recreate-style flip would have
+    // fired. dbInitialized must remain true throughout.
+    for _ in 0..6 {
+        tokio::time::sleep(POLL).await;
+        let still_initialized = instances
+            .get_status(name)
+            .await?
+            .status
+            .map(|s| s.db_initialized)
+            .unwrap_or(false);
+        assert!(
+            still_initialized,
+            "Ignore policy should not flip dbInitialized; saw it flip during wait"
+        );
+    }
+
+    mock_pg().set_database_exists(db_name, true);
+    Ok(())
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod auto_init;
 mod backup_job;
 mod bootstrap;
 mod child_resources;
+mod database_missing_policy;
 mod degraded;
 mod environment_labels;
 mod finalizer;

--- a/tests/postgres_harness/database_exists.rs
+++ b/tests/postgres_harness/database_exists.rs
@@ -1,0 +1,58 @@
+//! Tests for `PostgresManager::database_exists`.
+//!
+//! The operator's "DB missing" auto-recovery (issue #119, part D) is built
+//! on `database_exists` returning `Ok(false)` for a definitely-absent DB.
+//! The bare query `SELECT 1 FROM pg_database WHERE datname = $1` returns
+//! an empty result set for absent — this test verifies the production
+//! impl uses the `SELECT EXISTS(...)` form that collapses both cases into
+//! a clean bool, so callers can confidently distinguish "no" from
+//! "unknown" (which is `Err(_)`).
+
+use odoo_operator::postgres::PostgresManager;
+
+use super::harness::{admin_client, cluster_config, pg_manager};
+
+async fn cleanup(db_name: &str) {
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{db_name}""#))
+        .await;
+}
+
+#[tokio::test]
+async fn database_exists_returns_ok_true_when_present() -> anyhow::Result<()> {
+    let db_name = "odoo_test_db_exists_present";
+    cleanup(db_name).await;
+
+    let c = admin_client().await;
+    c.simple_query(&format!(r#"CREATE DATABASE "{db_name}""#))
+        .await?;
+
+    let result = pg_manager()
+        .database_exists(&cluster_config(), db_name)
+        .await?;
+    assert!(
+        result,
+        "expected database_exists to be true for a created DB"
+    );
+
+    cleanup(db_name).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn database_exists_returns_ok_false_when_absent() -> anyhow::Result<()> {
+    let db_name = "odoo_test_db_exists_absent";
+    cleanup(db_name).await; // make sure it's not there
+
+    let result = pg_manager()
+        .database_exists(&cluster_config(), db_name)
+        .await?;
+    assert!(
+        !result,
+        "expected database_exists to be Ok(false) for an absent DB; \
+         got Ok(true) instead — caller cannot distinguish 'absent' from 'present'"
+    );
+
+    Ok(())
+}

--- a/tests/postgres_harness/main.rs
+++ b/tests/postgres_harness/main.rs
@@ -6,5 +6,6 @@
 
 mod harness;
 
+mod database_exists;
 mod delete_role_errors;
 mod ensure_role;


### PR DESCRIPTION
## Summary

Part D (and final part) of #119.

Adds `spec.database.missingPolicy` (enum, default `Ignore`) controlling how the operator reacts when the per-instance database is observed missing post-initialization (e.g. dropped by a PG admin out-of-band):

| Policy | Behavior |
|---|---|
| `Ignore` *(default)* | Publish a `Warning` event \`DatabaseMissing\` and leave `dbInitialized` alone. Operator-external recovery: human restores the DB or manually flips `dbInitialized=false` to trigger re-init. **Safe default**: never wipes data during admin maintenance windows. |
| `Recreate` | Auto-flip `dbInitialized=false` and delete the prior auto-init CR so the state machine drives back to `Uninitialized` and the `spec.init` auto-init path recreates the DB. Opt in only when the operator exclusively owns DB lifecycle. |

## Detection design

New \`PostgresManager::database_exists(cluster, db_name) -> Result<bool>\` using \`SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = \$1)\`. The `EXISTS` wrapper collapses absent/present into a clean bool so callers can distinguish three cases:

- `Ok(true)` — DB present
- `Ok(false)` — DB definitely absent
- `Err(_)` — cluster unreachable / probe failed

The reconciler **trusts `Ok(false)`** and **ignores `Err`** — avoids false-positive flips during transient PG outages. The only way to trigger an erroneous Recreate is for PG to successfully return "DB does not exist" for a DB that actually exists, which doesn't happen.

The probe runs from \`reconcile_instance\` after gather, guarded by `dbInitialized=true && init_job absent` so it's a no-op during initial provisioning and during in-flight re-init.

## Test infrastructure

- **docker-pg harness**: \`tests/postgres_harness/database_exists.rs\` — round-trips against a real PG container to validate the SELECT EXISTS contract.
- **envtest harness**: \`MockPostgresManager.set_database_exists(db_name, exists)\` for per-test fault injection. New \`touch_instance\` helper to trigger a reconcile after out-of-band state changes (envtest has no kubelet to fire deployment-status watch events the way production would after a pod crash-loops on missing DB).
- **envtest tests**: \`database_missing_policy.rs\` covers both policy paths.

## Closes #119

This is the last part. Summary across all 4 PRs:

- **A** (#121) — finalizer retained on cleanup failure → no more silent orphans
- **C** (#123) — \`ensure_role\` always resets password → same-name re-create works
- **E** (#123) — surface real PG error text in events/logs
- **D** (this PR) — observe missing DB; configurable per-instance reaction

Out of scope: part **B** (robust \`delete_role\` with REASSIGN OWNED / connection termination). The new docker-pg harness is set up for it; the failure mode it addresses is "delete stuck in Terminating" — operational concern, not correctness. Worth its own PR.

## Test plan

- [x] Red/green TDD on both policy paths
- [x] envtest 44/44 green
- [x] postgres harness 4/4 green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] CRDs + helm chart regenerated
- [x] CI green