### PR TITLE
fix(backup): allow backups while the instance is Stopped

### DIFF
--- a/STATE_MACHINE.md
+++ b/STATE_MACHINE.md
@@ -80,6 +80,7 @@ stateDiagram-v2
     Stopped --> Restoring : [restore_job present]
     Stopped --> CloningFromSource : [refresh_job present]
     Stopped --> Upgrading : [upgrade_job ready]
+    Stopped --> BackingUp : [backup_job present]
     Stopped --> Starting : [replicas > 0]
 
     MigratingFilestore --> FinalizingFilestoreMigration : [migration_job succeeded] / CompleteFilestoreMigration

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -1583,6 +1583,18 @@ pub static TRANSITIONS: &[Transition] = &[
         guard_name: "upgrade_job ready",
         actions: &[],
     },
+    // Back up a stopped instance.  The DB cluster and filestore PVC are
+    // independent of the (scaled-to-0) Odoo deployments, so a backup runs
+    // fine while stopped.  The `replicas == 0` clause keeps this exclusive
+    // with the `Stopped → Starting` edge below if a scale-up races a backup;
+    // the matching `BackingUp → Stopped` exit edges return here afterwards.
+    Transition {
+        from: Stopped,
+        to: BackingUp,
+        guard: |i, s| s.backup_job.is_present() && i.spec.replicas == 0,
+        guard_name: "backup_job present",
+        actions: &[],
+    },
     Transition {
         from: Stopped,
         to: Starting,

--- a/src/controller/states/backing_up.rs
+++ b/src/controller/states/backing_up.rs
@@ -178,11 +178,10 @@ impl State for BackingUp {
 
         info!(%crd_name, %dump_image, server_major = %major, "selected pg client image for backup dump");
 
-        let job = OdooJobBuilder::new(&format!("{crd_name}-"), &ns, backup_job, instance)
+        let mut builder = OdooJobBuilder::new(&format!("{crd_name}-"), &ns, backup_job, instance)
             .active_deadline(5400)
             .without_standard_volumes()
             .extra_volumes(vec![workspace_vol, filestore_vol])
-            .affinity(pod_affinity)
             .init_containers(vec![
                 Container {
                     name: "dump".into(),
@@ -209,8 +208,18 @@ impl State for BackingUp {
                 env: Some(upload_env),
                 volume_mounts: Some(vec![workspace_mount]),
                 ..Default::default()
-            }])
-            .build();
+            }]);
+
+        // Co-locate the backup pod with a running Odoo web pod so a node-bound
+        // (RWO) filestore PVC, already mounted there, can also be mounted
+        // read-only here.  When the instance is stopped there are no Odoo pods
+        // and the PVC is unattached, so the backup pod can bind it on any node;
+        // applying the required affinity would instead leave it Pending forever.
+        if snap.ready_replicas > 0 {
+            builder = builder.affinity(pod_affinity);
+        }
+
+        let job = builder.build();
 
         let jobs_api: Api<Job> = Api::namespaced(client.clone(), &ns);
         let created = jobs_api.create(&PostParams::default(), &job).await?;

--- a/tests/integration/backup_job.rs
+++ b/tests/integration/backup_job.rs
@@ -50,6 +50,68 @@ async fn backup_job_lifecycle() {
     ready_handle.abort();
 }
 
+/// A backup requested while the instance is Stopped must run and then return
+/// to Stopped — without needing to scale the instance back up first.
+/// Regression: there was no `Stopped → BackingUp` transition, so backup jobs
+/// created while stopped were ignored until the instance was scaled up.
+#[tokio::test]
+async fn backup_while_stopped() {
+    let ctx = TestContext::new("test-backup-stopped").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let ready_handle = fast_track_to_running(&ctx, "test-backup-stopped-init").await;
+    assert!(
+        wait_for_phase(c, ns, "test-backup-stopped", OdooInstancePhase::Running).await,
+        "expected Running before stopping"
+    );
+
+    // Stop the instance: scale to 0 → Stopped.  Stop faking readiness first so
+    // the scaled-down deployment isn't continuously re-marked ready.
+    ready_handle.abort();
+    patch_instance_spec(c, ns, "test-backup-stopped", json!({ "replicas": 0 })).await;
+    fake_deployment_ready(c, ns, "test-backup-stopped", 0).await;
+    assert!(
+        wait_for_phase(c, ns, "test-backup-stopped", OdooInstancePhase::Stopped).await,
+        "expected Stopped after scaling to 0"
+    );
+
+    // Request a backup while stopped.
+    let backup_api: Api<OdooBackupJob> = Api::namespaced(c.clone(), ns);
+    let backup_job: OdooBackupJob = serde_json::from_value(json!({
+        "apiVersion": "bemade.org/v1alpha1",
+        "kind": "OdooBackupJob",
+        "metadata": { "name": "test-backup-stopped-job", "namespace": ns },
+        "spec": {
+            "odooInstanceRef": { "name": "test-backup-stopped" },
+            "destination": {
+                "bucket": "test-bucket",
+                "objectKey": "test-key",
+                "endpoint": "http://localhost:9000",
+            },
+        }
+    }))
+    .unwrap();
+    backup_api
+        .create(&PostParams::default(), &backup_job)
+        .await
+        .expect("failed to create OdooBackupJob");
+
+    // The operator must pick the backup up directly from Stopped.
+    assert!(
+        wait_for_phase(c, ns, "test-backup-stopped", OdooInstancePhase::BackingUp).await,
+        "expected BackingUp after backup job created while stopped"
+    );
+
+    let k8s_job = wait_for_k8s_job_name::<OdooBackupJob>(c, ns, "test-backup-stopped-job").await;
+    fake_job_succeeded(c, ns, &k8s_job).await;
+
+    // After the backup completes it must return to Stopped, not boot up.
+    assert!(
+        wait_for_phase(c, ns, "test-backup-stopped", OdooInstancePhase::Stopped).await,
+        "expected Stopped again after backup completed (must not scale up)"
+    );
+}
+
 /// Two OdooBackupJobs queued at nearly the same time must not cause the
 /// OdooInstance phase to flap BackingUp → Running → BackingUp as the first
 /// one completes and the reconciler picks up the second.  Regression test


### PR DESCRIPTION
## Problem

An `OdooBackupJob` created while an instance is **Stopped** (`replicas: 0`) was silently ignored — the operator never entered `BackingUp` and never created the underlying K8s Job. Scaling the instance back up to 1 triggered the backup immediately.

Root cause: edges into `BackingUp` existed only from `Starting`, `Running`, and `Degraded`. There was **no `Stopped → BackingUp` transition**, even though the exit side already handled it (`BackingUp → Stopped` on `replicas == 0`). The DB cluster (CNPG) and filestore PVC are independent of the scaled-to-0 Odoo deployments, so a backup can run fine while stopped.

## Changes

- **`state_machine.rs`** — add `Stopped → BackingUp` (guard: `backup_job present && replicas == 0`, kept mutually exclusive with the `Stopped → Starting` edge so a simultaneous scale-up still boots).
- **`states/backing_up.rs`** — the backup pod's `required_during_scheduling` pod-affinity co-locates it with a running Odoo pod so a node-bound (RWO) filestore PVC can be mounted read-only. When stopped there is no such pod and the PVC is unattached, so applying the affinity would leave the pod `Pending` forever — only attach it when `ready_replicas > 0`.
- **`STATE_MACHINE.md`** — regenerated to include the new edge.

## Tests

- New `backup_while_stopped` integration test: `Running → Stopped → BackingUp` (backup picked up while stopped) → job completes → `BackingUp → Stopped` (returns to stopped, does not boot up).
- All existing backup integration tests still pass (lifecycle, concurrent-flap, orphan recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)