### PR TITLE
fix(cleanup): scale deployments down before dropping database (#153)

### DIFF
--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -40,7 +40,8 @@ use crate::helpers::{odoo_username, OperatorDefaults};
 use crate::postgres::{PostgresClusterConfig, PostgresManager};
 
 use super::child_resources;
-use super::helpers::{controller_owner_ref, FIELD_MANAGER};
+use super::helpers::{controller_owner_ref, cron_depl_name, FIELD_MANAGER};
+use super::state_machine::scale_deployment;
 
 const FINALIZER: &str = "bemade.org/postgres-cleanup";
 const KOPF_FINALIZER: &str = "kopf.zalando.org/KopfFinalizerMarker";
@@ -592,6 +593,23 @@ async fn cleanup_instance(instance: &OdooInstance, ctx: &Context) -> Result<Acti
         Some("Deleting postgres role".to_string()),
     )
     .await;
+
+    // Scale the web and cron Deployments to 0 before dropping the database.
+    // A running instance keeps live psycopg2 connections open for the lifetime
+    // of its worker processes, so `DROP DATABASE` fails with "database is being
+    // accessed by other users" and the finalizer would be retained forever —
+    // the pods only stop once the owner is fully deleted (past this finalizer),
+    // but the finalizer can't complete until the pods stop.  Scaling down here
+    // breaks that deadlock regardless of how deletion was triggered (issue #153).
+    //
+    // Best-effort: a scale error (e.g. the Deployment is already gone, 404) must
+    // not block role cleanup.  If pods are genuinely still up when we reach the
+    // DROP below, `delete_role` fails and the finalizer retries on the next tick.
+    for depl in [name.clone(), cron_depl_name(instance)] {
+        if let Err(e) = scale_deployment(&ctx.client, &depl, &ns, 0).await {
+            warn!(%name, %depl, %e, "failed to scale down deployment during cleanup (non-fatal)");
+        }
+    }
 
     let username = odoo_username(&ns, &name);
     if let Ok((cluster_name, pg_cluster)) = load_postgres_cluster(ctx, instance).await {

--- a/tests/integration/finalizer_scale_down.rs
+++ b/tests/integration/finalizer_scale_down.rs
@@ -1,0 +1,83 @@
+//! Regression test for the running-instance cleanup deadlock (issue #153).
+//!
+//! Deleting a running OdooInstance used to hang forever: `cleanup_instance`
+//! went straight for `DROP DATABASE` while the web/cron pods still held live
+//! connections, so the drop failed with "database is being accessed by other
+//! users" and the finalizer was retained indefinitely.  The pods only stop
+//! once the owner is fully deleted (past the finalizer), but the finalizer
+//! can't complete until the pods stop — a genuine deadlock.
+//!
+//! The fix scales both Deployments to 0 as the first step of cleanup.  This
+//! test asserts that scale-down happens when a Running instance is deleted.
+
+use kube::api::{Api, DeleteParams};
+
+use super::common::*;
+use odoo_operator::crd::odoo_instance::OdooInstance;
+use odoo_operator::helpers::odoo_username;
+
+const FINALIZER: &str = "bemade.org/postgres-cleanup";
+
+/// Deleting a Running instance must scale the web and cron Deployments to 0
+/// during cleanup.  We arm the postgres mock to fail `delete_role` so the
+/// finalizer is retained and the (still-present) Deployments can be inspected;
+/// the scale-down must have happened regardless, since it precedes the drop.
+#[tokio::test]
+async fn cleanup_scales_deployments_down_on_delete() -> anyhow::Result<()> {
+    let ctx = TestContext::new("test-cleanup-scaledown").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+    let name = "test-cleanup-scaledown";
+    let cron = format!("{name}-cron");
+
+    // Bring the instance up to Running with both Deployments scaled up.
+    let ready_handle = fast_track_to_running(&ctx, "init-cleanup-scaledown").await;
+    check_deployment_scale(c, ns, name, 1).await?;
+
+    // Arm the mock so cleanup's DROP-side (delete_role) keeps failing.  This
+    // holds the finalizer open so we can observe the deployment scale after
+    // the delete, mirroring the real world where a live connection blocks the
+    // drop until the pods actually terminate.
+    let username = odoo_username(ns, name);
+    mock_pg().fail_delete_role(&username, "database still has sessions (test injection)");
+
+    // The keep-alive task patches Deployment *status* only, not spec.replicas,
+    // so it won't fight the scale-down; abort it anyway to keep teardown clean.
+    ready_handle.abort();
+
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances
+        .delete(name, &DeleteParams::default())
+        .await
+        .expect("failed to issue delete");
+
+    // Cleanup must scale both Deployments to 0 before (attempting) the drop.
+    assert!(
+        wait_for(TIMEOUT, POLL, || {
+            let (c, ns, name, cron) = (c.clone(), ns.to_string(), name.to_string(), cron.clone());
+            async move {
+                check_deployment_scale(&c, &ns, &name, 0).await.is_ok()
+                    && check_deployment_scale(&c, &ns, &cron, 0).await.is_ok()
+            }
+        })
+        .await,
+        "web and cron Deployments should be scaled to 0 during cleanup of a running instance"
+    );
+
+    // The finalizer is still held (delete_role is failing), so the instance
+    // must still exist — proving the scale-down happened independently of the
+    // drop succeeding, not as a side effect of GC after full deletion.
+    let inst = instances
+        .get_opt(name)
+        .await?
+        .expect("instance should still exist while delete_role fails");
+    let finalizers = inst.metadata.finalizers.unwrap_or_default();
+    assert!(
+        finalizers.iter().any(|f| f == FINALIZER),
+        "postgres-cleanup finalizer should still be held, got: {finalizers:?}"
+    );
+
+    // Clear the fault so the instance can finish cleaning up on teardown.
+    mock_pg().clear_delete_role_failure(&username);
+
+    Ok(())
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -17,6 +17,7 @@ mod degraded;
 mod environment_labels;
 mod finalizer;
 mod finalizer_postgres_cleanup_failure;
+mod finalizer_scale_down;
 mod init_job;
 mod migrate_database;
 mod migrate_filestore;


### PR DESCRIPTION
## Summary

Fixes the deletion deadlock described in #153. Deleting a **running** `OdooInstance` (replicas > 0, live pods) hung forever because `cleanup_instance()` attempted `DROP DATABASE` while the web/cron pods still held live psycopg2 connections:

```
ERROR: database "odoo_<uid>" is being accessed by other users
DETAIL: There are N other sessions using the database.
```

The `bemade.org/postgres-cleanup` finalizer was retained and retried every 30s indefinitely. Kubernetes GC can't resolve it either — owned Deployments aren't cascade-deleted until the owner clears all finalizers, but the finalizer can't clear until the pods (and their connections) stop.

## Fix

`cleanup_instance()` now scales the web and cron Deployments to `0` as its **first step**, before deleting the postgres role/database — mirroring the existing `InitFailed`/`Stopped`/`Restoring` scaling behaviour. The scale-down is best-effort: a 404 (Deployment already gone) or other scale error is logged and does not block role cleanup. If pods are still up when `DROP` runs, `delete_role` fails and the finalizer retries exactly as before — so the existing orphan-role guarantee (#119) is preserved.

This makes deletion of a running instance safe regardless of how it was triggered, including odoo-ci's `review-stop` job (a bare `kubectl delete odooinstance … --ignore-not-found` with no prior scale-down), which was the everyday trigger.

## Test

Adds `tests/integration/finalizer_scale_down.rs`: brings an instance to `Running`, arms the postgres mock to fail `delete_role` (holding the finalizer open), deletes the instance, and asserts **both** Deployments are scaled to 0 during cleanup while the finalizer is still held.

```
test finalizer::finalizer_cleans_up_on_delete ... ok
test finalizer_postgres_cleanup_failure::finalizer_retained_when_delete_role_fails ... ok
test finalizer_scale_down::cleanup_scales_deployments_down_on_delete ... ok
```

`cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Note (follow-up, not in this PR)

Per the issue, `postgres.rs::delete_role()`'s `DROP DATABASE` still has no `pg_terminate_backend` / `WITH (FORCE)` fallback, so a connection lingering during the pod grace period costs one extra 30s retry cycle rather than failing permanently. That defensive layer can be added separately if desired.

Closes #153