### PR TITLE
ci: run workflow_dispatch build past the skipped release-please job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,6 +58,11 @@ jobs:
   # The per-arch images are stitched into one manifest list by `merge`.
   build-and-publish:
     needs: resolve-ref
+    # Explicit gate: the default success() is poisoned by the skipped
+    # release-please job upstream (GitHub propagates the skip past resolve-ref's
+    # always()), so on workflow_dispatch this job would skip even though
+    # resolve-ref succeeded. Run whenever resolve-ref produced a tag.
+    if: ${{ !cancelled() && needs.resolve-ref.outputs.tag_name != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +127,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: [resolve-ref, build-and-publish]
+    if: ${{ !cancelled() && needs.resolve-ref.outputs.tag_name != '' && needs.build-and-publish.result == 'success' }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -164,6 +170,7 @@ jobs:
   release-chart:
     runs-on: ubuntu-latest
     needs: [resolve-ref, merge]
+    if: ${{ !cancelled() && needs.resolve-ref.outputs.tag_name != '' && needs.merge.result == 'success' }}
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
### Problem
A `workflow_dispatch` (the "(re)publish an existing tag" path) builds nothing: `resolve-ref` runs and outputs the tag, but `build-and-publish`, `merge`, and `release-chart` are **skipped**. Their default `success()` gate is poisoned by the skipped `release-please` job — the skip propagates downstream past `resolve-ref`'s `always()`.

### Fix
Gate those three jobs on `!cancelled() && needs.resolve-ref.outputs.tag_name != ''` (plus the prior job's result for `merge`/`release-chart`) so they run whenever a tag was resolved, regardless of the upstream skip.

### Testing
On a fork: before, `workflow_dispatch` with a tag ran only `resolve-ref` then skipped the build; after, the full multi-arch build + manifest merge + chart publish all run.