### PR TITLE
feat: inject read-only SQL credentials into the web pod when readOnlySqlAccess is enabled

### DIFF
--- a/src/controller/child_resources.rs
+++ b/src/controller/child_resources.rs
@@ -9,9 +9,9 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::{
     apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy},
     core::v1::{
-        ConfigMap, Container, ContainerPort, ExecAction, HTTPGetAction, PersistentVolumeClaim,
-        PersistentVolumeClaimSpec, PodSpec, PodTemplateSpec, Probe, Secret, Service, ServicePort,
-        ServiceSpec, TypedObjectReference, VolumeResourceRequirements,
+        ConfigMap, Container, ContainerPort, EnvVar, ExecAction, HTTPGetAction,
+        PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec, PodTemplateSpec, Probe, Secret,
+        Service, ServicePort, ServiceSpec, TypedObjectReference, VolumeResourceRequirements,
     },
     networking::v1::{
         HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
@@ -42,7 +42,7 @@ use crate::postgres::PostgresClusterConfig;
 
 use super::helpers::{
     cron_depl_name, env, image_pull_secrets, odoo_security_context, odoo_volume_mounts,
-    odoo_volumes, FIELD_MANAGER,
+    odoo_volumes, secret_env, FIELD_MANAGER,
 };
 use super::odoo_instance::Context;
 
@@ -718,7 +718,8 @@ pub async fn ensure_deployment(
     // Override PGDATABASE so the Odoo config layer (which reads env vars
     // with higher priority than the config file) uses the correct database.
     let db = db_name(instance);
-    let pg_env = vec![env("PGDATABASE", &db)];
+    let mut pg_env = vec![env("PGDATABASE", &db)];
+    pg_env.extend(readonly_sql_env(instance));
 
     let make_http_probe = |path: &str| -> Probe {
         Probe {
@@ -1124,6 +1125,28 @@ pub async fn ensure_cron_deployment(
 /// Name of the Secret that holds the read-only role password.
 pub fn ro_secret_name(instance_name: &str) -> String {
     format!("{instance_name}-db-ro-password")
+}
+
+/// Build the env vars that expose the read-only DB credentials to the web pod.
+///
+/// Returns two `EnvVar`s sourced from the `<instance>-db-ro-password` Secret
+/// when `spec.readOnlySqlAccess.enabled` is true; otherwise returns an empty
+/// Vec.  Called from `ensure_deployment` to extend the container env.
+pub fn readonly_sql_env(instance: &OdooInstance) -> Vec<EnvVar> {
+    if instance
+        .spec
+        .read_only_sql_access
+        .as_ref()
+        .is_some_and(|s| s.enabled)
+    {
+        let secret = ro_secret_name(&instance.name_any());
+        vec![
+            secret_env("ODOO_RO_DB_USER", &secret, "username"),
+            secret_env("ODOO_RO_DB_PASSWORD", &secret, "password"),
+        ]
+    } else {
+        vec![]
+    }
 }
 
 /// Ensure the k8s Secret for the read-only role exists.

--- a/src/controller/helpers.rs
+++ b/src/controller/helpers.rs
@@ -9,7 +9,7 @@ use k8s_openapi::api::{
     batch::v1::{Job, JobSpec},
     core::v1::{
         Affinity, ConfigMapKeySelector, Container, EnvVar, EnvVarSource, LocalObjectReference,
-        PodSecurityContext, PodSpec, PodTemplateSpec, Volume, VolumeMount,
+        PodSecurityContext, PodSpec, PodTemplateSpec, SecretKeySelector, Volume, VolumeMount,
     },
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
@@ -168,6 +168,22 @@ pub fn cm_env(env_name: &str, cm_name: &str, key: &str) -> EnvVar {
         value_from: Some(EnvVarSource {
             config_map_key_ref: Some(ConfigMapKeySelector {
                 name: cm_name.into(),
+                key: key.into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Build an `EnvVar` that reads its value from a Secret key.
+pub fn secret_env(env_name: &str, secret_name: &str, key: &str) -> EnvVar {
+    EnvVar {
+        name: env_name.into(),
+        value_from: Some(EnvVarSource {
+            secret_key_ref: Some(SecretKeySelector {
+                name: secret_name.into(),
                 key: key.into(),
                 ..Default::default()
             }),

--- a/tests/ro_env_injection_test.rs
+++ b/tests/ro_env_injection_test.rs
@@ -1,0 +1,148 @@
+//! Unit tests for `readonly_sql_env` — env-var injection for the read-only
+//! SQL access feature.
+
+use k8s_openapi::api::core::v1::EnvVarSource;
+use kube::api::ObjectMeta;
+
+use odoo_operator::controller::child_resources::{readonly_sql_env, ro_secret_name};
+use odoo_operator::crd::odoo_instance::{
+    CronSpec, IngressSpec, OdooInstance, OdooInstanceSpec, ReadOnlySqlAccessSpec,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn make_instance(name: &str, ro: Option<ReadOnlySqlAccessSpec>) -> OdooInstance {
+    OdooInstance {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some("test-ns".to_string()),
+            uid: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()),
+            ..Default::default()
+        },
+        spec: OdooInstanceSpec {
+            image: None,
+            image_pull_secret: None,
+            admin_password: "admin".to_string(),
+            replicas: 1,
+            cron: CronSpec::default(),
+            ingress: IngressSpec {
+                hosts: vec!["test.example.com".to_string()],
+                issuer: None,
+                class: None,
+                gateway_ref: None,
+            },
+            resources: None,
+            filestore: None,
+            config_options: None,
+            database: None,
+            init: Default::default(),
+            environment: Default::default(),
+            production_instance_ref: None,
+            strategy: None,
+            webhook: None,
+            probes: None,
+            affinity: None,
+            tolerations: vec![],
+            read_only_sql_access: ro,
+        },
+        status: None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn readonly_sql_env_enabled_returns_two_vars() {
+    let inst = make_instance(
+        "myinstance",
+        Some(ReadOnlySqlAccessSpec {
+            enabled: true,
+            connection_limit: 5,
+        }),
+    );
+    let vars = readonly_sql_env(&inst);
+    assert_eq!(vars.len(), 2, "expected exactly 2 env vars when enabled");
+
+    let user_var = vars.iter().find(|v| v.name == "ODOO_RO_DB_USER");
+    let pass_var = vars.iter().find(|v| v.name == "ODOO_RO_DB_PASSWORD");
+
+    assert!(user_var.is_some(), "ODOO_RO_DB_USER must be present");
+    assert!(pass_var.is_some(), "ODOO_RO_DB_PASSWORD must be present");
+}
+
+#[test]
+fn readonly_sql_env_user_points_at_correct_secret_and_key() {
+    let inst = make_instance(
+        "myinstance",
+        Some(ReadOnlySqlAccessSpec {
+            enabled: true,
+            connection_limit: 5,
+        }),
+    );
+    let vars = readonly_sql_env(&inst);
+    let user_var = vars.iter().find(|v| v.name == "ODOO_RO_DB_USER").unwrap();
+
+    let secret_ref = match &user_var.value_from {
+        Some(EnvVarSource {
+            secret_key_ref: Some(r),
+            ..
+        }) => r,
+        _ => panic!("ODOO_RO_DB_USER must use secretKeyRef"),
+    };
+    assert_eq!(secret_ref.name, ro_secret_name("myinstance"));
+    assert_eq!(secret_ref.key, "username");
+}
+
+#[test]
+fn readonly_sql_env_password_points_at_correct_secret_and_key() {
+    let inst = make_instance(
+        "myinstance",
+        Some(ReadOnlySqlAccessSpec {
+            enabled: true,
+            connection_limit: 5,
+        }),
+    );
+    let vars = readonly_sql_env(&inst);
+    let pass_var = vars
+        .iter()
+        .find(|v| v.name == "ODOO_RO_DB_PASSWORD")
+        .unwrap();
+
+    let secret_ref = match &pass_var.value_from {
+        Some(EnvVarSource {
+            secret_key_ref: Some(r),
+            ..
+        }) => r,
+        _ => panic!("ODOO_RO_DB_PASSWORD must use secretKeyRef"),
+    };
+    assert_eq!(secret_ref.name, ro_secret_name("myinstance"));
+    assert_eq!(secret_ref.key, "password");
+}
+
+#[test]
+fn readonly_sql_env_disabled_returns_empty() {
+    let inst = make_instance(
+        "myinstance",
+        Some(ReadOnlySqlAccessSpec {
+            enabled: false,
+            connection_limit: 5,
+        }),
+    );
+    let vars = readonly_sql_env(&inst);
+    assert!(
+        vars.is_empty(),
+        "expected no env vars when enabled: false, got {:?}",
+        vars.iter().map(|v| &v.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn readonly_sql_env_absent_returns_empty() {
+    let inst = make_instance("myinstance", None);
+    let vars = readonly_sql_env(&inst);
+    assert!(
+        vars.is_empty(),
+        "expected no env vars when read_only_sql_access is None, got {:?}",
+        vars.iter().map(|v| &v.name).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Completes the `readOnlySqlAccess` feature (#135). That feature provisions a per-tenant SELECT-only Postgres role + the `<instance>-db-ro-password` Secret, but never made those creds reachable by the Odoo process — so an in-pod consumer (the `bemade_sql_console` addon) had no way to connect as the RO role.

This injects, **automatically when `spec.readOnlySqlAccess.enabled` is true**, two env vars into the **web** Deployment, sourced from that Secret via `secretKeyRef`:
- `ODOO_RO_DB_USER` ← key `username`
- `ODOO_RO_DB_PASSWORD` ← key `password`

Host/port are intentionally NOT injected — the consumer derives them from Odoo's own config (primary, or `db_replica_host` if set). The cron deployment is untouched (the console is web/RPC-served).

**Built-in, zero per-instance config** — it can't drift out of sync with the role/Secret the same feature provisions. This is deliberately distinct from the generic `extraEnv`/`extraEnvFrom` passthrough (#127), which would require wiring `extraEnvFrom` → the RO Secret on every instance.

- New `secret_env(name, secret, key)` helper (mirrors `cm_env`).
- `readonly_sql_env(instance)` (pure, testable) extended into the web container env.
- 5 unit tests (enabled → 2 correctly-keyed secretKeyRef vars; disabled/absent → empty). fmt + clippy clean.

Manually verified against rwi2 (the equivalent hand-patch survives reconciles and the console connects). Once released, the hand-patch can be dropped.