### PR TITLE
feat(scaling): expose the pod selector via the scale subresource

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -1063,6 +1063,10 @@ spec:
                 default: 0
                 format: int32
                 type: integer
+              selector:
+                description: Label selector for the pods this instance manages, as a serialized selector string (e.g. `app=<name>`). Surfaced through the `scale` subresource via `labelSelectorPath`, so a HorizontalPodAutoscaler can discover the target pods. Populated by the controller.
+                nullable: true
+                type: string
               targetReplicas:
                 format: int32
                 nullable: true
@@ -1079,6 +1083,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.readyReplicas
       status: {}

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -488,6 +488,12 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
             .and_then(|s| s.active_cluster.as_deref())
             != Some(&cluster_name);
 
+    // Scale-subresource selector: the web Deployment's pod selector is a fixed,
+    // immutable `app=<name>` (see child_resources::ensure_deployment), so this
+    // is static per instance. Surfaced via `.status.selector` so an HPA can
+    // resolve the target pods through the `scale` subresource.
+    let selector = format!("app={name}");
+
     let cur = instance.status.as_ref();
     let status_changed = active_cluster_changed
         || !cur.is_some_and(|s| {
@@ -496,6 +502,7 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
                 && s.url == url
                 && s.target_replicas == Some(instance.spec.replicas)
                 && s.db_initialized == snapshot.db_initialized
+                && s.selector.as_deref() == Some(selector.as_str())
         });
 
     let api: Api<OdooInstance> = Api::namespaced(client.clone(), &ns);
@@ -508,6 +515,7 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
             "url": url,
             "targetReplicas": instance.spec.replicas,
             "dbInitialized": snapshot.db_initialized,
+            "selector": selector,
             "conditions": conditions,
         });
         if active_cluster_changed {

--- a/src/controller/states/starting.rs
+++ b/src/controller/states/starting.rs
@@ -32,7 +32,12 @@ impl State for Starting {
     ) -> Result<()> {
         let ns = instance.namespace().unwrap_or_default();
         let name = instance.name_any();
-        let replicas = instance.spec.replicas.max(1);
+        // Honor spec.replicas verbatim — it is the authoritative replica count
+        // owned by whoever writes the `scale` subresource (a human or an HPA).
+        // No `.max(1)` floor: replicas == 0 is a valid request and is handled by
+        // the Starting → Stopped transition (guard `replicas == 0`), so a floor
+        // here would only transiently override an external autoscaler.
+        let replicas = instance.spec.replicas;
         let cron_replicas = instance.spec.cron.replicas;
         scale_deployment(&ctx.client, &name, &ns, replicas).await?;
         scale_deployment(

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -301,7 +301,7 @@ fn default_init_modules() -> Vec<String> {
     shortname = "odoo",
     namespaced,
     status = "OdooInstanceStatus",
-    scale = r#"{"specReplicasPath": ".spec.replicas", "statusReplicasPath": ".status.readyReplicas"}"#,
+    scale = r#"{"specReplicasPath": ".spec.replicas", "statusReplicasPath": ".status.readyReplicas", "labelSelectorPath": ".status.selector"}"#,
     printcolumn = r#"{"name": "Image", "type": "string", "jsonPath": ".spec.image"}"#,
     printcolumn = r#"{"name": "Replicas", "type": "string", "jsonPath": ".status.readyReplicas"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,
@@ -483,6 +483,13 @@ pub struct OdooInstanceStatus {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_replicas: Option<i32>,
+
+    /// Label selector for the pods this instance manages, as a serialized
+    /// selector string (e.g. `app=<name>`). Surfaced through the `scale`
+    /// subresource via `labelSelectorPath`, so a HorizontalPodAutoscaler can
+    /// discover the target pods. Populated by the controller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition>,

--- a/tests/integration/scaling.rs
+++ b/tests/integration/scaling.rs
@@ -1,7 +1,9 @@
 use serde_json::json;
 
+use kube::api::{Api, Patch, PatchParams};
+
 use super::common::*;
-use odoo_operator::crd::odoo_instance::OdooInstancePhase;
+use odoo_operator::crd::odoo_instance::{OdooInstance, OdooInstancePhase};
 
 /// While Running, changing spec.replicas should update the Deployment's replica
 /// count without requiring a phase transition.
@@ -61,6 +63,78 @@ async fn scale_down_and_up() -> anyhow::Result<()> {
     assert!(
         wait_for_phase(c, ns, "test-scale", OdooInstancePhase::Starting).await,
         "expected Starting after scale to 1"
+    );
+    Ok(())
+}
+
+/// The `scale` subresource must expose a label selector so a HorizontalPodAutoscaler
+/// can discover the managed pods. The controller writes `status.selector =
+/// "app=<name>"`, and the apiserver surfaces it on the `/scale` subresource via
+/// the CRD's `labelSelectorPath`.
+#[tokio::test]
+async fn status_selector_is_populated_and_exposed_on_scale() -> anyhow::Result<()> {
+    let ctx = TestContext::new("test-sel").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let ready_handle = fast_track_to_running(&ctx, "test-sel-init").await;
+
+    // The controller sets status.selector during reconcile.
+    assert!(
+        wait_for(TIMEOUT, POLL, || async move {
+            let api: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+            api.get("test-sel")
+                .await
+                .ok()
+                .and_then(|i| i.status)
+                .and_then(|s| s.selector)
+                == Some("app=test-sel".to_string())
+        })
+        .await,
+        "expected status.selector to be set to app=test-sel"
+    );
+
+    // The apiserver exposes it on the /scale subresource (what an HPA reads).
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    let scale = instances.get_scale("test-sel").await?;
+    assert_eq!(
+        scale.status.and_then(|s| s.selector),
+        Some("app=test-sel".to_string()),
+        "scale subresource should report the label selector"
+    );
+
+    ready_handle.abort();
+    Ok(())
+}
+
+/// An autoscaler scales by writing the `/scale` subresource, not the full spec.
+/// A replica count written there must flow through `.spec.replicas` to the
+/// Deployment — and without the old `.max(1)` floor, the count is honored
+/// verbatim.
+#[tokio::test]
+async fn scale_subresource_write_updates_deployment() -> anyhow::Result<()> {
+    let ctx = TestContext::new("test-hpa").await;
+    let (c, ns) = (&ctx.client, ctx.ns.as_str());
+
+    let ready_handle = fast_track_to_running(&ctx, "test-hpa-init").await;
+    check_deployment_scale(c, ns, "test-hpa", 1).await?;
+
+    // Simulate an HPA: write replicas via the scale subresource (not spec).
+    ready_handle.abort();
+    let instances: Api<OdooInstance> = Api::namespaced(c.clone(), ns);
+    instances
+        .patch_scale(
+            "test-hpa",
+            &PatchParams::default(),
+            &Patch::Merge(json!({ "spec": { "replicas": 4 } })),
+        )
+        .await?;
+
+    assert!(
+        wait_for(TIMEOUT, POLL, || async move {
+            check_deployment_scale(c, ns, "test-hpa", 4).await.is_ok()
+        })
+        .await,
+        "expected Deployment to scale to 4 after a /scale subresource write"
     );
     Ok(())
 }


### PR DESCRIPTION
Implements the HPA-facing half of #132, per the direction settled there.

## What

- **Expose the pod selector via the `scale` subresource.** `OdooInstanceStatus` gains `selector: Option<String>`, populated by the controller as `app=<name>` (the web Deployment's pod selector, which is fixed and immutable per instance — see the NOTE in `child_resources::ensure_deployment`). The CRD's `scale` subresource adds `labelSelectorPath: .status.selector`, so `kubectl get --raw .../scale` — and therefore an HPA or KEDA — can resolve the target pods. Chart CRD regenerated via `make helm-crds`.
- **Honor `spec.replicas` verbatim in `Starting`.** The `.max(1)` floor is removed, making `spec.replicas` the authoritative replica count regardless of who authors it (a human or an autoscaler writing through `/scale`). `running.rs` already followed it faithfully; the floor only bit on the Starting transition, where it would transiently override an external autoscaler.

The phase-scoped safety forcing (Stopped/Initializing/Restoring pinning the Deployment to 0) is untouched: it lives in those state handlers at the child layer and correctly wins during disruptive phases, as discussed in #132. `replicas: 0` remains a valid request handled by the Starting → Stopped transition.

## Tests

Two integration tests added to `tests/integration/scaling.rs`:

- `status_selector_is_populated_and_exposed_on_scale` — asserts the controller writes `status.selector` and that the apiserver surfaces it on the `/scale` subresource (what an HPA actually reads).
- `scale_subresource_write_updates_deployment` — simulates an autoscaler by patching `/scale` (not the full spec) and asserts the Deployment follows to the requested count with no floor applied.

Full integration suite green single-threaded (CI's invocation), fmt + clippy clean.

Closes #132.
