### PR TITLE
fix(ci): sanitize workflow_dispatch tag input in release workflow (#136)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,9 +47,20 @@ jobs:
       tag_name: ${{ steps.pick.outputs.tag_name }}
     steps:
       - id: pick
+        # `inputs.tag` is carried via an env var (never inline `${{ }}` in the
+        # script text) and validated against a strict semver tag shape before
+        # use. This closes the script-injection vector (#136): a value that
+        # passes the regex contains no shell metacharacters, which also makes
+        # the downstream `${{ needs.resolve-ref.outputs.tag_name }}` uses safe.
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag_name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            if [[ ! "$DISPATCH_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::invalid tag format: '$DISPATCH_TAG' (expected vMAJOR.MINOR.PATCH, e.g. v1.10.6)"
+              exit 1
+            fi
+            echo "tag_name=$DISPATCH_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "tag_name=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Closes #136.

## Problem
The `resolve-ref` → `pick` step in `release-please.yml` interpolated the `workflow_dispatch` input `inputs.tag` directly into a `run:` script as `${{ inputs.tag }}`. That's a script-injection sink: a crafted tag such as `v1.0.0"; <command>; echo "` executes arbitrary commands in the release runner, which holds `contents: write` / `packages: write`. The path became reachable when #129 made the dispatch build path live (it checks out the tag and builds/publishes from it).

## Fix
Two layers, per GitHub's hardening guidance:

1. **Carry the input via an `env` var** (`DISPATCH_TAG`) instead of inline `${{ }}`. The script body now references the shell variable `$DISPATCH_TAG`, so the value is never substituted into executable script text.
2. **Validate at ingestion** against a strict semver tag shape — `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — erroring with `exit 1` on mismatch. A value that passes carries no shell metacharacters, which also makes the downstream `${{ needs.resolve-ref.outputs.tag_name }}` uses (imagetools inspect, metadata-action, checkout `ref`) safe.

The push path (release-please-generated tags) is unchanged.

## Verification
- YAML parses.
- Regex **accepts** real tags: `v1.10.6`, `v2.3.0`, `v1.0.0-rc.1`.
- Regex **rejects** injection payloads and malformed input: `v1.0.0"; touch /tmp/pwned; echo "`, `v1.2.3 && rm -rf /`, `latest`, `1.2.3`, `v1.0`.
- CI-only change — no Rust touched.