### PR TITLE
test(restore): poll for deployment scale-up instead of asserting synchronously

### DIFF
--- a/tests/integration/restore_job.rs
+++ b/tests/integration/restore_job.rs
@@ -69,8 +69,22 @@ async fn restore_job_lifecycle() -> anyhow::Result<()> {
         wait_for_phase(c, ns, "test-restore", OdooInstancePhase::Starting).await,
         "expected Starting after restore completed"
     );
-    check_deployment_scale(c, ns, "test-restore", 1).await?;
-    check_deployment_scale(c, ns, "test-restore-cron", 1).await?;
+    // Reaching Starting only patches the phase and requeues; the Deployment is
+    // scaled back up from 0 (Restoring's ensure) to spec.replicas on the next
+    // reconcile's ensure(Starting). Poll for the eventual scale rather than
+    // asserting it synchronously against that window.
+    assert!(
+        wait_for(TIMEOUT, POLL, || async move {
+            check_deployment_scale(c, ns, "test-restore", 1)
+                .await
+                .is_ok()
+                && check_deployment_scale(c, ns, "test-restore-cron", 1)
+                    .await
+                    .is_ok()
+        })
+        .await,
+        "expected both deployments to scale to 1 after restore completed"
+    );
 
     let ready_handle = keep_deployment_ready(c.clone(), ns.into(), "test-restore".into(), 1);
 


### PR DESCRIPTION
`restore_job_lifecycle` intermittently fails on master with `deployment test-restore has the wrong replica count: 0 instead of 1` (roughly 1 in 3 runs locally).

The test asserts `check_deployment_scale(.., 1)` immediately after `wait_for_phase(Starting)`, but reaching `Starting` only patches the phase and requeues: the Deployment is scaled back up from 0 (Restoring's ensure) to `spec.replicas` on the *next* reconcile's `ensure(Starting)`, per the state machine's ensure-then-transition ordering. The synchronous assertion races that window.

This change wraps both scale checks in the existing `wait_for` helper so the test asserts the eventual scale, matching how the rest of the suite handles reconcile-driven state.

Surfaced while preparing the #132 implementation, where an extra status write shifts reconcile timing enough to trip the race more often — but it reproduces on unmodified master. With this change: 6/6 consecutive green runs on d6058c5.