### PR TITLE
feat: inject spec.extraEnv / spec.extraEnvFrom into instance pods (#125)

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -621,6 +621,118 @@ spec:
                 - Staging
                 - Production
                 type: string
+              extraEnv:
+                description: Extra environment variables injected into the instance's Odoo containers (web, cron) and the Odoo steps of its jobs (init, upgrade, neutralize). Use a plain `value`, or `valueFrom.secretKeyRef` / `configMapKeyRef` / `fieldRef` to source from a Secret/ConfigMap without putting the value in the DB. Merged after the operator's own env (last-wins by `name`), so a user entry overrides an operator default of the same name — avoid the operator's own names (`PGDATABASE`, `ODOO_RC`, …). Operator tooling containers (the `mc` backup uploader, pg-client clone/restore steps) are deliberately NOT touched, so this can't clobber a backup destination's own credentials.
+                items:
+                  description: EnvVar represents an environment variable present in a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          - name
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes, optional for env vars'
+                              type: string
+                            divisor:
+                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              type: string
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              extraEnvFrom:
+                description: 'Extra `envFrom` sources (`secretRef` / `configMapRef`) injected into the same Odoo containers as `extraEnv`. Note this has the *opposite* override behavior from `extra_env`: Kubernetes always lets explicit container `env` (the operator''s own vars and anything in `extra_env`) win over `envFrom` on a name collision, regardless of order. So `extra_env_from` can add new keys or override *other* `envFrom` sources, but it cannot override an operator env var — use `extra_env` for that.'
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      required:
+                      - name
+                      type: object
+                    prefix:
+                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
               filestore:
                 description: FilestoreSpec defines persistent storage for the Odoo filestore.
                 nullable: true
@@ -742,6 +854,20 @@ spec:
                     type: string
                 required:
                 - name
+                type: object
+              readOnlySqlAccess:
+                description: Opt in to a read-only Postgres role for this instance. When enabled the operator provisions `<pg_user>_ro` with SELECT-only privileges on the tenant DB, stores the password in a k8s Secret, and tears everything down on disable or instance deletion. Default is absent / disabled — existing instances are unaffected.
+                nullable: true
+                properties:
+                  connectionLimit:
+                    default: 5
+                    description: Maximum number of simultaneous connections for the read-only role. Defaults to 5.
+                    format: int32
+                    type: integer
+                  enabled:
+                    default: false
+                    description: Enable read-only SQL access for this instance.  Defaults to `false`.
+                    type: boolean
                 type: object
               replicas:
                 default: 1

--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -41,8 +41,8 @@ use crate::helpers::{
 use crate::postgres::PostgresClusterConfig;
 
 use super::helpers::{
-    cron_depl_name, env, image_pull_secrets, odoo_security_context, odoo_volume_mounts,
-    odoo_volumes, secret_env, FIELD_MANAGER,
+    apply_extra_env, cron_depl_name, env, image_pull_secrets, odoo_security_context,
+    odoo_volume_mounts, odoo_volumes, secret_env, FIELD_MANAGER,
 };
 use super::odoo_instance::Context;
 
@@ -775,52 +775,55 @@ pub async fn ensure_deployment(
                     },
                     security_context: Some(odoo_security_context()),
                     volumes: Some(odoo_volumes(name)),
-                    containers: vec![Container {
-                        name: format!("odoo-{name}"),
-                        image: Some(image.to_string()),
-                        image_pull_policy: Some("IfNotPresent".to_string()),
-                        command: Some(vec![
-                            "/entrypoint.sh".to_string(),
-                            "odoo".to_string(),
-                            "--max-cron-threads".to_string(),
-                            "0".to_string(),
-                        ]),
-                        ports: Some(vec![
-                            ContainerPort {
-                                name: Some("http".to_string()),
-                                container_port: 8069,
-                                ..Default::default()
-                            },
-                            ContainerPort {
-                                name: Some("websocket".to_string()),
-                                container_port: 8072,
-                                ..Default::default()
-                            },
-                        ]),
-                        env: Some(pg_env),
-                        volume_mounts: Some(odoo_volume_mounts()),
-                        resources: instance.spec.resources.clone(),
-                        startup_probe: Some(Probe {
-                            initial_delay_seconds: Some(5),
-                            period_seconds: Some(10),
-                            timeout_seconds: Some(5),
-                            failure_threshold: Some(30),
-                            ..make_http_probe(probe_startup)
-                        }),
-                        liveness_probe: Some(Probe {
-                            period_seconds: Some(15),
-                            timeout_seconds: Some(5),
-                            failure_threshold: Some(3),
-                            ..make_http_probe(probe_liveness)
-                        }),
-                        readiness_probe: Some(Probe {
-                            period_seconds: Some(10),
-                            timeout_seconds: Some(5),
-                            failure_threshold: Some(3),
-                            ..make_http_probe(probe_readiness)
-                        }),
-                        ..Default::default()
-                    }],
+                    containers: vec![apply_extra_env(
+                        Container {
+                            name: format!("odoo-{name}"),
+                            image: Some(image.to_string()),
+                            image_pull_policy: Some("IfNotPresent".to_string()),
+                            command: Some(vec![
+                                "/entrypoint.sh".to_string(),
+                                "odoo".to_string(),
+                                "--max-cron-threads".to_string(),
+                                "0".to_string(),
+                            ]),
+                            ports: Some(vec![
+                                ContainerPort {
+                                    name: Some("http".to_string()),
+                                    container_port: 8069,
+                                    ..Default::default()
+                                },
+                                ContainerPort {
+                                    name: Some("websocket".to_string()),
+                                    container_port: 8072,
+                                    ..Default::default()
+                                },
+                            ]),
+                            env: Some(pg_env),
+                            volume_mounts: Some(odoo_volume_mounts()),
+                            resources: instance.spec.resources.clone(),
+                            startup_probe: Some(Probe {
+                                initial_delay_seconds: Some(5),
+                                period_seconds: Some(10),
+                                timeout_seconds: Some(5),
+                                failure_threshold: Some(30),
+                                ..make_http_probe(probe_startup)
+                            }),
+                            liveness_probe: Some(Probe {
+                                period_seconds: Some(15),
+                                timeout_seconds: Some(5),
+                                failure_threshold: Some(3),
+                                ..make_http_probe(probe_liveness)
+                            }),
+                            readiness_probe: Some(Probe {
+                                period_seconds: Some(10),
+                                timeout_seconds: Some(5),
+                                failure_threshold: Some(3),
+                                ..make_http_probe(probe_readiness)
+                            }),
+                            ..Default::default()
+                        },
+                        instance,
+                    )],
                     ..Default::default()
                 }),
             },
@@ -1065,42 +1068,45 @@ pub async fn ensure_cron_deployment(
                             include_str!("../../scripts/cron_liveness_probe.py").to_string(),
                         ];
 
-                        Container {
-                            name: format!("odoo-cron-{name}"),
-                            image: Some(image.to_string()),
-                            image_pull_policy: Some("IfNotPresent".to_string()),
-                            command: Some(vec![
-                                "/entrypoint.sh".to_string(),
-                                "odoo".to_string(),
-                                "--workers".to_string(),
-                                "0".to_string(),
-                                "--no-http".to_string(),
-                            ]),
-                            env: Some(pg_env),
-                            volume_mounts: Some(odoo_volume_mounts()),
-                            resources: instance.spec.cron.resources.clone(),
-                            startup_probe: Some(Probe {
-                                initial_delay_seconds: Some(5),
-                                period_seconds: Some(10),
-                                timeout_seconds: Some(5),
-                                failure_threshold: Some(30),
-                                exec: Some(ExecAction {
-                                    command: Some(startup_cmd),
+                        apply_extra_env(
+                            Container {
+                                name: format!("odoo-cron-{name}"),
+                                image: Some(image.to_string()),
+                                image_pull_policy: Some("IfNotPresent".to_string()),
+                                command: Some(vec![
+                                    "/entrypoint.sh".to_string(),
+                                    "odoo".to_string(),
+                                    "--workers".to_string(),
+                                    "0".to_string(),
+                                    "--no-http".to_string(),
+                                ]),
+                                env: Some(pg_env),
+                                volume_mounts: Some(odoo_volume_mounts()),
+                                resources: instance.spec.cron.resources.clone(),
+                                startup_probe: Some(Probe {
+                                    initial_delay_seconds: Some(5),
+                                    period_seconds: Some(10),
+                                    timeout_seconds: Some(5),
+                                    failure_threshold: Some(30),
+                                    exec: Some(ExecAction {
+                                        command: Some(startup_cmd),
+                                    }),
+                                    ..Default::default()
+                                }),
+                                liveness_probe: Some(Probe {
+                                    initial_delay_seconds: Some(300),
+                                    period_seconds: Some(30),
+                                    timeout_seconds: Some(5),
+                                    failure_threshold: Some(3),
+                                    exec: Some(ExecAction {
+                                        command: Some(liveness_cmd),
+                                    }),
+                                    ..Default::default()
                                 }),
                                 ..Default::default()
-                            }),
-                            liveness_probe: Some(Probe {
-                                initial_delay_seconds: Some(300),
-                                period_seconds: Some(30),
-                                timeout_seconds: Some(5),
-                                failure_threshold: Some(3),
-                                exec: Some(ExecAction {
-                                    command: Some(liveness_cmd),
-                                }),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        }
+                            },
+                            instance,
+                        )
                     }],
                     ..Default::default()
                 }),

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -193,6 +193,51 @@ pub fn secret_env(env_name: &str, secret_name: &str, key: &str) -> EnvVar {
     }
 }
 
+/// Merge two `EnvVar` slices, last-wins by `name`. `base` order is preserved;
+/// an `extra` entry whose `name` matches a base entry overrides it in place,
+/// and new names are appended. Used to layer an instance's `spec.extra_env` on
+/// top of the operator's own env so users can override by name (not by
+/// ordering) without silently clobbering reserved operator vars.
+pub fn merge_extra_env(base: &[EnvVar], extra: &[EnvVar]) -> Vec<EnvVar> {
+    let mut out: Vec<EnvVar> = base.to_vec();
+    for e in extra {
+        if let Some(slot) = out.iter_mut().find(|x| x.name == e.name) {
+            *slot = e.clone();
+        } else {
+            out.push(e.clone());
+        }
+    }
+    out
+}
+
+/// Layer an instance's `spec.extra_env` / `spec.extra_env_from` onto a single
+/// container and return it: `extra_env` is merged last-wins by `name` over the
+/// container's own env (base order preserved, via [`merge_extra_env`]), and
+/// `extra_env_from` is appended to its `envFrom`. A no-op (container returned
+/// untouched) when both are empty, so instances that set neither produce byte-
+/// identical pods to before — no spurious server-side-apply diffs.
+///
+/// Apply this ONLY to containers that run the Odoo image and execute Odoo: the
+/// web and cron Deployments and the init / upgrade / neutralize job steps. The
+/// operator's own tooling containers — the `mc` backup uploader/downloader, the
+/// pg-client `clone-db` / `load-db` steps, the rsync filestore mover — must be
+/// left untouched: their env carries operator-managed credentials (e.g. the
+/// backup *destination's* `AWS_*` / `S3_*` keys) that a last-wins user override
+/// would otherwise clobber, breaking backups when the DR target is a separate
+/// account.
+pub fn apply_extra_env(mut c: Container, instance: &OdooInstance) -> Container {
+    if !instance.spec.extra_env.is_empty() {
+        let base = c.env.take().unwrap_or_default();
+        c.env = Some(merge_extra_env(&base, &instance.spec.extra_env));
+    }
+    if !instance.spec.extra_env_from.is_empty() {
+        let mut ef = c.env_from.take().unwrap_or_default();
+        ef.extend(instance.spec.extra_env_from.iter().cloned());
+        c.env_from = Some(ef);
+    }
+    c
+}
+
 /// Get the cron deployment name for an odoo instance
 pub fn cron_depl_name(instance: &OdooInstance) -> String {
     instance.name_any().to_string() + "-cron"
@@ -351,5 +396,56 @@ impl OdooJobBuilder {
             }),
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_extra_env;
+    use k8s_openapi::api::core::v1::EnvVar;
+
+    fn ev(name: &str, value: &str) -> EnvVar {
+        EnvVar {
+            name: name.into(),
+            value: Some(value.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_base_empty_extra() {
+        assert!(merge_extra_env(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn empty_base_returns_extra() {
+        let extra = vec![ev("A", "1"), ev("B", "2")];
+        assert_eq!(merge_extra_env(&[], &extra), extra);
+    }
+
+    #[test]
+    fn empty_extra_returns_base() {
+        let base = vec![ev("PGDATABASE", "db")];
+        assert_eq!(merge_extra_env(&base, &[]), base);
+    }
+
+    #[test]
+    fn extra_overrides_base_in_place_and_appends_new() {
+        let base = vec![ev("PGDATABASE", "db"), ev("KEEP", "k")];
+        let extra = vec![ev("PGDATABASE", "override"), ev("NEW", "n")];
+        let out = merge_extra_env(&base, &extra);
+        // Order preserved: overridden entry stays in its base slot; new appended.
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], ev("PGDATABASE", "override"));
+        assert_eq!(out[1], ev("KEEP", "k"));
+        assert_eq!(out[2], ev("NEW", "n"));
+    }
+
+    #[test]
+    fn multiple_overlaps_last_wins_preserving_order() {
+        let base = vec![ev("A", "1"), ev("B", "2"), ev("C", "3")];
+        let extra = vec![ev("B", "B2"), ev("A", "A2")];
+        let out = merge_extra_env(&base, &extra);
+        assert_eq!(out, vec![ev("A", "A2"), ev("B", "B2"), ev("C", "3")]);
     }
 }

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -24,8 +24,8 @@ use crate::{controller::child_resources, crd::odoo_instance::OdooInstance};
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, controller_owner_ref, cron_depl_name, env, odoo_volume_mounts, pg_tools_image,
-    staging_mail_env_vars, OdooJobBuilder, FIELD_MANAGER,
+    apply_extra_env, cm_env, controller_owner_ref, cron_depl_name, env, odoo_volume_mounts,
+    pg_tools_image, staging_mail_env_vars, OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 use crate::helpers::sha256_hex;
@@ -814,18 +814,23 @@ fn build_neutralize_job(
         // exits) — that's the spec-drift retry path's responsibility, gated
         // on `neutralizeJobImageHash`.
         .backoff_limit(5)
-        .containers(vec![Container {
-            name: "neutralize".into(),
-            image: Some(image.into()),
-            command: Some(vec![
-                "/bin/bash".into(),
-                "-c".into(),
-                NEUTRALIZE_SCRIPT.into(),
-            ]),
-            env: Some(envs),
-            volume_mounts: Some(odoo_volume_mounts()),
-            ..Default::default()
-        }])
+        // Neutralize runs the Odoo image; the db/filestore clone steps (pg-client
+        // and rsync tooling) deliberately do not get the instance's extra env.
+        .containers(vec![apply_extra_env(
+            Container {
+                name: "neutralize".into(),
+                image: Some(image.into()),
+                command: Some(vec![
+                    "/bin/bash".into(),
+                    "-c".into(),
+                    NEUTRALIZE_SCRIPT.into(),
+                ]),
+                env: Some(envs),
+                volume_mounts: Some(odoo_volume_mounts()),
+                ..Default::default()
+            },
+            instance,
+        )])
         .build()
 }
 

--- a/src/controller/states/initializing.rs
+++ b/src/controller/states/initializing.rs
@@ -13,7 +13,9 @@ use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::FIELD_MANAGER;
 use crate::controller::state_machine::scale_deployment;
 
-use crate::controller::helpers::{cron_depl_name, odoo_volume_mounts, OdooJobBuilder};
+use crate::controller::helpers::{
+    apply_extra_env, cron_depl_name, odoo_volume_mounts, OdooJobBuilder,
+};
 
 /// Initializing: init job is running, deployment must be scaled down.
 /// On entry: scale to 0, create the K8s Job if the CRD hasn't started one
@@ -118,14 +120,17 @@ pub fn build_init_job(
                     odoo_args,
                 )
             };
-            Container {
-                name: "init".to_string(),
-                image: Some(image.to_string()),
-                command: Some(command),
-                args: Some(args),
-                volume_mounts: Some(odoo_volume_mounts()),
-                ..Default::default()
-            }
+            apply_extra_env(
+                Container {
+                    name: "init".to_string(),
+                    image: Some(image.to_string()),
+                    command: Some(command),
+                    args: Some(args),
+                    volume_mounts: Some(odoo_volume_mounts()),
+                    ..Default::default()
+                },
+                instance,
+            )
         }])
         .build()
 }

--- a/src/controller/states/restoring.rs
+++ b/src/controller/states/restoring.rs
@@ -18,8 +18,8 @@ use crate::notify;
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cm_env, cron_depl_name, env, pg_tools_image, staging_mail_env_vars, OdooJobBuilder,
-    FIELD_MANAGER,
+    apply_extra_env, cm_env, cron_depl_name, env, pg_tools_image, staging_mail_env_vars,
+    OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 
@@ -235,17 +235,23 @@ impl State for Restoring {
                 env("DB_NAME", db.clone()),
             ];
             neut_env.extend(staging_mail_env_vars(instance, &ctx.defaults));
-            Container {
-                name: "neutralize".into(),
-                image: Some(odoo_image.into()),
-                command: Some(vec![
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    NEUTRALIZE_SCRIPT.into(),
-                ]),
-                env: Some(neut_env),
-                ..Default::default()
-            }
+            // Neutralize runs the Odoo image; layer the instance's extra env on
+            // (the `noop` alpine fallback below and the pg/mc tooling containers
+            // are left untouched — see `apply_extra_env`).
+            apply_extra_env(
+                Container {
+                    name: "neutralize".into(),
+                    image: Some(odoo_image.into()),
+                    command: Some(vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        NEUTRALIZE_SCRIPT.into(),
+                    ]),
+                    env: Some(neut_env),
+                    ..Default::default()
+                },
+                instance,
+            )
         } else {
             Container {
                 name: "noop".into(),

--- a/src/controller/states/upgrading.rs
+++ b/src/controller/states/upgrading.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use super::{Context, ReconcileSnapshot, State};
 use crate::controller::helpers::{
-    cron_depl_name, odoo_volume_mounts, OdooJobBuilder, FIELD_MANAGER,
+    apply_extra_env, cron_depl_name, odoo_volume_mounts, OdooJobBuilder, FIELD_MANAGER,
 };
 use crate::controller::state_machine::scale_deployment;
 use crate::crd::odoo_instance::OdooInstance;
@@ -74,14 +74,17 @@ impl State for Upgrading {
 
         let job = OdooJobBuilder::new(&format!("{crd_name}-"), &ns, upgrade_job, instance)
             .active_deadline(3600)
-            .containers(vec![Container {
-                name: "odoo-upgrade".into(),
-                image: Some(image.into()),
-                command: Some(vec!["/entrypoint.sh".into(), "odoo".into()]),
-                args: Some(args),
-                volume_mounts: Some(odoo_volume_mounts()),
-                ..Default::default()
-            }])
+            .containers(vec![apply_extra_env(
+                Container {
+                    name: "odoo-upgrade".into(),
+                    image: Some(image.into()),
+                    command: Some(vec!["/entrypoint.sh".into(), "odoo".into()]),
+                    args: Some(args),
+                    volume_mounts: Some(odoo_volume_mounts()),
+                    ..Default::default()
+                },
+                instance,
+            )])
             .build();
 
         let jobs_api: Api<Job> = Api::namespaced(client.clone(), &ns);

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -1,4 +1,6 @@
-use k8s_openapi::api::core::v1::{Affinity, ResourceRequirements, Toleration};
+use k8s_openapi::api::core::v1::{
+    Affinity, EnvFromSource, EnvVar, ResourceRequirements, Toleration,
+};
 use kube::{CELSchema, CustomResource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -376,6 +378,29 @@ pub struct OdooInstanceSpec {
     /// Default is absent / disabled — existing instances are unaffected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only_sql_access: Option<ReadOnlySqlAccessSpec>,
+
+    /// Extra environment variables injected into the instance's Odoo containers
+    /// (web, cron) and the Odoo steps of its jobs (init, upgrade, neutralize).
+    /// Use a plain `value`, or `valueFrom.secretKeyRef` / `configMapKeyRef` /
+    /// `fieldRef` to source from a Secret/ConfigMap without putting the value in
+    /// the DB. Merged after the operator's own env (last-wins by `name`), so a
+    /// user entry overrides an operator default of the same name — avoid the
+    /// operator's own names (`PGDATABASE`, `ODOO_RC`, …). Operator tooling
+    /// containers (the `mc` backup uploader, pg-client clone/restore steps) are
+    /// deliberately NOT touched, so this can't clobber a backup destination's
+    /// own credentials.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_env: Vec<EnvVar>,
+
+    /// Extra `envFrom` sources (`secretRef` / `configMapRef`) injected into the
+    /// same Odoo containers as `extraEnv`. Note this has the *opposite*
+    /// override behavior from `extra_env`: Kubernetes always lets explicit
+    /// container `env` (the operator's own vars and anything in `extra_env`) win
+    /// over `envFrom` on a name collision, regardless of order. So
+    /// `extra_env_from` can add new keys or override *other* `envFrom` sources,
+    /// but it cannot override an operator env var — use `extra_env` for that.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_env_from: Vec<EnvFromSource>,
 }
 
 fn default_replicas() -> i32 {

--- a/tests/controller_helpers_test.rs
+++ b/tests/controller_helpers_test.rs
@@ -44,6 +44,8 @@ fn test_instance(name: &str, pull_secret: Option<&str>) -> OdooInstance {
             affinity: None,
             tolerations: vec![],
             read_only_sql_access: None,
+            extra_env: vec![],
+            extra_env_from: vec![],
         },
         status: None,
     }

--- a/tests/extra_env_injection_test.rs
+++ b/tests/extra_env_injection_test.rs
@@ -1,0 +1,169 @@
+//! Tests for `apply_extra_env` — the `spec.extraEnv` / `spec.extraEnvFrom`
+//! layering applied to an instance's Odoo containers (web, cron, init,
+//! upgrade, neutralize). Operator-tooling containers (the `mc` backup
+//! uploader, pg-client clone/restore steps) are deliberately NOT wrapped at
+//! their call sites, so this helper is the single place the merge semantics
+//! live; the scoping is enforced by where it is (and is not) called.
+
+use k8s_openapi::api::core::v1::{
+    Container, EnvFromSource, EnvVar, EnvVarSource, SecretEnvSource, SecretKeySelector,
+};
+use kube::api::ObjectMeta;
+
+use odoo_operator::controller::helpers::apply_extra_env;
+use odoo_operator::crd::odoo_instance::{CronSpec, IngressSpec, OdooInstance, OdooInstanceSpec};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn ev(name: &str, value: &str) -> EnvVar {
+    EnvVar {
+        name: name.into(),
+        value: Some(value.into()),
+        ..Default::default()
+    }
+}
+
+fn make_instance(extra_env: Vec<EnvVar>, extra_env_from: Vec<EnvFromSource>) -> OdooInstance {
+    OdooInstance {
+        metadata: ObjectMeta {
+            name: Some("inst".to_string()),
+            namespace: Some("test-ns".to_string()),
+            uid: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()),
+            ..Default::default()
+        },
+        spec: OdooInstanceSpec {
+            image: None,
+            image_pull_secret: None,
+            admin_password: "admin".to_string(),
+            replicas: 1,
+            cron: CronSpec::default(),
+            ingress: IngressSpec {
+                hosts: vec!["inst.example.com".to_string()],
+                issuer: None,
+                class: None,
+                gateway_ref: None,
+            },
+            resources: None,
+            filestore: None,
+            config_options: None,
+            database: None,
+            init: Default::default(),
+            environment: Default::default(),
+            production_instance_ref: None,
+            strategy: None,
+            webhook: None,
+            probes: None,
+            affinity: None,
+            tolerations: vec![],
+            read_only_sql_access: None,
+            extra_env,
+            extra_env_from,
+        },
+        status: None,
+    }
+}
+
+fn secret_from(name: &str) -> EnvFromSource {
+    EnvFromSource {
+        secret_ref: Some(SecretEnvSource {
+            name: name.into(),
+            optional: None,
+        }),
+        ..Default::default()
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn noop_when_no_extras_leaves_container_byte_identical() {
+    // A container with no env at all (e.g. the init job) must stay env: None /
+    // env_from: None so server-side apply sees no diff for instances that set
+    // neither field.
+    let c = Container {
+        name: "init".into(),
+        env: None,
+        ..Default::default()
+    };
+    let out = apply_extra_env(c, &make_instance(vec![], vec![]));
+    assert!(out.env.is_none(), "env must stay None when no extra_env");
+    assert!(
+        out.env_from.is_none(),
+        "env_from must stay None when no extra_env_from"
+    );
+}
+
+#[test]
+fn noop_when_no_extras_preserves_existing_env() {
+    let c = Container {
+        name: "odoo".into(),
+        env: Some(vec![ev("PGDATABASE", "db")]),
+        ..Default::default()
+    };
+    let out = apply_extra_env(c, &make_instance(vec![], vec![]));
+    assert_eq!(out.env.unwrap(), vec![ev("PGDATABASE", "db")]);
+}
+
+#[test]
+fn extra_env_merges_last_wins_over_operator_env() {
+    let c = Container {
+        name: "odoo".into(),
+        env: Some(vec![ev("PGDATABASE", "db"), ev("ODOO_RC", "/etc/odoo")]),
+        ..Default::default()
+    };
+    // A plain new var plus an override of an operator-set name.
+    let out = apply_extra_env(
+        c,
+        &make_instance(
+            vec![ev("AWS_ACCESS_KEY_ID", "AKIA"), ev("PGDATABASE", "other")],
+            vec![],
+        ),
+    );
+    let env = out.env.unwrap();
+    // Override lands in the base slot; new var appended; order preserved.
+    assert_eq!(
+        env,
+        vec![
+            ev("PGDATABASE", "other"),
+            ev("ODOO_RC", "/etc/odoo"),
+            ev("AWS_ACCESS_KEY_ID", "AKIA"),
+        ]
+    );
+}
+
+#[test]
+fn extra_env_supports_value_from_secret() {
+    let secret_var = EnvVar {
+        name: "SMTP_PASSWORD".into(),
+        value_from: Some(EnvVarSource {
+            secret_key_ref: Some(SecretKeySelector {
+                name: "smtp-creds".into(),
+                key: "password".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let c = Container {
+        name: "odoo".into(),
+        env: None,
+        ..Default::default()
+    };
+    let out = apply_extra_env(c, &make_instance(vec![secret_var.clone()], vec![]));
+    assert_eq!(out.env.unwrap(), vec![secret_var]);
+}
+
+#[test]
+fn extra_env_from_is_appended_to_existing_env_from() {
+    let pre = secret_from("operator-managed");
+    let user = secret_from("oca-s3-attachments");
+    let c = Container {
+        name: "odoo".into(),
+        env_from: Some(vec![pre.clone()]),
+        ..Default::default()
+    };
+    let out = apply_extra_env(c, &make_instance(vec![], vec![user.clone()]));
+    // Appended after the operator's own sources, preserving order.
+    assert_eq!(out.env_from.unwrap(), vec![pre, user]);
+}

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -159,6 +159,8 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
             affinity: None,
             tolerations: vec![],
             read_only_sql_access: None,
+            extra_env: vec![],
+            extra_env_from: vec![],
         },
         status: None,
     }

--- a/tests/readonly_sql_access_test.rs
+++ b/tests/readonly_sql_access_test.rs
@@ -48,6 +48,8 @@ fn make_instance_with_ro(ro_enabled: bool, connection_limit: i32) -> OdooInstanc
                 enabled: ro_enabled,
                 connection_limit,
             }),
+            extra_env: vec![],
+            extra_env_from: vec![],
         },
         status: None,
     }
@@ -86,6 +88,8 @@ fn make_instance_no_ro() -> OdooInstance {
             affinity: None,
             tolerations: vec![],
             read_only_sql_access: None,
+            extra_env: vec![],
+            extra_env_from: vec![],
         },
         status: None,
     }

--- a/tests/ro_env_injection_test.rs
+++ b/tests/ro_env_injection_test.rs
@@ -44,6 +44,8 @@ fn make_instance(name: &str, ro: Option<ReadOnlySqlAccessSpec>) -> OdooInstance 
             affinity: None,
             tolerations: vec![],
             read_only_sql_access: ro,
+            extra_env: vec![],
+            extra_env_from: vec![],
         },
         status: None,
     }


### PR DESCRIPTION
Proposed implementation for #125. Opening as a concrete starting point rather than a finished design — field naming, scoping, and merge semantics are yours to set; happy to reshape to whatever you prefer.

### What it does
Adds `extraEnv` (`[]EnvVar`) and `extraEnvFrom` (`[]EnvFromSource`) to `OdooInstanceSpec`, using native `k8s_openapi` types (same JsonSchema path as the existing `affinity` / `tolerations`). They are merged into the web and cron containers and every job pod the operator spawns (via `OdooJobBuilder`). A `merge_extra_env` helper layers the user env over the operator's own, last-wins by name (base order preserved); `extraEnvFrom` is appended.

### Scope (deliberately minimal)
Instance-level fields only. Not included, pending your design preference: per-job CRD overrides / `env_inheritance`, and a validating-webhook reserved-name denylist (a fuller design is sketched separately; happy to follow up). Additive — no breaking changes to existing manifests.

### Testing
Unit tests for `merge_extra_env`; verified live on a CloudNativePG / PG17 cluster — `extraEnvFrom` from a `Secret` reaches the web, cron, and init pods. First consumer is OCA `fs_storage` (S3-backed attachments), keeping bucket credentials out of `ir.config_parameter`.