### PR TITLE
fix(webhook): hot-reload TLS serving cert on rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +251,15 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -463,6 +520,26 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -1599,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1737,6 +1814,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1870,7 @@ name = "odoo-operator"
 version = "2.3.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "assert-json-diff",
  "async-trait",
  "chrono",
@@ -1782,19 +1885,33 @@ dependencies = [
  "kube",
  "kube-custom-resources-rs",
  "rand 0.8.5",
+ "rcgen",
  "reqwest",
+ "rustls 0.23.36",
+ "rustls-pemfile",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tokio-rustls 0.26.4",
  "tower-test",
  "tracing",
  "tracing-subscriber",
  "warp",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2054,6 +2171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,6 +2276,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2316,10 +2453,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustix"
-version = "1.1.3"
+name = "rusticata-macros"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2802,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
@@ -2860,6 +3006,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3871,6 +4047,34 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ clap = { version = "4", features = ["derive", "env"] }
 # Webhook server
 warp = { version = "0.3", features = ["tls"] }
 kube-custom-resources-rs = { version = "2024.11.1", features = ["snapshot_storage_k8s_io"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls-pemfile = "2"
+arc-swap = "1"
 
 [dev-dependencies]
 tower-test = "0.4"
@@ -62,3 +66,5 @@ http = "1"
 assert-json-diff = "2"
 http-body-util = "0.1"
 envtest = "0.0.1"
+rcgen = "0.14.8"
+tempfile = "3.27.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ pub mod error;
 pub mod helpers;
 pub mod notify;
 pub mod postgres;
+pub mod tls;
 pub mod webhook;

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,9 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let webhook_addr = std::net::SocketAddr::from(([0, 0, 0, 0], args.webhook_port));
+    let webhook_listener = tokio::net::TcpListener::bind(webhook_addr)
+        .await
+        .expect("failed to bind webhook listener");
     let tls_cert = args.webhook_tls_cert;
     let tls_key = args.webhook_tls_key;
 
@@ -243,7 +246,7 @@ async fn main() -> anyhow::Result<()> {
     // logic via the state machine), webhook server, and health probes.
     tokio::select! {
         _ = controller::odoo_instance::run(ctx.clone()) => {},
-        _ = webhook::run(webhook_addr, &tls_cert, &tls_key) => {},
+        _ = webhook::run(webhook_listener, &tls_cert, &tls_key) => {},
         _ = warp::serve(health_routes).run(health_addr) => {},
     }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,264 @@
+//! Hot-reloading TLS for the validating webhook server.
+//!
+//! Kubernetes (cert-manager) rotates the webhook serving certificate
+//! periodically and writes the new cert/key into the mounted Secret on disk.
+//! A process that loads the certificate only once at startup keeps presenting
+//! the *old* cert after a rotation. The API server — which by then trusts the
+//! *new* CA via the `caBundle` injected into the `ValidatingWebhookConfiguration`
+//! by cert-manager-cainjector — rejects the stale cert with
+//! `x509: certificate signed by unknown authority`, and the webhook stays
+//! broken until the pod is restarted.
+//!
+//! This module closes that gap with a [`ReloadingCertResolver`]: the current
+//! certificate lives in an [`ArcSwap`] consulted on every TLS handshake, and a
+//! background poller reloads it from disk whenever the bytes change. Rotations
+//! are picked up live, with no restart and no dropped connections.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arc_swap::ArcSwap;
+use rustls::crypto::ring::sign::any_supported_type;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+
+/// How often the background task re-reads the cert files looking for a rotation.
+/// Rotations happen on the order of months, so a slow poll is plenty; the cost
+/// of a poll that finds no change is two small file reads and a hash.
+const RELOAD_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A parsed serving certificate plus a fingerprint of the source bytes. The
+/// fingerprint lets the poller skip the swap (and the log line) when the files
+/// are unchanged, which is the overwhelmingly common case.
+struct LoadedCert {
+    certified_key: Arc<CertifiedKey>,
+    fingerprint: [u8; 32],
+}
+
+/// Read the PEM cert chain + private key from disk and build a [`CertifiedKey`],
+/// returning it alongside a SHA-256 fingerprint of the raw file bytes.
+fn load_from_disk(cert_path: &str, key_path: &str) -> Result<LoadedCert> {
+    let cert_pem =
+        std::fs::read(cert_path).with_context(|| format!("reading webhook cert {cert_path}"))?;
+    let key_pem =
+        std::fs::read(key_path).with_context(|| format!("reading webhook key {key_path}"))?;
+
+    let certs = rustls_pemfile::certs(&mut cert_pem.as_slice())
+        .collect::<std::result::Result<Vec<CertificateDer>, _>>()
+        .context("parsing webhook certificate chain")?;
+    if certs.is_empty() {
+        anyhow::bail!("no certificates found in {cert_path}");
+    }
+
+    let key: PrivateKeyDer = rustls_pemfile::private_key(&mut key_pem.as_slice())
+        .context("parsing webhook private key")?
+        .ok_or_else(|| anyhow::anyhow!("no private key found in {key_path}"))?;
+
+    let signing_key = any_supported_type(&key).context("unsupported webhook private key type")?;
+    let certified_key = Arc::new(CertifiedKey::new(certs, signing_key));
+
+    let mut hasher = Sha256::new();
+    hasher.update(&cert_pem);
+    hasher.update(&key_pem);
+    let fingerprint = hasher.finalize().into();
+
+    Ok(LoadedCert {
+        certified_key,
+        fingerprint,
+    })
+}
+
+/// A rustls server-cert resolver whose certificate can be swapped at runtime.
+///
+/// Every handshake reads the current cert via a lock-free [`ArcSwap`] load; the
+/// background poller replaces it in place when a rotation is detected.
+pub struct ReloadingCertResolver {
+    current: ArcSwap<CertifiedKey>,
+}
+
+impl ReloadingCertResolver {
+    fn new(initial: Arc<CertifiedKey>) -> Self {
+        Self {
+            current: ArcSwap::new(initial),
+        }
+    }
+
+    fn store(&self, certified_key: Arc<CertifiedKey>) {
+        self.current.store(certified_key);
+    }
+}
+
+// rustls requires `Debug` on `ResolvesServerCert`; a `CertifiedKey` has no
+// secret-safe Debug we want to leak, so keep it opaque.
+impl std::fmt::Debug for ReloadingCertResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReloadingCertResolver")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvesServerCert for ReloadingCertResolver {
+    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<CertifiedKey>> {
+        Some(self.current.load_full())
+    }
+}
+
+/// Load the webhook cert from disk and spawn a background task that reloads it
+/// every [`RELOAD_INTERVAL`], returning a resolver wired to the live cert.
+///
+/// The *initial* load is fatal on failure — the caller should propagate the
+/// error so the pod crash-loops rather than serve with no certificate. Later
+/// reload failures are non-fatal: they are logged and the last-good cert keeps
+/// serving, so a transient read during an atomic Secret swap can't take the
+/// webhook down.
+pub fn spawn_reloading_resolver(
+    cert_path: &str,
+    key_path: &str,
+) -> Result<Arc<ReloadingCertResolver>> {
+    let initial =
+        load_from_disk(cert_path, key_path).context("initial webhook certificate load")?;
+    let resolver = Arc::new(ReloadingCertResolver::new(initial.certified_key));
+
+    let task_resolver = resolver.clone();
+    let cert_path = cert_path.to_string();
+    let key_path = key_path.to_string();
+    tokio::spawn(async move {
+        let mut current_fp = initial.fingerprint;
+        let mut interval = tokio::time::interval(RELOAD_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // First tick fires immediately; skip it since we just loaded.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            match load_from_disk(&cert_path, &key_path) {
+                Ok(loaded) if loaded.fingerprint != current_fp => {
+                    task_resolver.store(loaded.certified_key);
+                    current_fp = loaded.fingerprint;
+                    info!("webhook serving certificate reloaded after rotation");
+                }
+                Ok(_) => { /* unchanged — the common case */ }
+                Err(e) => {
+                    warn!(error = %e, "failed to reload webhook certificate; keeping current")
+                }
+            }
+        }
+    });
+
+    Ok(resolver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Generate a fresh self-signed cert/key PEM pair for `host`.
+    fn gen_cert_pem(host: &str) -> (String, String) {
+        let cert = rcgen::generate_simple_self_signed(vec![host.to_string()]).unwrap();
+        (cert.cert.pem(), cert.signing_key.serialize_pem())
+    }
+
+    /// Write cert+key PEM into a temp dir, returning the dir and the two paths.
+    fn write_pair(cert_pem: &str, key_pem: &str) -> (tempfile::TempDir, String, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("tls.crt");
+        let key_path = dir.path().join("tls.key");
+        std::fs::File::create(&cert_path)
+            .unwrap()
+            .write_all(cert_pem.as_bytes())
+            .unwrap();
+        std::fs::File::create(&key_path)
+            .unwrap()
+            .write_all(key_pem.as_bytes())
+            .unwrap();
+        (
+            dir,
+            cert_path.to_str().unwrap().to_string(),
+            key_path.to_str().unwrap().to_string(),
+        )
+    }
+
+    #[test]
+    fn load_from_disk_parses_valid_cert() {
+        let (cert_pem, key_pem) = gen_cert_pem("webhook.example.com");
+        let (_dir, cert_path, key_path) = write_pair(&cert_pem, &key_pem);
+
+        let loaded = load_from_disk(&cert_path, &key_path).expect("should parse");
+        assert!(!loaded.certified_key.cert.is_empty(), "chain present");
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_unchanged_files() {
+        let (cert_pem, key_pem) = gen_cert_pem("webhook.example.com");
+        let (_dir, cert_path, key_path) = write_pair(&cert_pem, &key_pem);
+
+        let a = load_from_disk(&cert_path, &key_path).unwrap();
+        let b = load_from_disk(&cert_path, &key_path).unwrap();
+        assert_eq!(
+            a.fingerprint, b.fingerprint,
+            "same bytes must hash identically so the poller skips the swap"
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_after_rotation() {
+        // Simulate cert-manager rotating the serving cert in place.
+        let (cert1, key1) = gen_cert_pem("webhook.example.com");
+        let (dir, cert_path, key_path) = write_pair(&cert1, &key1);
+        let before = load_from_disk(&cert_path, &key_path).unwrap().fingerprint;
+
+        let (cert2, key2) = gen_cert_pem("webhook.example.com");
+        std::fs::write(dir.path().join("tls.crt"), cert2).unwrap();
+        std::fs::write(dir.path().join("tls.key"), key2).unwrap();
+        let after = load_from_disk(&cert_path, &key_path).unwrap().fingerprint;
+
+        assert_ne!(
+            before, after,
+            "a rotated cert must produce a different fingerprint so the poller reloads"
+        );
+    }
+
+    #[test]
+    fn resolver_serves_swapped_cert() {
+        // The resolver must hand out whatever cert was last stored, proving a
+        // rotation is reflected in handshakes without rebuilding the resolver.
+        let (cert1, key1) = gen_cert_pem("webhook.example.com");
+        let (dir, cert_path, key_path) = write_pair(&cert1, &key1);
+        let first = load_from_disk(&cert_path, &key_path).unwrap();
+        let resolver = ReloadingCertResolver::new(first.certified_key.clone());
+
+        let initial = resolver.current.load_full();
+        assert!(Arc::ptr_eq(&initial, &first.certified_key));
+
+        let (cert2, key2) = gen_cert_pem("webhook.example.com");
+        std::fs::write(dir.path().join("tls.crt"), cert2).unwrap();
+        std::fs::write(dir.path().join("tls.key"), key2).unwrap();
+        let second = load_from_disk(&cert_path, &key_path).unwrap();
+        resolver.store(second.certified_key.clone());
+
+        let after = resolver.current.load_full();
+        assert!(
+            Arc::ptr_eq(&after, &second.certified_key),
+            "resolver must serve the cert stored after rotation"
+        );
+        assert!(!Arc::ptr_eq(&after, &first.certified_key));
+    }
+
+    #[test]
+    fn load_from_disk_errors_on_missing_file() {
+        let err = load_from_disk("/nonexistent/tls.crt", "/nonexistent/tls.key");
+        assert!(err.is_err(), "missing cert file must be an error");
+    }
+
+    #[test]
+    fn load_from_disk_errors_on_empty_cert() {
+        let (_cert_pem, key_pem) = gen_cert_pem("webhook.example.com");
+        let (_dir, cert_path, key_path) = write_pair("", &key_pem);
+        let err = load_from_disk(&cert_path, &key_path);
+        assert!(err.is_err(), "empty cert chain must be an error");
+    }
+}

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -7,16 +7,29 @@
 //! handles migration automatically.  Changes are rejected during unsafe
 //! phases (Restoring, Upgrading, BackingUp, migrating phases, Uninitialized).
 
+use std::sync::Arc;
+
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, AdmissionReview};
-use tracing::{info, warn};
+use rustls::ServerConfig;
+use tokio_rustls::TlsAcceptor;
+use tracing::{error, info, warn};
 use warp::Filter;
 
 use crate::crd::odoo_instance::OdooInstance;
 use crate::helpers::parse_quantity;
+use crate::tls::spawn_reloading_resolver;
 
-/// Start the validating webhook server on the given address.
+/// Start the validating webhook server on an already-bound TCP listener.
 /// Returns a future that runs the HTTPS server forever.
-pub async fn run(addr: std::net::SocketAddr, tls_cert: &str, tls_key: &str) {
+///
+/// Taking a pre-bound listener (rather than a `SocketAddr`) lets callers — and
+/// tests — observe the actual bound port via [`tokio::net::TcpListener::local_addr`].
+///
+/// TLS termination is handled here (rather than via warp's built-in
+/// `.tls().cert_path()`) so the serving certificate can be **hot-reloaded**
+/// when cert-manager rotates it — see [`crate::tls`]. Decrypted connections are
+/// fed to the warp filter via [`warp::Server::run_incoming`].
+pub async fn run(listener: tokio::net::TcpListener, tls_cert: &str, tls_key: &str) {
     let route = warp::post()
         .and(warp::path("validate-bemade-org-v1alpha1-odooinstance"))
         .and(warp::body::json())
@@ -34,13 +47,64 @@ pub async fn run(addr: std::net::SocketAddr, tls_cert: &str, tls_key: &str) {
             warp::reply::json(&resp.into_review())
         });
 
-    info!(%addr, "starting validating webhook server");
-    warp::serve(route)
-        .tls()
-        .cert_path(tls_cert)
-        .key_path(tls_key)
-        .run(addr)
-        .await;
+    // A resolver backed by the cert on disk, kept fresh by a background poller.
+    // Failing the initial load is fatal: returning here ends the webhook future
+    // in main's `select!`, which exits the process so the pod restarts.
+    let resolver = match spawn_reloading_resolver(tls_cert, tls_key) {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "failed to load webhook TLS certificate; webhook not started");
+            return;
+        }
+    };
+
+    // Build with the ring provider explicitly so we don't depend on a
+    // process-wide default provider being installed elsewhere.
+    let config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .expect("ring provider supports the default protocol versions")
+            .with_no_client_auth()
+            .with_cert_resolver(resolver);
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+
+    let local_addr = listener.local_addr().ok();
+    info!(
+        ?local_addr,
+        "starting validating webhook server (hot-reloading TLS)"
+    );
+
+    // Accept TCP connections, perform the TLS handshake off the accept path so a
+    // slow/stalled handshake can't block other clients, and stream the decrypted
+    // connections into warp. The channel decouples accept from warp's consumer.
+    let (tx, rx) = tokio::sync::mpsc::channel(128);
+    tokio::spawn(async move {
+        loop {
+            let (tcp, peer) = match listener.accept().await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!(error = %e, "tcp accept failed");
+                    continue;
+                }
+            };
+            let acceptor = acceptor.clone();
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                match acceptor.accept(tcp).await {
+                    Ok(stream) => {
+                        // A send error just means warp has shut down; drop the conn.
+                        let _ = tx.send(Ok::<_, std::io::Error>(stream)).await;
+                    }
+                    Err(e) => warn!(%peer, error = %e, "tls handshake failed"),
+                }
+            });
+        }
+    });
+
+    let incoming = futures::stream::unfold(rx, |mut rx| async move {
+        rx.recv().await.map(|conn| (conn, rx))
+    });
+    warp::serve(route).run_incoming(incoming).await;
 }
 
 /// Validate an OdooInstance admission request.

--- a/tests/webhook_tls.rs
+++ b/tests/webhook_tls.rs
@@ -1,0 +1,205 @@
+//! End-to-end smoke test for the hot-reloading webhook TLS server.
+//!
+//! Proves the production serving path actually works: a real TLS handshake
+//! completes against `webhook::run`, the cert presented is the one on disk
+//! (i.e. the reloading resolver is wired in), and a CREATE `AdmissionReview`
+//! posted over that connection comes back `allowed: true`.
+//!
+//! The per-rotation reload logic itself is unit-tested in `src/tls.rs`; this
+//! test covers the warp `run_incoming` + `tokio-rustls` acceptor glue that
+//! those unit tests can't reach.
+
+use std::io::Write as _;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_rustls::TlsConnector;
+
+/// A client cert verifier that accepts anything but records the leaf cert the
+/// server presented, so the test can assert the resolver served the disk cert.
+#[derive(Debug)]
+struct CapturingVerifier {
+    seen_leaf: Mutex<Option<Vec<u8>>>,
+}
+
+impl ServerCertVerifier for CapturingVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        *self.seen_leaf.lock().unwrap() = Some(end_entity.as_ref().to_vec());
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+        ]
+    }
+}
+
+fn write_pair(dir: &std::path::Path, cert_pem: &str, key_pem: &str) -> (String, String) {
+    let cert_path = dir.join("tls.crt");
+    let key_path = dir.join("tls.key");
+    std::fs::File::create(&cert_path)
+        .unwrap()
+        .write_all(cert_pem.as_bytes())
+        .unwrap();
+    std::fs::File::create(&key_path)
+        .unwrap()
+        .write_all(key_pem.as_bytes())
+        .unwrap();
+    (
+        cert_path.to_str().unwrap().to_string(),
+        key_path.to_str().unwrap().to_string(),
+    )
+}
+
+/// A minimal CREATE AdmissionReview (no oldObject) — `validate()` allows it.
+fn create_review_body() -> String {
+    serde_json::json!({
+        "apiVersion": "admission.k8s.io/v1",
+        "kind": "AdmissionReview",
+        "request": {
+            "uid": "e2e-1",
+            "kind": {"group": "bemade.org", "version": "v1alpha1", "kind": "OdooInstance"},
+            "resource": {"group": "bemade.org", "version": "v1alpha1", "resource": "odooinstances"},
+            "name": "e2e",
+            "namespace": "default",
+            "operation": "CREATE",
+            "userInfo": {"username": "tester"},
+            "object": {
+                "apiVersion": "bemade.org/v1alpha1",
+                "kind": "OdooInstance",
+                "metadata": {"name": "e2e", "namespace": "default", "uid": "e2e-uid"},
+                "spec": {"adminPassword": "x", "ingress": {"hosts": ["e2e.example.com"]}}
+            }
+        }
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn webhook_serves_admission_over_tls_with_disk_cert() {
+    let dir = tempfile::tempdir().unwrap();
+    let cert = rcgen::generate_simple_self_signed(vec!["webhook.example.com".to_string()]).unwrap();
+    let cert_der = cert.cert.der().to_vec();
+    let (cert_path, key_path) = write_pair(
+        dir.path(),
+        &cert.cert.pem(),
+        &cert.signing_key.serialize_pem(),
+    );
+
+    // Bind on an ephemeral port and hand the listener to the server so we know
+    // the real port without a bind race.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        odoo_operator::webhook::run(listener, &cert_path, &key_path).await;
+    });
+
+    // Build a TLS client that trusts nothing but captures the served cert.
+    let verifier = Arc::new(CapturingVerifier {
+        seen_leaf: Mutex::new(None),
+    });
+    let client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(verifier.clone())
+    .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(client_config));
+
+    // Retry the connect briefly while the server task spins up.
+    let body = create_review_body();
+    let mut response = String::new();
+    let mut connected = false;
+    for _ in 0..50 {
+        let tcp = match tokio::net::TcpStream::connect(addr).await {
+            Ok(s) => s,
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                continue;
+            }
+        };
+        let server_name = ServerName::try_from("webhook.example.com").unwrap();
+        let mut tls = match connector.connect(server_name, tcp).await {
+            Ok(s) => s,
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                continue;
+            }
+        };
+        let req = format!(
+            "POST /validate-bemade-org-v1alpha1-odooinstance HTTP/1.1\r\n\
+             Host: webhook.example.com\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\
+             Connection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        tls.write_all(req.as_bytes()).await.unwrap();
+        tls.read_to_string(&mut response).await.unwrap();
+        connected = true;
+        break;
+    }
+
+    assert!(
+        connected,
+        "could not establish a TLS connection to the webhook"
+    );
+    assert!(
+        response.contains("200 OK"),
+        "expected HTTP 200, got:\n{response}"
+    );
+    assert!(
+        response.contains("\"allowed\":true"),
+        "expected admission allowed, got:\n{response}"
+    );
+
+    // The cert the server presented must be exactly the one on disk — proof the
+    // reloading resolver (not some other path) is serving the handshake.
+    let seen = verifier.seen_leaf.lock().unwrap().clone();
+    assert_eq!(
+        seen.as_deref(),
+        Some(cert_der.as_slice()),
+        "server must present the on-disk serving certificate"
+    );
+}


### PR DESCRIPTION
## Problem

The validating admission webhook (`vodooinstance.kb.io`) loaded its serving certificate **once at startup** via warp's `.tls().cert_path()` and never reloaded it.

When cert-manager rotates the webhook cert, cainjector updates the `caBundle` on the `ValidatingWebhookConfiguration` to the **new CA** — but the running operator keeps presenting the **old serving cert** (signed by the old CA key). The API server then rejects every `OdooInstance` create/update:

```
failed calling webhook "vodooinstance.kb.io": tls: failed to verify certificate:
x509: certificate signed by unknown authority (... "odoo-operator-webhook-ca")
```

…and stays broken until the pod is manually restarted. This took down CI deploys on 2026-06-15 after a routine rotation. The Certificates use cert-manager defaults (no explicit `duration`/`renewBefore`), so rotations — and the outage — recur roughly every ~60 days.

## Fix

In-process certificate hot-reload, so rotations are picked up live with **no restart and no dropped connections**:

- **`src/tls.rs`** (new) — `ReloadingCertResolver` holds the serving cert in an `ArcSwap` (lock-free read per handshake). A 30s background poller reloads from disk only when the bytes change (SHA-256 fingerprint guard). Initial load failure is fatal (pod crash-loops); later reload failures keep the last-good cert serving, so a transient read during an atomic Secret swap can't take the webhook down.
- **`src/webhook.rs`** — replaced warp's built-in TLS with a `tokio-rustls` acceptor driven by the resolver, feeding decrypted connections to the **unchanged** validation filter via `run_incoming`. Handshakes run off the accept path so a stalled client can't block others. `run` now takes a pre-bound `TcpListener` (testability seam).
- **`src/main.rs`** binds the listener and passes it in; **`src/lib.rs`** registers the module.
- New deps: `rustls` 0.23 (ring), `tokio-rustls` 0.26, `rustls-pemfile`, `arc-swap`.

## Tests (TDD)

- 6 unit tests in `tls.rs`: cert parsing, fingerprint stability, rotation detection, resolver swap semantics, error paths.
- 1 end-to-end test (`tests/webhook_tls.rs`): real TLS handshake against `webhook::run`, asserts `allowed:true` **and** that the server presents the exact on-disk cert — proving the reloading resolver is the serving path.
- Existing 16 webhook validation tests untouched. `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

## Notes

No Helm/CRD changes — certs are already cert-manager-provisioned; this is purely the operator picking up rotations without a restart.