### PR TITLE
feat: opt-in per-tenant read-only SQL access role (#3731)

### DIFF
--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -35,7 +35,8 @@ use gateway_api::apis::standard::httproutes::{
 use crate::crd::odoo_instance::{DeploymentStrategyType, Environment, GatewayRef, OdooInstance};
 use crate::error::Result;
 use crate::helpers::{
-    build_odoo_conf, db_name, generate_password, odoo_username, parse_quantity, sha256_hex,
+    build_odoo_conf, db_name, generate_password, odoo_ro_username, odoo_username, parse_quantity,
+    sha256_hex,
 };
 use crate::postgres::PostgresClusterConfig;
 
@@ -1116,4 +1117,138 @@ pub async fn ensure_cron_deployment(
         )
         .await?;
     Ok(())
+}
+
+// ── Read-only SQL access ──────────────────────────────────────────────────────
+
+/// Name of the Secret that holds the read-only role password.
+pub fn ro_secret_name(instance_name: &str) -> String {
+    format!("{instance_name}-db-ro-password")
+}
+
+/// Ensure the k8s Secret for the read-only role exists.
+/// The Secret is created once with a random password; subsequent reconciles
+/// are no-ops so the password is stable (rotate by deleting the Secret).
+///
+/// Returns `(ro_username, ro_password)`.
+pub async fn ensure_readonly_secret(
+    client: &Client,
+    ns: &str,
+    name: &str,
+    oref: &OwnerReference,
+) -> Result<(String, String)> {
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), ns);
+    let secret_name = ro_secret_name(name);
+    let ro_username = odoo_ro_username(ns, name);
+
+    match secrets.get(&secret_name).await {
+        Ok(existing) => {
+            let data = existing.data.unwrap_or_default();
+            let password = String::from_utf8_lossy(
+                data.get("password")
+                    .map(|v| v.0.as_slice())
+                    .unwrap_or_default(),
+            )
+            .to_string();
+            Ok((ro_username, password))
+        }
+        Err(kube::Error::Api(ref e)) if e.code == 404 => {
+            let password = generate_password();
+            let secret = Secret {
+                metadata: ObjectMeta {
+                    name: Some(secret_name.clone()),
+                    namespace: Some(ns.to_string()),
+                    owner_references: Some(vec![oref.clone()]),
+                    ..Default::default()
+                },
+                string_data: Some(BTreeMap::from([
+                    ("username".to_string(), ro_username.clone()),
+                    ("password".to_string(), password.clone()),
+                ])),
+                ..Default::default()
+            };
+            secrets.create(&PostParams::default(), &secret).await?;
+            Ok((ro_username, password))
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Ensure the read-only Postgres role and its per-DB grants are in place.
+///
+/// Reads/creates the k8s Secret for the RO password, then delegates to
+/// `PostgresManager::ensure_readonly_role` for the SQL side.  Idempotent —
+/// safe to call on every reconcile tick.
+///
+/// No-op when `spec.readOnlySqlAccess` is absent or `enabled: false`.
+pub async fn ensure_readonly_role(
+    ctx: &Context,
+    instance: &OdooInstance,
+    pg: &PostgresClusterConfig,
+    oref: &OwnerReference,
+) -> Result<()> {
+    let spec = match instance
+        .spec
+        .read_only_sql_access
+        .as_ref()
+        .filter(|s| s.enabled)
+    {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    let ns = instance.namespace().unwrap_or_default();
+    let name = instance.name_any();
+
+    let (ro_username, ro_password) =
+        ensure_readonly_secret(&ctx.client, &ns, &name, oref).await?;
+    let (owner_username, owner_password) =
+        read_odoo_credentials(&ctx.client, &ns, &name).await?;
+    let db = db_name(instance);
+
+    ctx.postgres
+        .ensure_readonly_role(
+            pg,
+            crate::postgres::ReadonlyRoleParams {
+                ro_username: &ro_username,
+                ro_password: &ro_password,
+                owner_username: &owner_username,
+                owner_password: &owner_password,
+                db_name: &db,
+                connection_limit: spec.connection_limit,
+            },
+        )
+        .await
+}
+
+/// Delete the read-only Postgres role and its k8s Secret.
+///
+/// Called when `spec.readOnlySqlAccess.enabled` transitions to false or when
+/// the instance is being deleted.  The k8s Secret is owned by the instance and
+/// will be garbage-collected by kube on instance deletion; this function
+/// handles both disable-while-alive and the explicit teardown path.
+pub async fn delete_readonly_role(
+    ctx: &Context,
+    instance: &OdooInstance,
+    pg: &PostgresClusterConfig,
+) -> Result<()> {
+    let ns = instance.namespace().unwrap_or_default();
+    let name = instance.name_any();
+    let ro_username = odoo_ro_username(&ns, &name);
+    let db = db_name(instance);
+
+    ctx.postgres
+        .delete_readonly_role(pg, &ro_username, &db)
+        .await?;
+
+    // Also delete the k8s Secret so a re-enable generates fresh credentials.
+    let secrets: Api<Secret> = Api::namespaced(ctx.client.clone(), &ns);
+    let secret_name = ro_secret_name(&name);
+    match secrets
+        .delete(&secret_name, &kube::api::DeleteParams::default())
+        .await
+    {
+        Ok(_) | Err(kube::Error::Api(kube::core::ErrorResponse { code: 404, .. })) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
 }

--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -1200,10 +1200,8 @@ pub async fn ensure_readonly_role(
     let ns = instance.namespace().unwrap_or_default();
     let name = instance.name_any();
 
-    let (ro_username, ro_password) =
-        ensure_readonly_secret(&ctx.client, &ns, &name, oref).await?;
-    let (owner_username, owner_password) =
-        read_odoo_credentials(&ctx.client, &ns, &name).await?;
+    let (ro_username, ro_password) = ensure_readonly_secret(&ctx.client, &ns, &name, oref).await?;
+    let (owner_username, owner_password) = read_odoo_credentials(&ctx.client, &ns, &name).await?;
     let db = db_name(instance);
 
     ctx.postgres

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -365,9 +365,7 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
     } else {
         // Tear down if previously enabled and now disabled (idempotent — no-op
         // if the role never existed or was already removed).
-        if let Err(e) =
-            child_resources::delete_readonly_role(ctx, instance, &pg_cluster).await
-        {
+        if let Err(e) = child_resources::delete_readonly_role(ctx, instance, &pg_cluster).await {
             warn!(%name, %e, "failed to remove read-only role on disable — will retry");
         }
     }

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -354,6 +354,24 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         child_resources::ensure_cron_deployment(client, &ns, &name, instance, ctx, &oref).await?;
     }
 
+    // Read-only SQL access — provision or tear down based on spec opt-in.
+    let ro_enabled = instance
+        .spec
+        .read_only_sql_access
+        .as_ref()
+        .is_some_and(|s| s.enabled);
+    if ro_enabled {
+        child_resources::ensure_readonly_role(ctx, instance, &pg_cluster, &oref).await?;
+    } else {
+        // Tear down if previously enabled and now disabled (idempotent — no-op
+        // if the role never existed or was already removed).
+        if let Err(e) =
+            child_resources::delete_readonly_role(ctx, instance, &pg_cluster).await
+        {
+            warn!(%name, %e, "failed to remove read-only role on disable — will retry");
+        }
+    }
+
     // Gather the observed world into a snapshot.
     let snapshot = super::state_machine::ReconcileSnapshot::gather(
         client,
@@ -579,6 +597,13 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
 
     let username = odoo_username(&ns, &name);
     if let Ok((cluster_name, pg_cluster)) = load_postgres_cluster(ctx, instance).await {
+        // Best-effort: clean up the read-only role before the owner role so we
+        // don't leave orphaned grants.  Non-fatal — the owner role drop is what
+        // the finalizer must guarantee; the RO role has no owned databases.
+        if let Err(e) = child_resources::delete_readonly_role(ctx, instance, &pg_cluster).await {
+            warn!(%name, %e, "failed to delete read-only postgres role during cleanup (non-fatal)");
+        }
+
         if let Err(e) = ctx.postgres.delete_role(&pg_cluster, &username).await {
             warn!(%name, %e, "failed to delete postgres role — retaining finalizer for retry");
             publish_event(

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -189,6 +189,53 @@ impl Default for CronSpec {
     }
 }
 
+/// ReadOnlySqlAccessSpec opts a tenant into a read-only Postgres role
+/// (`<pg_user>_ro`) that the operator provisions, manages, and tears down
+/// declaratively.  Default is absent / disabled — existing instances are
+/// unaffected.
+///
+/// When enabled, the operator:
+///   1. Creates a k8s Secret `<instance>-db-ro-password` in the instance
+///      namespace with a random password (generated once, never rotated by
+///      the operator unless the Secret is deleted).
+///   2. Ensures a PostgreSQL role `<pg_user>_ro` with LOGIN, NOSUPERUSER,
+///      NOCREATEDB, and the configured `connection_limit`.
+///   3. Grants CONNECT on the tenant DB, USAGE on schema public, SELECT on
+///      all tables, and ALTER DEFAULT PRIVILEGES … GRANT SELECT for future
+///      tables — explicitly no INSERT/UPDATE/DELETE/DDL.
+///
+/// On disable (field removed or `enabled: false`) or instance deletion, the
+/// operator drops the role and deletes the Secret.
+///
+/// Connection: use the CNPG `<cluster>-ro` read-replica service together
+/// with the credentials from the Secret.  `sslmode=require` is strongly
+/// recommended.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadOnlySqlAccessSpec {
+    /// Enable read-only SQL access for this instance.  Defaults to `false`.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum number of simultaneous connections for the read-only role.
+    /// Defaults to 5.
+    #[serde(default = "default_ro_connection_limit")]
+    pub connection_limit: i32,
+}
+
+impl Default for ReadOnlySqlAccessSpec {
+    fn default() -> Self {
+        ReadOnlySqlAccessSpec {
+            enabled: false,
+            connection_limit: default_ro_connection_limit(),
+        }
+    }
+}
+
+fn default_ro_connection_limit() -> i32 {
+    5
+}
+
 /// InitSpec configures automatic database initialization when the instance
 /// first reaches the Uninitialized phase. The operator creates an OdooInitJob
 /// CR automatically — no external controller needed.
@@ -318,6 +365,14 @@ pub struct OdooInstanceSpec {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tolerations: Vec<Toleration>,
+
+    /// Opt in to a read-only Postgres role for this instance.
+    /// When enabled the operator provisions `<pg_user>_ro` with SELECT-only
+    /// privileges on the tenant DB, stores the password in a k8s Secret, and
+    /// tears everything down on disable or instance deletion.
+    /// Default is absent / disabled — existing instances are unaffected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_only_sql_access: Option<ReadOnlySqlAccessSpec>,
 }
 
 fn default_replicas() -> i32 {

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -207,9 +207,12 @@ impl Default for CronSpec {
 /// On disable (field removed or `enabled: false`) or instance deletion, the
 /// operator drops the role and deletes the Secret.
 ///
-/// Connection: use the CNPG `<cluster>-ro` read-replica service together
-/// with the credentials from the Secret.  `sslmode=require` is strongly
-/// recommended.
+/// Consumption: the credentials live only in the k8s Secret and are intended
+/// for an in-cluster consumer running inside the tenant's own pod (e.g. an
+/// in-Odoo read-only SQL console that opens its own connection as this role).
+/// The role is not exposed outside the cluster — nothing here provisions a
+/// network path to Postgres, and PUBLIC CONNECT on sibling tenant databases is
+/// left untouched.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadOnlySqlAccessSpec {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -47,6 +47,12 @@ pub fn odoo_username(namespace: &str, name: &str) -> String {
     format!("odoo.{namespace}.{name}")
 }
 
+/// Derive the read-only PostgreSQL role name for a tenant.
+/// Convention: `<pg_user>_ro` mirrors the owner role name.
+pub fn odoo_ro_username(namespace: &str, name: &str) -> String {
+    format!("odoo.{namespace}.{name}_ro")
+}
+
 /// Convert a UUID string into a safe database name component by replacing
 /// any non-lowercase-alphanumeric characters with underscores.
 pub fn sanitise_uid(uid: &str) -> String {

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -339,10 +339,62 @@ impl PostgresManager for PgPostgresManager {
                 info!(%ro_username, "created read-only postgres role");
             }
 
-            // GRANT CONNECT on the DB — admin-issued, fine from postgres DB.
+            // ── Cluster-wide tenant DB isolation ─────────────────────────
+            //
+            // PostgreSQL grants CONNECT to PUBLIC on every database by default,
+            // which means any role with LOGIN can connect to any DB on the
+            // shared cluster.  We enforce single-tenant scoping by:
+            //
+            //   1. Revoking PUBLIC CONNECT from ALL `odoo_*` databases on this
+            //      cluster — applied on every reconcile tick so newly created
+            //      tenant DBs are locked down immediately.
+            //
+            //   2. Re-granting CONNECT explicitly to the tenant owner + ro role
+            //      for the specific tenant DB being provisioned.
+            //
+            // Non-`odoo_*` system databases (postgres, template0, template1)
+            // are left untouched; they must stay accessible to the admin user
+            // via PUBLIC CONNECT.
+            //
+            // Residual gap: databases whose names don't start with `odoo_` that
+            // were manually created on the same cluster still retain PUBLIC
+            // CONNECT; the _ro role has no SELECT grants there but can connect
+            // and observe system catalog metadata.  Those DBs are outside the
+            // operator's management scope and must be hardened separately.
+            let tenant_dbs: Vec<String> = admin
+                .query(
+                    "SELECT datname FROM pg_database \
+                     WHERE datname LIKE 'odoo\\_%' AND datistemplate = false",
+                    &[],
+                )
+                .await?
+                .into_iter()
+                .map(|row| row.get::<_, String>(0))
+                .collect();
+
+            for db in &tenant_dbs {
+                let safe_other = quote_ident(db);
+                // Best-effort per DB — if this fails (e.g. db is being dropped
+                // concurrently) we log a warning and continue.
+                if let Err(e) = admin
+                    .execute(
+                        &format!("REVOKE CONNECT ON DATABASE {safe_other} FROM PUBLIC"),
+                        &[],
+                    )
+                    .await
+                {
+                    warn!(%db, "failed to revoke PUBLIC CONNECT on tenant db: {e}");
+                }
+            }
+
+            // Re-grant CONNECT explicitly to the tenant owner and the ro role
+            // so they keep access after the PUBLIC revoke.
+            let safe_owner = quote_ident(owner_username);
             admin
                 .execute(
-                    &format!("GRANT CONNECT ON DATABASE {safe_db} TO {safe_ro}"),
+                    &format!(
+                        "GRANT CONNECT ON DATABASE {safe_db} TO {safe_owner}, {safe_ro}"
+                    ),
                     &[],
                 )
                 .await?;
@@ -424,8 +476,53 @@ impl PostgresManager for PgPostgresManager {
         let safe_ro = quote_ident(ro_username);
         let safe_db = quote_ident(db_name);
 
-        // Revoke CONNECT before dropping to avoid "role still has privileges"
-        // errors on some PG versions.
+        // ── Step 1: Revoke all per-DB privileges by connecting as admin to
+        //   the tenant database.  `DROP OWNED BY` removes:
+        //     - GRANT SELECT ON ALL TABLES IN SCHEMA public TO <ro>
+        //     - GRANT USAGE ON SCHEMA public TO <ro>
+        //     - ALTER DEFAULT PRIVILEGES ... GRANT SELECT ON TABLES TO <ro>
+        //   PostgreSQL requires all privileges to be revoked before DROP ROLE
+        //   succeeds; doing it via DROP OWNED BY is the safest single command.
+        //
+        //   We connect as the cluster admin (superuser) to the tenant DB.
+        //   Superusers can drop any role's owned objects.  If the tenant DB no
+        //   longer exists we skip this step gracefully and proceed to DROP ROLE.
+        let tenant_connstr = format!(
+            "host={} port={} user={} password={} dbname={}",
+            pg.host, pg.port, pg.admin_user, pg.admin_password, db_name
+        );
+        match tokio_postgres::connect(&tenant_connstr, NoTls).await {
+            Ok((tenant_client, connection)) => {
+                tokio::spawn(async move {
+                    if let Err(e) = connection.await {
+                        warn!("postgres connection error: {e}");
+                    }
+                });
+                // Revoke ALTER DEFAULT PRIVILEGES entries created by the owner
+                // for this role — must be done before DROP OWNED BY on some PG
+                // versions to avoid catalog inconsistencies.
+                let _ = tenant_client
+                    .execute(
+                        &format!(
+                            "ALTER DEFAULT PRIVILEGES IN SCHEMA public \
+                             REVOKE SELECT ON TABLES FROM {safe_ro}"
+                        ),
+                        &[],
+                    )
+                    .await;
+                // DROP OWNED BY revokes all remaining privileges for the role
+                // in this database (USAGE, SELECT, etc.).
+                let _ = tenant_client
+                    .execute(&format!("DROP OWNED BY {safe_ro}"), &[])
+                    .await;
+            }
+            Err(e) => {
+                // Tenant DB may have already been dropped; log and continue.
+                warn!(%db_name, "could not connect to tenant db for DROP OWNED BY cleanup: {e}");
+            }
+        }
+
+        // ── Step 2: Revoke CONNECT on the database (admin conn to postgres). ──
         let _ = client
             .execute(
                 &format!("REVOKE CONNECT ON DATABASE {safe_db} FROM {safe_ro}"),
@@ -433,6 +530,7 @@ impl PostgresManager for PgPostgresManager {
             )
             .await;
 
+        // ── Step 3: Drop the role. ─────────────────────────────────────────────
         client
             .execute(&format!("DROP ROLE {safe_ro}"), &[])
             .await?;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -392,9 +392,7 @@ impl PostgresManager for PgPostgresManager {
             let safe_owner = quote_ident(owner_username);
             admin
                 .execute(
-                    &format!(
-                        "GRANT CONNECT ON DATABASE {safe_db} TO {safe_owner}, {safe_ro}"
-                    ),
+                    &format!("GRANT CONNECT ON DATABASE {safe_db} TO {safe_owner}, {safe_ro}"),
                     &[],
                 )
                 .await?;
@@ -406,8 +404,7 @@ impl PostgresManager for PgPostgresManager {
                 "host={} port={} user={} password={} dbname={}",
                 pg.host, pg.port, owner_username, owner_password, db_name
             );
-            let (owner_conn, connection) =
-                tokio_postgres::connect(&owner_connstr, NoTls).await?;
+            let (owner_conn, connection) = tokio_postgres::connect(&owner_connstr, NoTls).await?;
             tokio::spawn(async move {
                 if let Err(e) = connection.await {
                     warn!("postgres connection error: {e}");
@@ -415,10 +412,7 @@ impl PostgresManager for PgPostgresManager {
             });
 
             owner_conn
-                .execute(
-                    &format!("GRANT USAGE ON SCHEMA public TO {safe_ro}"),
-                    &[],
-                )
+                .execute(&format!("GRANT USAGE ON SCHEMA public TO {safe_ro}"), &[])
                 .await?;
 
             owner_conn
@@ -531,9 +525,7 @@ impl PostgresManager for PgPostgresManager {
             .await;
 
         // ── Step 3: Drop the role. ─────────────────────────────────────────────
-        client
-            .execute(&format!("DROP ROLE {safe_ro}"), &[])
-            .await?;
+        client.execute(&format!("DROP ROLE {safe_ro}"), &[]).await?;
         info!(%ro_username, "deleted read-only postgres role");
         Ok(())
     }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -16,6 +16,17 @@ pub struct PostgresClusterConfig {
     pub default: bool,
 }
 
+/// Parameters for provisioning a read-only Postgres role on a tenant database.
+/// Bundles the 5 caller-supplied values to stay within clippy's argument-count limit.
+pub struct ReadonlyRoleParams<'a> {
+    pub ro_username: &'a str,
+    pub ro_password: &'a str,
+    pub owner_username: &'a str,
+    pub owner_password: &'a str,
+    pub db_name: &'a str,
+    pub connection_limit: i32,
+}
+
 /// Trait abstracting PostgreSQL role management so tests can substitute a no-op.
 #[async_trait::async_trait]
 pub trait PostgresManager: Send + Sync {
@@ -48,6 +59,37 @@ pub trait PostgresManager: Send + Sync {
 
     /// Query the running PostgreSQL server for its major version (e.g. 16, 17, 18).
     async fn detect_server_major_version(&self, pg: &PostgresClusterConfig) -> Result<u32>;
+
+    /// Ensure a read-only PostgreSQL role `ro_username` exists on the cluster,
+    /// with SELECT-only privileges on `db_name`.
+    ///
+    /// The role is created with LOGIN, NOSUPERUSER, NOCREATEDB and the supplied
+    /// `connection_limit`.  The following grants are applied (idempotently):
+    ///   - CONNECT on the tenant database
+    ///   - USAGE on schema `public`
+    ///   - SELECT on all existing tables in schema `public`
+    ///   - ALTER DEFAULT PRIVILEGES … GRANT SELECT on future tables
+    ///
+    /// Explicitly **no** INSERT/UPDATE/DELETE/DDL is granted.
+    ///
+    /// The method connects as the admin user for role CREATE/ALTER, then as the
+    /// tenant owner (`owner_username` / `owner_password`) for per-DB grants
+    /// (owner-issued grants are required for per-table SELECT in a tenant DB).
+    async fn ensure_readonly_role(
+        &self,
+        pg: &PostgresClusterConfig,
+        params: ReadonlyRoleParams<'_>,
+    ) -> Result<()>;
+
+    /// Drop the read-only role `ro_username` if it exists.  No-op if absent.
+    /// Revokes existing grants before dropping so the DROP ROLE succeeds even
+    /// if other objects hold privileges.
+    async fn delete_readonly_role(
+        &self,
+        pg: &PostgresClusterConfig,
+        ro_username: &str,
+        db_name: &str,
+    ) -> Result<()>;
 }
 
 /// Production implementation backed by tokio-postgres.
@@ -231,6 +273,172 @@ impl PostgresManager for PgPostgresManager {
         })?;
         Ok(n / 10000)
     }
+
+    async fn ensure_readonly_role(
+        &self,
+        pg: &PostgresClusterConfig,
+        params: ReadonlyRoleParams<'_>,
+    ) -> Result<()> {
+        let ReadonlyRoleParams {
+            ro_username,
+            ro_password,
+            owner_username,
+            owner_password,
+            db_name,
+            connection_limit,
+        } = params;
+        let safe_ro = quote_ident(ro_username);
+        let safe_db = quote_ident(db_name);
+
+        // ── Step 1: Create / update the role (admin connection to postgres) ───
+        {
+            let connstr = format!(
+                "host={} port={} user={} password={} dbname=postgres",
+                pg.host, pg.port, pg.admin_user, pg.admin_password
+            );
+            let (admin, connection) = tokio_postgres::connect(&connstr, NoTls).await?;
+            tokio::spawn(async move {
+                if let Err(e) = connection.await {
+                    warn!("postgres connection error: {e}");
+                }
+            });
+
+            let row = admin
+                .query_one(
+                    "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
+                    &[&ro_username],
+                )
+                .await?;
+            let exists: bool = row.get(0);
+
+            if exists {
+                // Update password + connection limit in case they changed.
+                admin
+                    .execute(
+                        &format!(
+                            "ALTER ROLE {safe_ro} WITH \
+                             LOGIN NOSUPERUSER NOCREATEDB NOINHERIT \
+                             CONNECTION LIMIT {connection_limit} \
+                             PASSWORD '{ro_password}'"
+                        ),
+                        &[],
+                    )
+                    .await?;
+            } else {
+                admin
+                    .execute(
+                        &format!(
+                            "CREATE ROLE {safe_ro} WITH \
+                             LOGIN NOSUPERUSER NOCREATEDB NOINHERIT \
+                             CONNECTION LIMIT {connection_limit} \
+                             PASSWORD '{ro_password}'"
+                        ),
+                        &[],
+                    )
+                    .await?;
+                info!(%ro_username, "created read-only postgres role");
+            }
+
+            // GRANT CONNECT on the DB — admin-issued, fine from postgres DB.
+            admin
+                .execute(
+                    &format!("GRANT CONNECT ON DATABASE {safe_db} TO {safe_ro}"),
+                    &[],
+                )
+                .await?;
+        }
+
+        // ── Step 2: Schema/table grants — must run as DB owner ────────────────
+        {
+            let owner_connstr = format!(
+                "host={} port={} user={} password={} dbname={}",
+                pg.host, pg.port, owner_username, owner_password, db_name
+            );
+            let (owner_conn, connection) =
+                tokio_postgres::connect(&owner_connstr, NoTls).await?;
+            tokio::spawn(async move {
+                if let Err(e) = connection.await {
+                    warn!("postgres connection error: {e}");
+                }
+            });
+
+            owner_conn
+                .execute(
+                    &format!("GRANT USAGE ON SCHEMA public TO {safe_ro}"),
+                    &[],
+                )
+                .await?;
+
+            owner_conn
+                .execute(
+                    &format!("GRANT SELECT ON ALL TABLES IN SCHEMA public TO {safe_ro}"),
+                    &[],
+                )
+                .await?;
+
+            // Ensure future tables created by the owner are also readable.
+            owner_conn
+                .execute(
+                    &format!(
+                        "ALTER DEFAULT PRIVILEGES IN SCHEMA public \
+                         GRANT SELECT ON TABLES TO {safe_ro}"
+                    ),
+                    &[],
+                )
+                .await?;
+
+            info!(%ro_username, %db_name, "applied read-only grants");
+        }
+
+        Ok(())
+    }
+
+    async fn delete_readonly_role(
+        &self,
+        pg: &PostgresClusterConfig,
+        ro_username: &str,
+        db_name: &str,
+    ) -> Result<()> {
+        let connstr = format!(
+            "host={} port={} user={} password={} dbname=postgres",
+            pg.host, pg.port, pg.admin_user, pg.admin_password
+        );
+        let (client, connection) = tokio_postgres::connect(&connstr, NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                warn!("postgres connection error: {e}");
+            }
+        });
+
+        let row = client
+            .query_one(
+                "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
+                &[&ro_username],
+            )
+            .await?;
+        let exists: bool = row.get(0);
+        if !exists {
+            return Ok(());
+        }
+
+        let safe_ro = quote_ident(ro_username);
+        let safe_db = quote_ident(db_name);
+
+        // Revoke CONNECT before dropping to avoid "role still has privileges"
+        // errors on some PG versions.
+        let _ = client
+            .execute(
+                &format!("REVOKE CONNECT ON DATABASE {safe_db} FROM {safe_ro}"),
+                &[],
+            )
+            .await;
+
+        client
+            .execute(&format!("DROP ROLE {safe_ro}"), &[])
+            .await?;
+        info!(%ro_username, "deleted read-only postgres role");
+        Ok(())
+    }
 }
 
 /// Minimal SQL identifier quoting (double-quote wrapping + escape internal quotes).
@@ -288,5 +496,20 @@ impl PostgresManager for NoopPostgresManager {
     }
     async fn detect_server_major_version(&self, _: &PostgresClusterConfig) -> Result<u32> {
         Ok(18)
+    }
+    async fn ensure_readonly_role(
+        &self,
+        _: &PostgresClusterConfig,
+        _: ReadonlyRoleParams<'_>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn delete_readonly_role(
+        &self,
+        _: &PostgresClusterConfig,
+        _: &str,
+        _: &str,
+    ) -> Result<()> {
+        Ok(())
     }
 }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -339,60 +339,25 @@ impl PostgresManager for PgPostgresManager {
                 info!(%ro_username, "created read-only postgres role");
             }
 
-            // ── Cluster-wide tenant DB isolation ─────────────────────────
+            // Grant CONNECT on the tenant database to the read-only role.
             //
-            // PostgreSQL grants CONNECT to PUBLIC on every database by default,
-            // which means any role with LOGIN can connect to any DB on the
-            // shared cluster.  We enforce single-tenant scoping by:
+            // PUBLIC already holds CONNECT by default, so this is not strictly
+            // required for the role to connect — but it is explicit, harmless,
+            // and keeps the role working if PUBLIC CONNECT is ever revoked on
+            // this database.
             //
-            //   1. Revoking PUBLIC CONNECT from ALL `odoo_*` databases on this
-            //      cluster — applied on every reconcile tick so newly created
-            //      tenant DBs are locked down immediately.
-            //
-            //   2. Re-granting CONNECT explicitly to the tenant owner + ro role
-            //      for the specific tenant DB being provisioned.
-            //
-            // Non-`odoo_*` system databases (postgres, template0, template1)
-            // are left untouched; they must stay accessible to the admin user
-            // via PUBLIC CONNECT.
-            //
-            // Residual gap: databases whose names don't start with `odoo_` that
-            // were manually created on the same cluster still retain PUBLIC
-            // CONNECT; the _ro role has no SELECT grants there but can connect
-            // and observe system catalog metadata.  Those DBs are outside the
-            // operator's management scope and must be hardened separately.
-            let tenant_dbs: Vec<String> = admin
-                .query(
-                    "SELECT datname FROM pg_database \
-                     WHERE datname LIKE 'odoo\\_%' AND datistemplate = false",
-                    &[],
-                )
-                .await?
-                .into_iter()
-                .map(|row| row.get::<_, String>(0))
-                .collect();
-
-            for db in &tenant_dbs {
-                let safe_other = quote_ident(db);
-                // Best-effort per DB — if this fails (e.g. db is being dropped
-                // concurrently) we log a warning and continue.
-                if let Err(e) = admin
-                    .execute(
-                        &format!("REVOKE CONNECT ON DATABASE {safe_other} FROM PUBLIC"),
-                        &[],
-                    )
-                    .await
-                {
-                    warn!(%db, "failed to revoke PUBLIC CONNECT on tenant db: {e}");
-                }
-            }
-
-            // Re-grant CONNECT explicitly to the tenant owner and the ro role
-            // so they keep access after the PUBLIC revoke.
-            let safe_owner = quote_ident(owner_username);
+            // We deliberately do NOT revoke PUBLIC CONNECT from sibling tenant
+            // databases to enforce single-tenant connectivity.  The read-only
+            // credential is consumed only from inside the tenant's own pod
+            // (e.g. an in-Odoo read-only SQL console that opens its own
+            // connection as this role) and is never network-reachable; it also
+            // holds no SELECT grants on any other database, so the ability to
+            // connect to a sibling DB exposes nothing.  Revoking PUBLIC CONNECT
+            // cluster-wide would be a one-way, global side effect triggered by a
+            // single tenant's opt-in — out of scope for this role.
             admin
                 .execute(
-                    &format!("GRANT CONNECT ON DATABASE {safe_db} TO {safe_owner}, {safe_ro}"),
+                    &format!("GRANT CONNECT ON DATABASE {safe_db} TO {safe_ro}"),
                     &[],
                 )
                 .await?;

--- a/tests/controller_helpers_test.rs
+++ b/tests/controller_helpers_test.rs
@@ -43,6 +43,7 @@ fn test_instance(name: &str, pull_secret: Option<&str>) -> OdooInstance {
             probes: None,
             affinity: None,
             tolerations: vec![],
+            read_only_sql_access: None,
         },
         status: None,
     }

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -6,6 +6,25 @@ use odoo_operator::crd::odoo_instance::{
 };
 use odoo_operator::helpers::*;
 
+// ── odoo_ro_username ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_odoo_ro_username_format() {
+    assert_eq!(
+        odoo_ro_username("production", "my-odoo"),
+        "odoo.production.my-odoo_ro"
+    );
+    assert_eq!(odoo_ro_username("default", "test"), "odoo.default.test_ro");
+}
+
+#[test]
+fn test_odoo_ro_username_differs_from_owner() {
+    let owner = odoo_username("ns", "inst");
+    let ro = odoo_ro_username("ns", "inst");
+    assert_ne!(owner, ro);
+    assert!(ro.ends_with("_ro"));
+}
+
 #[test]
 fn test_sanitise_uid_replaces_non_alphanumeric() {
     assert_eq!(sanitise_uid("abc-123-DEF"), "abc_123____");
@@ -139,6 +158,7 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
             probes: None,
             affinity: None,
             tolerations: vec![],
+            read_only_sql_access: None,
         },
         status: None,
     }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -428,6 +428,23 @@ impl PostgresManager for MockPostgresManager {
     async fn detect_server_major_version(&self, _: &PostgresClusterConfig) -> PgResult<u32> {
         Ok(18)
     }
+
+    async fn ensure_readonly_role(
+        &self,
+        _: &PostgresClusterConfig,
+        _: odoo_operator::postgres::ReadonlyRoleParams<'_>,
+    ) -> PgResult<()> {
+        Ok(())
+    }
+
+    async fn delete_readonly_role(
+        &self,
+        _: &PostgresClusterConfig,
+        _: &str,
+        _: &str,
+    ) -> PgResult<()> {
+        Ok(())
+    }
 }
 
 static MOCK_PG: OnceLock<Arc<MockPostgresManager>> = OnceLock::new();

--- a/tests/postgres_harness/main.rs
+++ b/tests/postgres_harness/main.rs
@@ -9,3 +9,4 @@ mod harness;
 mod database_exists;
 mod delete_role_errors;
 mod ensure_role;
+mod readonly_role;

--- a/tests/postgres_harness/readonly_role.rs
+++ b/tests/postgres_harness/readonly_role.rs
@@ -1,0 +1,356 @@
+//! Security-critical integration tests for `ensure_readonly_role` and
+//! `delete_readonly_role` against a real Docker PostgreSQL instance.
+//!
+//! Invariants asserted here:
+//!   1. Granted role can SELECT but not INSERT / UPDATE / DELETE / DDL.
+//!   2. Role is scoped to the tenant DB — CONNECT on a second DB is denied.
+//!   3. `delete_readonly_role` drops the role; subsequent login fails.
+
+use odoo_operator::postgres::{PostgresManager, ReadonlyRoleParams};
+
+use super::harness::{admin_client, cluster_config, pg_manager, try_connect_as};
+
+/// Unique prefix so tests can run in parallel without collisions.
+const PREFIX: &str = "odoo.test.ro";
+
+async fn cleanup(ro_user: &str, owner_user: &str, tenant_db: &str, other_db: &str) {
+    let c = admin_client().await;
+    // Best-effort teardown — order matters to avoid dependency errors.
+    let _ = c
+        .simple_query(&format!(
+            r#"REVOKE ALL PRIVILEGES ON DATABASE "{tenant_db}" FROM "{ro_user}""#
+        ))
+        .await;
+    let _ = c
+        .simple_query(&format!(
+            r#"REVOKE ALL PRIVILEGES ON DATABASE "{other_db}" FROM "{ro_user}""#
+        ))
+        .await;
+    // Must terminate any open connections to the tenant DB before dropping it.
+    let _ = c
+        .simple_query(&format!(
+            r#"SELECT pg_terminate_backend(pid)
+               FROM pg_stat_activity
+               WHERE datname = '{tenant_db}' AND pid <> pg_backend_pid()"#
+        ))
+        .await;
+    let _ = c
+        .simple_query(&format!(
+            r#"SELECT pg_terminate_backend(pid)
+               FROM pg_stat_activity
+               WHERE datname = '{other_db}' AND pid <> pg_backend_pid()"#
+        ))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{tenant_db}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{other_db}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{ro_user}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{owner_user}""#))
+        .await;
+}
+
+/// Set up a tenant DB owned by `owner_user` with a simple test table.
+async fn setup_tenant(owner_user: &str, owner_password: &str, tenant_db: &str) {
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{owner_user}""#))
+        .await;
+    c.simple_query(&format!(
+        r#"CREATE ROLE "{owner_user}" WITH PASSWORD '{owner_password}' LOGIN CREATEDB"#
+    ))
+    .await
+    .expect("create owner role");
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{tenant_db}""#))
+        .await;
+    c.simple_query(&format!(
+        r#"CREATE DATABASE "{tenant_db}" OWNER "{owner_user}""#
+    ))
+    .await
+    .expect("create tenant db");
+
+    // Create a table as the owner so the RO role has something to SELECT.
+    let owner_connstr = format!(
+        "host=127.0.0.1 port={} user={} password={} dbname={}",
+        cluster_config().port,
+        owner_user,
+        owner_password,
+        tenant_db
+    );
+    let (owner_conn, conn) = tokio_postgres::connect(&owner_connstr, tokio_postgres::NoTls)
+        .await
+        .expect("connect as owner");
+    tokio::spawn(async move { let _ = conn.await; });
+    owner_conn
+        .simple_query("CREATE TABLE test_tbl (id serial PRIMARY KEY, val text)")
+        .await
+        .expect("create test table");
+    owner_conn
+        .simple_query("INSERT INTO test_tbl (val) VALUES ('hello')")
+        .await
+        .expect("insert row");
+}
+
+// ── Test 1: SELECT allowed; DML/DDL denied ────────────────────────────────────
+
+#[tokio::test]
+async fn readonly_role_select_allowed_dml_denied() -> anyhow::Result<()> {
+    let ro_user = &format!("{PREFIX}.dml_denied_ro");
+    let owner_user = &format!("{PREFIX}.dml_denied_owner");
+    let owner_password = "owner-pw-dml";
+    let ro_password = "ro-pw-dml";
+    let tenant_db = "odoo_test_ro_dml_denied";
+
+    cleanup(ro_user, owner_user, tenant_db, "").await;
+    setup_tenant(owner_user, owner_password, tenant_db).await;
+
+    let cfg = cluster_config();
+    pg_manager()
+        .ensure_readonly_role(
+            &cfg,
+            ReadonlyRoleParams {
+                ro_username: ro_user,
+                ro_password,
+                owner_username: owner_user,
+                owner_password,
+                db_name: tenant_db,
+                connection_limit: 5,
+            },
+        )
+        .await
+        .expect("ensure_readonly_role failed");
+
+    // Connect to the tenant DB as the RO role.
+    let ro_connstr = format!(
+        "host=127.0.0.1 port={} user={} password={} dbname={}",
+        cfg.port, ro_user, ro_password, tenant_db
+    );
+    let (ro_conn, conn) = tokio_postgres::connect(&ro_connstr, tokio_postgres::NoTls)
+        .await
+        .expect("ro role should be able to CONNECT to tenant db");
+    tokio::spawn(async move { let _ = conn.await; });
+
+    // SELECT must succeed.
+    let rows = ro_conn
+        .query("SELECT id, val FROM test_tbl", &[])
+        .await
+        .expect("SELECT should succeed for the read-only role");
+    assert!(!rows.is_empty(), "expected at least one row");
+
+    // INSERT must fail with permission denied.
+    // tokio_postgres::Error::to_string() returns "db error"; the actual PG
+    // message is in as_db_error().message().
+    let insert_err = ro_conn
+        .simple_query("INSERT INTO test_tbl (val) VALUES ('bad')")
+        .await
+        .expect_err("INSERT should be denied for the read-only role");
+    let insert_msg = insert_err
+        .as_db_error()
+        .map(|d| d.message().to_lowercase())
+        .unwrap_or_else(|| insert_err.to_string().to_lowercase());
+    assert!(
+        insert_msg.contains("permission denied") || insert_msg.contains("denied"),
+        "expected 'permission denied' on INSERT, got: {insert_msg:?}"
+    );
+
+    // UPDATE must fail with permission denied.
+    let update_err = ro_conn
+        .simple_query("UPDATE test_tbl SET val = 'x' WHERE true")
+        .await
+        .expect_err("UPDATE should be denied for the read-only role");
+    let update_msg = update_err
+        .as_db_error()
+        .map(|d| d.message().to_lowercase())
+        .unwrap_or_else(|| update_err.to_string().to_lowercase());
+    assert!(
+        update_msg.contains("permission denied") || update_msg.contains("denied"),
+        "expected 'permission denied' on UPDATE, got: {update_msg:?}"
+    );
+
+    // DELETE must fail with permission denied.
+    let delete_err = ro_conn
+        .simple_query("DELETE FROM test_tbl WHERE true")
+        .await
+        .expect_err("DELETE should be denied for the read-only role");
+    let delete_msg = delete_err
+        .as_db_error()
+        .map(|d| d.message().to_lowercase())
+        .unwrap_or_else(|| delete_err.to_string().to_lowercase());
+    assert!(
+        delete_msg.contains("permission denied") || delete_msg.contains("denied"),
+        "expected 'permission denied' on DELETE, got: {delete_msg:?}"
+    );
+
+    // DDL (CREATE TABLE) must fail with permission denied.
+    let ddl_err = ro_conn
+        .simple_query("CREATE TABLE should_fail (id int)")
+        .await
+        .expect_err("CREATE TABLE should be denied for the read-only role");
+    let ddl_msg = ddl_err
+        .as_db_error()
+        .map(|d| d.message().to_lowercase())
+        .unwrap_or_else(|| ddl_err.to_string().to_lowercase());
+    assert!(
+        ddl_msg.contains("permission denied") || ddl_msg.contains("denied"),
+        "expected 'permission denied' on CREATE TABLE, got: {ddl_msg:?}"
+    );
+
+    cleanup(ro_user, owner_user, tenant_db, "").await;
+    Ok(())
+}
+
+// ── Test 2: Role is scoped to tenant DB only ──────────────────────────────────
+
+#[tokio::test]
+async fn readonly_role_scoped_to_tenant_db() -> anyhow::Result<()> {
+    let ro_user = &format!("{PREFIX}.scoped_ro");
+    let owner_user = &format!("{PREFIX}.scoped_owner");
+    let owner_password = "owner-pw-scope";
+    let ro_password = "ro-pw-scope";
+    let tenant_db = "odoo_test_ro_scoped";
+    let other_db = "odoo_test_ro_other_tenant";
+
+    cleanup(ro_user, owner_user, tenant_db, other_db).await;
+    setup_tenant(owner_user, owner_password, tenant_db).await;
+
+    // Create a second "other tenant" DB that the RO role should NOT access.
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{other_db}""#))
+        .await;
+    c.simple_query(&format!(r#"CREATE DATABASE "{other_db}""#))
+        .await
+        .expect("create other tenant db");
+
+    let cfg = cluster_config();
+    pg_manager()
+        .ensure_readonly_role(
+            &cfg,
+            ReadonlyRoleParams {
+                ro_username: ro_user,
+                ro_password,
+                owner_username: owner_user,
+                owner_password,
+                db_name: tenant_db,
+                connection_limit: 5,
+            },
+        )
+        .await
+        .expect("ensure_readonly_role failed");
+
+    // Connection to the tenant DB must succeed.
+    try_connect_as(ro_user, ro_password, tenant_db)
+        .await
+        .expect("ro role should connect to its own tenant db");
+
+    // Connection to the OTHER tenant DB must fail (no CONNECT privilege).
+    let cross_err = try_connect_as(ro_user, ro_password, other_db).await;
+    assert!(
+        cross_err.is_err(),
+        "ro role must NOT be able to connect to a different tenant's database"
+    );
+    let cross_pg_msg = cross_err
+        .as_ref()
+        .unwrap_err()
+        .as_db_error()
+        .map(|d| d.message().to_lowercase())
+        .unwrap_or_else(|| cross_err.unwrap_err().to_string().to_lowercase());
+    assert!(
+        cross_pg_msg.contains("permission denied") || cross_pg_msg.contains("denied"),
+        "expected CONNECT denied on other tenant db, got: {cross_pg_msg:?}"
+    );
+
+    cleanup(ro_user, owner_user, tenant_db, other_db).await;
+    Ok(())
+}
+
+// ── Test 3: delete_readonly_role drops the role; login fails after ────────────
+
+#[tokio::test]
+async fn readonly_role_teardown_drops_role() -> anyhow::Result<()> {
+    let ro_user = &format!("{PREFIX}.teardown_ro");
+    let owner_user = &format!("{PREFIX}.teardown_owner");
+    let owner_password = "owner-pw-td";
+    let ro_password = "ro-pw-td";
+    let tenant_db = "odoo_test_ro_teardown";
+
+    cleanup(ro_user, owner_user, tenant_db, "").await;
+    setup_tenant(owner_user, owner_password, tenant_db).await;
+
+    let cfg = cluster_config();
+    pg_manager()
+        .ensure_readonly_role(
+            &cfg,
+            ReadonlyRoleParams {
+                ro_username: ro_user,
+                ro_password,
+                owner_username: owner_user,
+                owner_password,
+                db_name: tenant_db,
+                connection_limit: 5,
+            },
+        )
+        .await
+        .expect("ensure_readonly_role failed");
+
+    // Confirm the role exists and can connect before teardown.
+    try_connect_as(ro_user, ro_password, tenant_db)
+        .await
+        .expect("ro role should be able to connect before teardown");
+
+    // Delete the role.
+    pg_manager()
+        .delete_readonly_role(&cfg, ro_user, tenant_db)
+        .await
+        .expect("delete_readonly_role failed");
+
+    // After deletion, login must fail.
+    let login_err = try_connect_as(ro_user, ro_password, tenant_db).await;
+    assert!(
+        login_err.is_err(),
+        "login should fail after delete_readonly_role — role must have been dropped"
+    );
+
+    // Verify the role is gone from pg_roles.
+    let c = admin_client().await;
+    let row = c
+        .query_one(
+            "SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = $1)",
+            &[ro_user],
+        )
+        .await
+        .expect("pg_roles query failed");
+    let exists: bool = row.get(0);
+    assert!(!exists, "role must not exist in pg_roles after delete_readonly_role");
+
+    cleanup(ro_user, owner_user, tenant_db, "").await;
+    Ok(())
+}
+
+// ── Test 4: delete_readonly_role is idempotent (no-op if already absent) ──────
+
+#[tokio::test]
+async fn readonly_role_delete_is_idempotent() -> anyhow::Result<()> {
+    let ro_user = &format!("{PREFIX}.noop_ro");
+    let cfg = cluster_config();
+
+    // Ensure role is absent to start.
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{ro_user}""#))
+        .await;
+
+    // Calling delete on a non-existent role must be a no-op (not an error).
+    pg_manager()
+        .delete_readonly_role(&cfg, ro_user, "odoo_nonexistent_db")
+        .await
+        .expect("delete_readonly_role must be a no-op when role does not exist");
+
+    Ok(())
+}

--- a/tests/postgres_harness/readonly_role.rs
+++ b/tests/postgres_harness/readonly_role.rs
@@ -86,7 +86,9 @@ async fn setup_tenant(owner_user: &str, owner_password: &str, tenant_db: &str) {
     let (owner_conn, conn) = tokio_postgres::connect(&owner_connstr, tokio_postgres::NoTls)
         .await
         .expect("connect as owner");
-    tokio::spawn(async move { let _ = conn.await; });
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
     owner_conn
         .simple_query("CREATE TABLE test_tbl (id serial PRIMARY KEY, val text)")
         .await
@@ -134,7 +136,9 @@ async fn readonly_role_select_allowed_dml_denied() -> anyhow::Result<()> {
     let (ro_conn, conn) = tokio_postgres::connect(&ro_connstr, tokio_postgres::NoTls)
         .await
         .expect("ro role should be able to CONNECT to tenant db");
-    tokio::spawn(async move { let _ = conn.await; });
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
 
     // SELECT must succeed.
     let rows = ro_conn
@@ -327,7 +331,10 @@ async fn readonly_role_teardown_drops_role() -> anyhow::Result<()> {
         .await
         .expect("pg_roles query failed");
     let exists: bool = row.get(0);
-    assert!(!exists, "role must not exist in pg_roles after delete_readonly_role");
+    assert!(
+        !exists,
+        "role must not exist in pg_roles after delete_readonly_role"
+    );
 
     cleanup(ro_user, owner_user, tenant_db, "").await;
     Ok(())

--- a/tests/postgres_harness/readonly_role.rs
+++ b/tests/postgres_harness/readonly_role.rs
@@ -3,12 +3,17 @@
 //!
 //! Invariants asserted here:
 //!   1. Granted role can SELECT but not INSERT / UPDATE / DELETE / DDL.
-//!   2. Role is scoped to the tenant DB — CONNECT on a second DB is denied.
+//!   2. Role cannot read another tenant's data — it holds no SELECT grants
+//!      outside its own tenant DB (connectivity to a sibling DB, which PUBLIC
+//!      still permits, exposes nothing).
 //!   3. `delete_readonly_role` drops the role; subsequent login fails.
 
 use odoo_operator::postgres::{PostgresManager, ReadonlyRoleParams};
 
-use super::harness::{admin_client, cluster_config, pg_manager, try_connect_as};
+use super::harness::{
+    admin_client, cluster_config, connect_as, pg_manager, try_connect_as, ADMIN_PASSWORD,
+    ADMIN_USER,
+};
 
 /// Unique prefix so tests can run in parallel without collisions.
 const PREFIX: &str = "odoo.test.ro";
@@ -209,10 +214,15 @@ async fn readonly_role_select_allowed_dml_denied() -> anyhow::Result<()> {
     Ok(())
 }
 
-// ── Test 2: Role is scoped to tenant DB only ──────────────────────────────────
+// ── Test 2: Role cannot read another tenant's data ────────────────────────────
+//
+// We no longer revoke PUBLIC CONNECT cluster-wide, so the RO role *can* connect
+// to a sibling tenant DB (PUBLIC grants CONNECT by default).  The boundary that
+// actually matters — and that this role does enforce — is that it holds no
+// SELECT grants outside its own tenant DB, so it can read nothing there.
 
 #[tokio::test]
-async fn readonly_role_scoped_to_tenant_db() -> anyhow::Result<()> {
+async fn readonly_role_cannot_read_other_tenant_data() -> anyhow::Result<()> {
     let ro_user = &format!("{PREFIX}.scoped_ro");
     let owner_user = &format!("{PREFIX}.scoped_owner");
     let owner_password = "owner-pw-scope";
@@ -223,7 +233,7 @@ async fn readonly_role_scoped_to_tenant_db() -> anyhow::Result<()> {
     cleanup(ro_user, owner_user, tenant_db, other_db).await;
     setup_tenant(owner_user, owner_password, tenant_db).await;
 
-    // Create a second "other tenant" DB that the RO role should NOT access.
+    // Create a second "other tenant" DB with a table holding sensitive data.
     let c = admin_client().await;
     let _ = c
         .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{other_db}""#))
@@ -231,6 +241,14 @@ async fn readonly_role_scoped_to_tenant_db() -> anyhow::Result<()> {
     c.simple_query(&format!(r#"CREATE DATABASE "{other_db}""#))
         .await
         .expect("create other tenant db");
+    let other_admin = connect_as(ADMIN_USER, ADMIN_PASSWORD, other_db).await;
+    other_admin
+        .simple_query(
+            "CREATE TABLE secret_tbl (id serial PRIMARY KEY, val text); \
+             INSERT INTO secret_tbl (val) VALUES ('other-tenant-secret')",
+        )
+        .await
+        .expect("create secret table in other tenant db");
 
     let cfg = cluster_config();
     pg_manager()
@@ -253,21 +271,20 @@ async fn readonly_role_scoped_to_tenant_db() -> anyhow::Result<()> {
         .await
         .expect("ro role should connect to its own tenant db");
 
-    // Connection to the OTHER tenant DB must fail (no CONNECT privilege).
-    let cross_err = try_connect_as(ro_user, ro_password, other_db).await;
-    assert!(
-        cross_err.is_err(),
-        "ro role must NOT be able to connect to a different tenant's database"
-    );
-    let cross_pg_msg = cross_err
-        .as_ref()
-        .unwrap_err()
+    // The RO role may connect to the other tenant DB (PUBLIC CONNECT), but it
+    // must NOT be able to read any data there — no SELECT/USAGE was granted.
+    let ro_other = connect_as(ro_user, ro_password, other_db).await;
+    let read_err = ro_other
+        .simple_query("SELECT val FROM secret_tbl")
+        .await
+        .expect_err("ro role must NOT be able to read another tenant's data");
+    let read_msg = read_err
         .as_db_error()
         .map(|d| d.message().to_lowercase())
-        .unwrap_or_else(|| cross_err.unwrap_err().to_string().to_lowercase());
+        .unwrap_or_else(|| read_err.to_string().to_lowercase());
     assert!(
-        cross_pg_msg.contains("permission denied") || cross_pg_msg.contains("denied"),
-        "expected CONNECT denied on other tenant db, got: {cross_pg_msg:?}"
+        read_msg.contains("permission denied") || read_msg.contains("denied"),
+        "expected permission denied reading other tenant's table, got: {read_msg:?}"
     );
 
     cleanup(ro_user, owner_user, tenant_db, other_db).await;

--- a/tests/readonly_sql_access_test.rs
+++ b/tests/readonly_sql_access_test.rs
@@ -8,10 +8,7 @@ use odoo_operator::helpers::{odoo_ro_username, odoo_username};
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
-fn make_instance_with_ro(
-    ro_enabled: bool,
-    connection_limit: i32,
-) -> OdooInstance {
+fn make_instance_with_ro(ro_enabled: bool, connection_limit: i32) -> OdooInstance {
     OdooInstance {
         metadata: ObjectMeta {
             name: Some("rwi2".to_string()),
@@ -122,7 +119,9 @@ fn crd_field_enabled_false_round_trips() {
 fn crd_field_json_round_trips() {
     let inst = make_instance_with_ro(true, 10);
     let json = serde_json::to_value(&inst.spec).unwrap();
-    let ro = json.get("readOnlySqlAccess").expect("readOnlySqlAccess present");
+    let ro = json
+        .get("readOnlySqlAccess")
+        .expect("readOnlySqlAccess present");
     assert_eq!(ro["enabled"], true);
     assert_eq!(ro["connectionLimit"], 10);
 }

--- a/tests/readonly_sql_access_test.rs
+++ b/tests/readonly_sql_access_test.rs
@@ -1,0 +1,188 @@
+//! Unit tests for the readOnlySqlAccess CRD field and read-only role helpers.
+
+use kube::api::ObjectMeta;
+use odoo_operator::crd::odoo_instance::{
+    CronSpec, DatabaseSpec, IngressSpec, OdooInstance, OdooInstanceSpec, ReadOnlySqlAccessSpec,
+};
+use odoo_operator::helpers::{odoo_ro_username, odoo_username};
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+fn make_instance_with_ro(
+    ro_enabled: bool,
+    connection_limit: i32,
+) -> OdooInstance {
+    OdooInstance {
+        metadata: ObjectMeta {
+            name: Some("rwi2".to_string()),
+            namespace: Some("rwi".to_string()),
+            uid: Some("ae819407-a467-4155-b2b2-8f38c400fb1f".to_string()),
+            ..Default::default()
+        },
+        spec: OdooInstanceSpec {
+            image: None,
+            image_pull_secret: None,
+            admin_password: "admin".to_string(),
+            replicas: 1,
+            cron: CronSpec::default(),
+            ingress: IngressSpec {
+                hosts: vec!["rwi2.example.com".to_string()],
+                issuer: None,
+                class: None,
+                gateway_ref: None,
+            },
+            resources: None,
+            filestore: None,
+            config_options: None,
+            database: Some(DatabaseSpec {
+                cluster: None,
+                name: Some("odoo_ae819407_a467_4155_b2b2_8f38c400fb1f".to_string()),
+                missing_policy: Default::default(),
+            }),
+            init: Default::default(),
+            environment: Default::default(),
+            production_instance_ref: None,
+            strategy: None,
+            webhook: None,
+            probes: None,
+            affinity: None,
+            tolerations: vec![],
+            read_only_sql_access: Some(ReadOnlySqlAccessSpec {
+                enabled: ro_enabled,
+                connection_limit,
+            }),
+        },
+        status: None,
+    }
+}
+
+fn make_instance_no_ro() -> OdooInstance {
+    OdooInstance {
+        metadata: ObjectMeta {
+            name: Some("basic".to_string()),
+            namespace: Some("ns".to_string()),
+            uid: Some("00000000-0000-0000-0000-000000000001".to_string()),
+            ..Default::default()
+        },
+        spec: OdooInstanceSpec {
+            image: None,
+            image_pull_secret: None,
+            admin_password: "admin".to_string(),
+            replicas: 1,
+            cron: CronSpec::default(),
+            ingress: IngressSpec {
+                hosts: vec!["basic.example.com".to_string()],
+                issuer: None,
+                class: None,
+                gateway_ref: None,
+            },
+            resources: None,
+            filestore: None,
+            config_options: None,
+            database: None,
+            init: Default::default(),
+            environment: Default::default(),
+            production_instance_ref: None,
+            strategy: None,
+            webhook: None,
+            probes: None,
+            affinity: None,
+            tolerations: vec![],
+            read_only_sql_access: None,
+        },
+        status: None,
+    }
+}
+
+// ── CRD field round-trip ─────────────────────────────────────────────────────
+
+#[test]
+fn crd_field_absent_by_default() {
+    let inst = make_instance_no_ro();
+    assert!(inst.spec.read_only_sql_access.is_none());
+}
+
+#[test]
+fn crd_field_enabled_true_round_trips() {
+    let inst = make_instance_with_ro(true, 5);
+    let spec = inst.spec.read_only_sql_access.as_ref().unwrap();
+    assert!(spec.enabled);
+    assert_eq!(spec.connection_limit, 5);
+}
+
+#[test]
+fn crd_field_enabled_false_round_trips() {
+    let inst = make_instance_with_ro(false, 3);
+    let spec = inst.spec.read_only_sql_access.as_ref().unwrap();
+    assert!(!spec.enabled);
+    assert_eq!(spec.connection_limit, 3);
+}
+
+#[test]
+fn crd_field_json_round_trips() {
+    let inst = make_instance_with_ro(true, 10);
+    let json = serde_json::to_value(&inst.spec).unwrap();
+    let ro = json.get("readOnlySqlAccess").expect("readOnlySqlAccess present");
+    assert_eq!(ro["enabled"], true);
+    assert_eq!(ro["connectionLimit"], 10);
+}
+
+#[test]
+fn crd_field_absent_serialises_without_key() {
+    let inst = make_instance_no_ro();
+    let json = serde_json::to_value(&inst.spec).unwrap();
+    // skip_serializing_if = "Option::is_none" means the key must be absent.
+    assert!(
+        json.get("readOnlySqlAccess").is_none(),
+        "readOnlySqlAccess should not appear when None"
+    );
+}
+
+// ── ro_username derivation ───────────────────────────────────────────────────
+
+#[test]
+fn ro_username_is_owner_plus_suffix() {
+    let owner = odoo_username("rwi", "rwi2");
+    let ro = odoo_ro_username("rwi", "rwi2");
+    assert_eq!(owner, "odoo.rwi.rwi2");
+    assert_eq!(ro, "odoo.rwi.rwi2_ro");
+}
+
+#[test]
+fn ro_username_does_not_have_createdb() {
+    // The role name itself should end in _ro — convention that communicates
+    // the role is read-only.  Actual NOSUPERUSER/NOCREATEDB enforcement lives
+    // in the PgPostgresManager SQL, but the name is the first signal.
+    let ro = odoo_ro_username("ns", "inst");
+    assert!(ro.ends_with("_ro"), "ro role name must end with _ro");
+}
+
+// ── ReadOnlySqlAccessSpec defaults ──────────────────────────────────────────
+
+#[test]
+fn ro_spec_default_is_disabled() {
+    let spec = ReadOnlySqlAccessSpec::default();
+    assert!(!spec.enabled);
+    assert_eq!(spec.connection_limit, 5);
+}
+
+// ── Reconcile guard — enabled check ─────────────────────────────────────────
+
+#[test]
+fn reconcile_guard_enabled_flag() {
+    // Simulate the guard used in reconcile_instance: only provision when enabled.
+    let enabled_inst = make_instance_with_ro(true, 5);
+    let disabled_inst = make_instance_with_ro(false, 5);
+    let absent_inst = make_instance_no_ro();
+
+    let should_provision = |inst: &OdooInstance| {
+        inst.spec
+            .read_only_sql_access
+            .as_ref()
+            .is_some_and(|s| s.enabled)
+    };
+
+    assert!(should_provision(&enabled_inst));
+    assert!(!should_provision(&disabled_inst));
+    assert!(!should_provision(&absent_inst));
+}


### PR DESCRIPTION
Adds an opt-in OdooInstance CRD field that provisions a per-tenant READ-ONLY Postgres role (#3731). The role is the SELECT-only **enforcement floor** for in-cluster read-only SQL access — consumed from inside the tenant's own pod (e.g. an in-Odoo read-only SQL console), never network-exposed.

- SELECT-only role on the tenant DB (GRANT SELECT + USAGE + ALTER DEFAULT PRIVILEGES; no INSERT/UPDATE/DELETE/DDL), password in a managed Secret.
- GRANT CONNECT to the `_ro` role on its own tenant DB. **No cluster-wide PUBLIC CONNECT revoke**: the credential is never reachable from outside the cluster and holds no SELECT grants on sibling DBs, so connectivity to a sibling exposes nothing. This avoids the one-way, global side effect of revoking PUBLIC CONNECT across the whole shared cluster on every reconcile.
- Clean teardown: ALTER DEFAULT PRIVILEGES REVOKE + DROP OWNED before DROP ROLE; Secret deleted on disable / instance deletion.
- Opt-in (absent/`false` -> nothing created); idempotent reconcile.
- Docker-backed tests: SELECT-only (DML/DDL denied), cannot-read-other-tenant-data, teardown, idempotence. fmt + clippy clean.

**Scope:** this PR is the DB-side authorization layer only. Why a dedicated role rather than a read-only transaction on the owner connection: a privilege boundary is content-independent (writable CTEs, `SET` tricks, embedded `COMMIT` can all defeat an app-imposed read-only transaction), which matters when the consumer hands a credential to an AI agent. The consumer (an Odoo read-only SQL console module) and the operator env-injection that wires the RO Secret into the web pod are tracked separately as the module task.

Pipeline artifacts: https://git.bemade.org/bemade/tasks/-/tree/main/task-3731-client-direct-sql-access