### PR TITLE
fix(restore): strip COMMENT ON EXTENSION from plain SQL load

### DIFF
--- a/scripts/restore-load-db.sh
+++ b/scripts/restore-load-db.sh
@@ -48,6 +48,14 @@ case "$BACKUP_FORMAT" in
         # robust against any future multi-line variant.  Also strips
         # `SET transaction_timeout = 0` from pg_dump 17+ which earlier
         # servers reject as an unrecognized parameter.
+        #
+        # `COMMENT ON EXTENSION` is dropped because the cluster pre-seeds
+        # extensions (e.g. `vector`) into template1 owned by the `postgres`
+        # superuser; createdb clones template1, so the fresh DB inherits them
+        # owned by postgres.  CREATE EXTENSION IF NOT EXISTS is then a no-op,
+        # but the following COMMENT ON EXTENSION fails with "must be owner of
+        # extension <name>" under the non-superuser restore role.  The comment
+        # is pure metadata, so dropping it is harmless.
         echo "=== Loading plain SQL dump ==="
         sed -E \
             -e '/^SET transaction_timeout /d' \
@@ -55,6 +63,7 @@ case "$BACKUP_FORMAT" in
             -e '/^GRANT [^;]*;$/d' \
             -e '/^REVOKE [^;]*;$/d' \
             -e '/^REASSIGN OWNED BY [^;]*;$/d' \
+            -e '/^COMMENT ON EXTENSION [^;]*;$/d' \
             /workspace/dump.sql | \
             psql -h "$HOST" -p "$PORT" -U "$USER" -d "$DB_NAME" \
                 -v ON_ERROR_STOP=1 --quiet


### PR DESCRIPTION
## Problem

Restoring `fitcrew-19` from an S3 backup failed in `load-db`:

```
=== Loading plain SQL dump ===
 set_config
------------
(1 row)
ERROR:  must be owner of extension vector
=== Load failed (rc=3) — dropping ... ===
```

## Root cause

The CNPG cluster pre-seeds the `vector` extension into **`template1`**, owned by the `postgres` superuser. `createdb` clones `template1`, so the freshly created target DB inherits `vector` owned by `postgres`.

The plain SQL dump (pg_dump 18.4) emits:

```sql
CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;   -- no-op, already present
COMMENT ON EXTENSION vector IS 'vector data type ...';      -- ← fails
```

The non-superuser restore role (`odoo.<ns>.<instance>`) doesn't own the extension, so `COMMENT ON EXTENSION vector` fails with `must be owner of extension vector`. With `ON_ERROR_STOP=1` the whole load aborts and the DB is dropped.

Trusted extensions like `unaccent` are unaffected — the restore role creates and therefore owns them, so their `COMMENT ON EXTENSION` succeeds.

## Fix

Add `COMMENT ON EXTENSION` to the existing cross-cluster noise filter in `restore-load-db.sh`, alongside `OWNER TO` / `GRANT` / `REVOKE` / `REASSIGN`. The comment is pure metadata; dropping it is harmless. `ON_ERROR_STOP=1` is kept so genuine load failures still abort.

Verified against the actual failing dump (`BKP/01688/20260626-174601.zip`): the filter strips both `COMMENT ON EXTENSION` lines while preserving `CREATE EXTENSION` and unrelated `COMMENT ON TABLE` statements.