### PR TITLE
fix(postgres): only ALTER ROLE when the supplied password does not already authenticate

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -80,13 +80,23 @@ impl PostgresManager for PgPostgresManager {
             .await?;
         let exists: bool = row.get(0);
         let safe_user = quote_ident(username);
-        // Passwords are random per-instance Secrets; rotate to the current
-        // value whether the role is new or already present so a same-name
-        // re-create after a finalizer-blocked delete can authenticate with
-        // its fresh Secret (issue #119, part C).
+        // Passwords are random per-instance Secrets; when the role already
+        // exists, rotate to the current value so a same-name re-create after
+        // a finalizer-blocked delete can authenticate with its fresh Secret
+        // (issue #119, part C). But only ALTER when the supplied password
+        // does not already authenticate: on PostgreSQL 16+ ALTER ROLE
+        // requires the admin to hold ADMIN OPTION on the target role (or be
+        // superuser), and an externally managed admin (e.g. CloudNativePG
+        // `managed.roles`) does not retain that grant across the external
+        // manager's own reconciles — an unconditional ALTER then fails every
+        // reconcile with "permission denied to alter role" (issue #128).
         if exists {
+            if password_authenticates(pg, username, password).await {
+                return Ok(());
+            }
             let stmt = format!("ALTER ROLE {safe_user} WITH PASSWORD '{password}'");
             client.execute(&stmt, &[]).await?;
+            info!(%username, "reset postgres role password");
             return Ok(());
         }
 
@@ -226,6 +236,30 @@ impl PostgresManager for PgPostgresManager {
 /// Minimal SQL identifier quoting (double-quote wrapping + escape internal quotes).
 fn quote_ident(ident: &str) -> String {
     format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
+/// Probe whether `username`/`password` can authenticate against the cluster.
+/// Any failure (bad password, unreachable host, missing CONNECT privilege)
+/// returns `false`, in which case the caller falls back to ALTER ROLE — the
+/// pre-#128 behavior.
+async fn password_authenticates(
+    pg: &PostgresClusterConfig,
+    username: &str,
+    password: &str,
+) -> bool {
+    let connstr = format!(
+        "host={} port={} user={} password={} dbname=postgres",
+        pg.host, pg.port, username, password
+    );
+    match tokio_postgres::connect(&connstr, NoTls).await {
+        Ok((client, connection)) => {
+            tokio::spawn(async move {
+                let _ = connection.await;
+            });
+            client.simple_query("SELECT 1").await.is_ok()
+        }
+        Err(_) => false,
+    }
 }
 
 /// No-op implementation for testing.

--- a/tests/postgres_harness/ensure_role.rs
+++ b/tests/postgres_harness/ensure_role.rs
@@ -52,3 +52,65 @@ async fn ensure_role_resets_password_when_role_already_exists() -> anyhow::Resul
     cleanup_role(username).await;
     Ok(())
 }
+
+/// Regression test for issue #128.
+///
+/// On PostgreSQL 16+ `ALTER ROLE ... WITH PASSWORD` by a non-superuser admin
+/// requires ADMIN OPTION on the target role. The implicit grant the admin
+/// receives at CREATE ROLE time is not durable when the admin role itself is
+/// reconciled by an external manager (e.g. CloudNativePG `managed.roles`
+/// re-asserts the membership list, stripping it). An unconditional ALTER on
+/// every reconcile then fails with "permission denied to alter role" even
+/// though the password never changed. `ensure_role` must succeed without
+/// ALTER privileges when the supplied password already authenticates.
+#[tokio::test]
+async fn ensure_role_succeeds_without_alter_privilege_when_password_is_current(
+) -> anyhow::Result<()> {
+    let username = "odoo.test.ensure_role_no_alter_priv";
+    let limited_admin = "odoo.test.limited_admin";
+    cleanup_role(username).await;
+    cleanup_role(limited_admin).await;
+
+    let superuser = admin_client().await;
+    // A realistic non-superuser operator admin: can create roles/databases
+    // but holds no blanket privilege over existing roles (PG16+ semantics).
+    superuser
+        .simple_query(&format!(
+            r#"CREATE ROLE "{limited_admin}" WITH LOGIN CREATEROLE CREATEDB PASSWORD 'limited-pw'"#
+        ))
+        .await?;
+
+    let mut cfg = cluster_config();
+    cfg.admin_user = limited_admin.to_string();
+    cfg.admin_password = "limited-pw".to_string();
+
+    let mgr = pg_manager();
+    // First reconcile: the limited admin creates the role (and implicitly
+    // receives ADMIN OPTION on it, being its creator).
+    mgr.ensure_role(&cfg, username, "steady-password")
+        .await
+        .expect("initial ensure_role as limited admin failed");
+
+    // Simulate the external role manager re-asserting the admin's
+    // memberships: the implicit grant from CREATE ROLE is stripped.
+    superuser
+        .simple_query(&format!(r#"REVOKE "{username}" FROM "{limited_admin}""#))
+        .await?;
+
+    // Steady-state reconcile: same username, same password. This must not
+    // require ALTER ROLE privileges the admin no longer has.
+    mgr.ensure_role(&cfg, username, "steady-password")
+        .await
+        .expect(
+            "ensure_role with an unchanged password must not require ALTER \
+             ROLE privileges on the target role (issue #128)",
+        );
+
+    try_connect_as(username, "steady-password", "postgres")
+        .await
+        .expect("the unchanged password should still authenticate");
+
+    cleanup_role(username).await;
+    cleanup_role(limited_admin).await;
+    Ok(())
+}


### PR DESCRIPTION
### Problem

Since v2.1.0 (#123), `ensure_role` runs `ALTER ROLE … WITH PASSWORD` on every reconcile for an existing role. On PostgreSQL 16+ this requires the operator's admin to hold `ADMIN OPTION` on the target role (or be superuser). When the admin role is itself reconciled by an external manager — e.g. CloudNativePG `managed.roles` — the implicit grant acquired at `CREATE ROLE` time is stripped again, and every reconcile of an existing instance fails with `permission denied to alter role` (#128).

### Fix

Probe-connect as the instance role before altering: when the supplied password already authenticates, the `ALTER` is skipped. Steady-state reconciles then require no privilege over the role. When the password genuinely differs (the same-name re-create scenario from #119 part C), the rotation happens exactly as before. Any probe failure (unreachable, missing CONNECT, wrong password) falls back to the `ALTER` — the previous behavior.

### Notes

- The residual case — an actual password change while the admin lacks `ADMIN OPTION` — still fails, but now only when a rotation is truly needed, and surfaces the real PG error per #123.
- The regression test reproduces the external-manager scenario in the docker harness; it fails on master and passes with this change.

### Testing

- `cargo test --test postgres_harness -- --test-threads=1` — 5 passed, including the existing #119 rotation test
- `cargo clippy --all-targets -- -D warnings` — clean

Fixes #128