### PR TITLE
fix(refresh): rename filestore to target db name on snapshot path

### DIFF
--- a/scripts/rename-filestore.sh
+++ b/scripts/rename-filestore.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Renames the filestore subdirectory on the staging instance's filestore PVC
+# from the *source* database name to the *target* database name, after the
+# snapshot-path refresh has cloned the source PVC verbatim.
+#
+# The snapshot path (CSI VolumeSnapshot → dataSourceRef) clones the source
+# filestore PVC byte-for-byte, so the filestore lands under the *source* db
+# name (e.g. filestore/odoo_<prod-uid>).  Odoo on staging looks under the
+# *target* db name (filestore/odoo_<staging-uid>) and would otherwise find
+# nothing — every attachment missing, web assets regenerated from scratch.
+# This step reconciles the directory name so the cloned DB and filestore
+# align.  The copy path (clone-filestore.sh) already maps SRC_DB → TGT_DB at
+# copy time; this is its snapshot-path equivalent.
+#
+# Required env vars:
+#   SRC_DB, TGT_DB  — database names used as subdirectories under the PVC
+#   FILESTORE       — mount path of the filestore PVC (e.g. /var/lib/odoo)
+
+set -euo pipefail
+
+FS="${FILESTORE:-/var/lib/odoo}/filestore"
+SRC_DIR="${FS}/${SRC_DB}"
+TGT_DIR="${FS}/${TGT_DB}"
+
+echo "=== Rename filestore: $SRC_DIR -> $TGT_DIR ==="
+
+if [ "$SRC_DB" = "$TGT_DB" ]; then
+    # Source and target share a db name (e.g. spec.database.name pinned to
+    # the same value on both instances).  The snapshot already placed the
+    # filestore under the right name — nothing to do.
+    echo "Source and target db names identical — nothing to rename"
+    mkdir -p "$TGT_DIR"
+    exit 0
+fi
+
+if [ ! -d "$SRC_DIR" ]; then
+    # Source filestore absent (brand-new prod with zero attachments, or an
+    # already-renamed PVC from a retried Job).  Ensure the target exists.
+    echo "Source filestore directory absent — ensuring target exists"
+    mkdir -p "$TGT_DIR"
+    exit 0
+fi
+
+if [ ! -e "$TGT_DIR" ]; then
+    # Fast path: atomic rename within the same filesystem.
+    mv "$SRC_DIR" "$TGT_DIR"
+else
+    # Target already exists (e.g. Odoo regenerated a few asset bundles
+    # against the staging db before the rename).  Merge source into target
+    # — filestore entries are content-addressable (sha1 filenames), so any
+    # name collision refers to identical content by construction — then drop
+    # the now-redundant source dir.  shutil.copytree(dirs_exist_ok=True)
+    # matches the rsync -a semantics used elsewhere; rsync isn't in the odoo
+    # image.
+    python3 -c "
+import shutil, sys
+shutil.copytree(sys.argv[1], sys.argv[2], dirs_exist_ok=True)
+" "$SRC_DIR" "$TGT_DIR"
+    rm -rf "$SRC_DIR"
+fi
+
+echo "=== Filestore rename complete ==="
+du -sh "$TGT_DIR" 2>/dev/null || true

--- a/scripts/tests/test-rename-filestore.sh
+++ b/scripts/tests/test-rename-filestore.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression test for rename-filestore.sh.
+#
+# The snapshot-path staging refresh clones the source filestore PVC
+# byte-for-byte, so the filestore lands under the *source* DB name.  This
+# script renames it to the *target* DB name in place so Odoo can resolve
+# filestore/<db_name>.  It runs entirely on the local filesystem (bash +
+# python3), so — unlike test-restore-extract.sh — no docker is needed.
+#
+# Covered branches:
+#   1. Fast path      — target absent → atomic mv src → tgt
+#   2. Merge path     — target pre-exists → copytree merge + drop src
+#   3. Identical names— SRC_DB == TGT_DB → no-op, ensure tgt exists
+#   4. Source absent  — src dir missing → no-op, ensure tgt exists
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/rename-filestore.sh"
+
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 required" >&2; exit 1; }
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Each case gets a fresh filestore root under a temp dir.
+setup_case() {
+    ROOT=$(mktemp -d)
+    FS="$ROOT/filestore"
+    mkdir -p "$FS"
+}
+teardown_case() { rm -rf "$ROOT"; }
+
+# ── Case 1: fast path (mv) ───────────────────────────────────────────────
+setup_case
+mkdir -p "$FS/odoo_src"
+echo "content-a" > "$FS/odoo_src/aa"
+echo "content-b" > "$FS/odoo_src/bb"
+SRC_DB=odoo_src TGT_DB=odoo_tgt FILESTORE="$ROOT" bash "$SCRIPT" >/dev/null
+[ ! -e "$FS/odoo_src" ]           || fail "case1: source dir not removed after mv"
+[ -f "$FS/odoo_tgt/aa" ]          || fail "case1: aa missing after rename"
+[ -f "$FS/odoo_tgt/bb" ]          || fail "case1: bb missing after rename"
+[ "$(cat "$FS/odoo_tgt/aa")" = content-a ] || fail "case1: aa content corrupted"
+teardown_case
+echo "ok: case1 fast-path mv"
+
+# ── Case 2: merge path (target pre-exists) ───────────────────────────────
+# Odoo regenerated a couple of asset bundles under the target name before the
+# rename.  The synced source must merge in without clobbering target-only
+# files; content-addressable collisions (same sha1 filename) are identical by
+# construction, so overwriting is safe.
+setup_case
+mkdir -p "$FS/odoo_src" "$FS/odoo_tgt"
+echo "shared" > "$FS/odoo_src/shared_sha"   # exists in both (identical content)
+echo "shared" > "$FS/odoo_tgt/shared_sha"
+echo "from-src-only" > "$FS/odoo_src/src_only"
+echo "from-tgt-only" > "$FS/odoo_tgt/tgt_only"
+SRC_DB=odoo_src TGT_DB=odoo_tgt FILESTORE="$ROOT" bash "$SCRIPT" >/dev/null
+[ ! -e "$FS/odoo_src" ]                       || fail "case2: source dir not removed after merge"
+[ -f "$FS/odoo_tgt/src_only" ]                || fail "case2: source-only file not merged in"
+[ -f "$FS/odoo_tgt/tgt_only" ]                || fail "case2: target-only file clobbered"
+[ "$(cat "$FS/odoo_tgt/src_only")" = from-src-only ] || fail "case2: src_only content wrong"
+[ "$(cat "$FS/odoo_tgt/tgt_only")" = from-tgt-only ] || fail "case2: tgt_only content wrong"
+[ "$(cat "$FS/odoo_tgt/shared_sha")" = shared ]      || fail "case2: shared file content wrong"
+teardown_case
+echo "ok: case2 merge-path copytree"
+
+# ── Case 3: identical DB names (no-op) ───────────────────────────────────
+setup_case
+mkdir -p "$FS/odoo_same"
+echo "keep" > "$FS/odoo_same/keep"
+SRC_DB=odoo_same TGT_DB=odoo_same FILESTORE="$ROOT" bash "$SCRIPT" >/dev/null
+[ -f "$FS/odoo_same/keep" ]                || fail "case3: identical-name run disturbed files"
+[ "$(cat "$FS/odoo_same/keep")" = keep ]   || fail "case3: identical-name content changed"
+teardown_case
+echo "ok: case3 identical-names no-op"
+
+# ── Case 4: source absent (no-op, ensure target exists) ──────────────────
+setup_case
+SRC_DB=odoo_missing TGT_DB=odoo_tgt FILESTORE="$ROOT" bash "$SCRIPT" >/dev/null
+[ -d "$FS/odoo_tgt" ]        || fail "case4: target dir not created when source absent"
+[ ! -e "$FS/odoo_missing" ] || fail "case4: phantom source dir created"
+teardown_case
+echo "ok: case4 source-absent no-op"
+
+echo "PASS: all rename-filestore.sh cases"

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -285,13 +285,14 @@ impl ReconcileSnapshot {
                                 )
                                 .await,
                                 // Filestore step is mode-agnostic: prefer the
-                                // explicit `filestore_phase` field when set
-                                // (covers the snapshot path, which has no
-                                // underlying Job).  On the Copy path, fall
-                                // back to the Job-based observer so that
-                                // `filestore_job_phase` keeps being recorded
-                                // for GC durability.  skipFilestore short-
-                                // circuits to Succeeded.
+                                // explicit `filestore_phase` field when set,
+                                // else fall back to the Job-based observer via
+                                // `filestore_job_name` so `filestore_job_phase`
+                                // keeps being recorded for GC durability.  Both
+                                // modes run a Job now — the Copy path's clone
+                                // Job and the Snapshot path's post-clone rename
+                                // Job — so the observer applies to either.
+                                // skipFilestore short-circuits to Succeeded.
                                 if job.spec.skip_filestore {
                                     JobStatus::Succeeded
                                 } else {

--- a/src/controller/states/cloning_from_source.rs
+++ b/src/controller/states/cloning_from_source.rs
@@ -32,6 +32,7 @@ use crate::helpers::sha256_hex;
 
 const CLONE_DB_SCRIPT: &str = include_str!("../../../scripts/clone-db.sh");
 const CLONE_FILESTORE_SCRIPT: &str = include_str!("../../../scripts/clone-filestore.sh");
+const RENAME_FILESTORE_SCRIPT: &str = include_str!("../../../scripts/rename-filestore.sh");
 const NEUTRALIZE_SCRIPT: &str = include_str!("../../../scripts/neutralize.sh");
 
 /// Number of hex characters of the image's sha256 we persist in the refresh
@@ -508,14 +509,18 @@ impl State for CloningFromSource {
                 .and_then(|s| s.filestore_phase.as_ref()),
             Some(Phase::Running)
         ) {
-            let terminal = if refresh
+            if refresh
                 .status
                 .as_ref()
                 .and_then(|s| s.filestore_job_name.as_deref())
                 .is_some()
             {
-                // Copy path: mirror Job's recorded terminal phase.
-                match refresh
+                // A filestore Job is in flight — the Copy path's clone Job,
+                // or the Snapshot path's post-clone rename Job (launched in
+                // the `else` branch below once its name is recorded).  Either
+                // way, mirror the Job's recorded terminal phase onto
+                // `filestore_phase`.
+                let terminal = match refresh
                     .status
                     .as_ref()
                     .and_then(|s| s.filestore_job_phase.as_ref())
@@ -523,32 +528,66 @@ impl State for CloningFromSource {
                     Some(Phase::Completed) => Some(Phase::Completed),
                     Some(Phase::Failed) => Some(Phase::Failed),
                     _ => None,
+                };
+                if let Some(p) = terminal {
+                    patch_refresh_status(
+                        &ctx.client,
+                        &ns,
+                        &refresh.name_any(),
+                        &json!({"status": {"filestorePhase": p}}),
+                    )
+                    .await?;
                 }
             } else {
-                // Snapshot path: new PVC bound ⇒ Completed.  Defensively
-                // require no `deletionTimestamp` so a still-terminating
-                // old PVC can't masquerade as the recreated one.
+                // Snapshot path: the dest PVC was recreated from the source
+                // VolumeSnapshot but no rename Job exists yet.  The clone is
+                // byte-for-byte, so the filestore landed under the *source*
+                // DB name — Odoo on the target resolves
+                // `filestore/<target_db>` and would find nothing (every
+                // ir.attachment 500s).  Once the new PVC is Bound (so it can
+                // be mounted) launch a Job that renames
+                // `filestore/<src_db>` → `filestore/<tgt_db>` in place.
+                // Recording its name routes subsequent ticks through the
+                // mirror branch above, which settles `filestore_phase` when
+                // the rename Job terminates.  Require no `deletionTimestamp`
+                // so a still-terminating old PVC can't masquerade as the
+                // recreated one, and wait for Bound so the Job's pod doesn't
+                // sit Pending on an absent volume.
                 let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), &ns);
                 let target_pvc = format!("{inst_name}-filestore-pvc");
-                match pvcs.get(target_pvc.as_str()).await {
+                let bound = matches!(
+                    pvcs.get(target_pvc.as_str()).await,
                     Ok(pvc)
                         if pvc.metadata.deletion_timestamp.is_none()
                             && pvc.status.as_ref().and_then(|s| s.phase.as_deref())
-                                == Some("Bound") =>
-                    {
-                        Some(Phase::Completed)
-                    }
-                    _ => None,
+                                == Some("Bound")
+                );
+                if bound {
+                    let job = build_filestore_rename_job(
+                        &refresh.name_any(),
+                        &ns,
+                        image,
+                        instance,
+                        refresh,
+                        &source_db,
+                        &target_db,
+                    );
+                    let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), &ns);
+                    let created = jobs_api.create(&PostParams::default(), &job).await?;
+                    let k8s_job_name = created.name_any();
+                    info!(
+                        crd_name = %refresh.name_any(),
+                        %k8s_job_name,
+                        "created filestore rename job (snapshot path)"
+                    );
+                    patch_refresh_status(
+                        &ctx.client,
+                        &ns,
+                        &refresh.name_any(),
+                        &json!({"status": {"filestoreJobName": &k8s_job_name}}),
+                    )
+                    .await?;
                 }
-            };
-            if let Some(p) = terminal {
-                patch_refresh_status(
-                    &ctx.client,
-                    &ns,
-                    &refresh.name_any(),
-                    &json!({"status": {"filestorePhase": p}}),
-                )
-                .await?;
             }
         }
 
@@ -775,6 +814,48 @@ fn build_filestore_clone_job(
             ]),
             env: Some(envs),
             volume_mounts: Some(mounts),
+            ..Default::default()
+        }])
+        .build()
+}
+
+/// Snapshot-path filestore reconcile: rename `filestore/<src_db>` →
+/// `filestore/<tgt_db>` in place on the recreated dest PVC.
+///
+/// The snapshot clone (`dataSourceRef → VolumeSnapshot`) copies the source
+/// filestore PVC byte-for-byte, so the filestore lands under the source DB
+/// name.  Only the target PVC is mounted (the standard `/var/lib/odoo`
+/// mount via `odoo_volume_mounts()`) — the rename is within that one
+/// volume, so no source PVC is needed.  This is the snapshot-path
+/// equivalent of `build_filestore_clone_job`, which maps SRC_DB → TGT_DB at
+/// copy time; the snapshot path can't map at copy time (the CSI clone is
+/// opaque), so it reconciles the directory name afterward.
+fn build_filestore_rename_job(
+    crd_name: &str,
+    ns: &str,
+    image: &str,
+    instance: &OdooInstance,
+    refresh: &OdooStagingRefreshJob,
+    source_db: &str,
+    target_db: &str,
+) -> Job {
+    let envs = vec![
+        env("SRC_DB", source_db),
+        env("TGT_DB", target_db),
+        env("FILESTORE", "/var/lib/odoo"),
+    ];
+    OdooJobBuilder::new(&format!("{crd_name}-fsrename-"), ns, refresh, instance)
+        .active_deadline(7200)
+        .containers(vec![Container {
+            name: "rename-filestore".into(),
+            image: Some(image.into()),
+            command: Some(vec![
+                "/bin/bash".into(),
+                "-c".into(),
+                RENAME_FILESTORE_SCRIPT.into(),
+            ]),
+            env: Some(envs),
+            volume_mounts: Some(odoo_volume_mounts()),
             ..Default::default()
         }])
         .build()

--- a/tests/integration/staging_refresh.rs
+++ b/tests/integration/staging_refresh.rs
@@ -436,12 +436,15 @@ async fn fake_volume_snapshot_ready(client: &kube::Client, ns: &str, name: &str)
 }
 
 /// Snapshot path: when source and target share a StorageClass and
-/// `filestoreMethod: snapshot` is requested, the operator must NOT spawn a
-/// filestore Job.  Instead, it deletes the staging PVC, recreates it (which
-/// would clone from the source PVC in a real cluster), and waits for the
-/// new PVC to bind.  The settle block then patches `filestore_phase: Completed`
-/// — which is the gate that lets neutralize spawn.  Regression for the
-/// "fs_done never trips" stall in the snapshot path.
+/// `filestoreMethod: snapshot` is requested, the operator deletes the staging
+/// PVC and recreates it (which would clone from the source VolumeSnapshot in a
+/// real cluster).  Once the new PVC is Bound, it launches a filestore *rename*
+/// Job — the byte-for-byte snapshot clone lands the filestore under the
+/// *source* DB name, so it must be renamed to the target DB name before Odoo
+/// can resolve `filestore/<db_name>` (otherwise every ir.attachment 500s).
+/// `filestore_phase` settles Completed when the rename Job succeeds, which is
+/// the gate that lets neutralize spawn.  Regression for both the "fs_done never
+/// trips" stall and the missing-rename attachment-404 bug.
 #[tokio::test]
 async fn staging_refresh_snapshot_path_completes_via_pvc_bound() -> anyhow::Result<()> {
     let ctx = TestContext::new("src-snap").await;
@@ -517,7 +520,8 @@ async fn staging_refresh_snapshot_path_completes_via_pvc_bound() -> anyhow::Resu
     // status (PVC delete + ensure_filestore_pvc complete).
     wait_for_filestore_phase(c, ns, "tgt-snap-refresh", Phase::Running).await;
 
-    // No filestore Job exists on the snapshot path.
+    // No filestore Job exists until the recreated PVC is Bound — the rename
+    // Job mounts that PVC, so it can't be launched before the volume is ready.
     let after = refreshes.get("tgt-snap-refresh").await?;
     assert!(
         after
@@ -525,12 +529,23 @@ async fn staging_refresh_snapshot_path_completes_via_pvc_bound() -> anyhow::Resu
             .as_ref()
             .and_then(|s| s.filestore_job_name.as_deref())
             .is_none(),
-        "snapshot path must not create a filestore Job"
+        "no filestore rename Job before the recreated PVC is Bound"
     );
 
-    // Fake the recreated staging PVC into Bound; the settle block on the
-    // next reconcile flips filestorePhase to Completed.
+    // Fake the recreated staging PVC into Bound; the operator then launches
+    // the filestore rename Job (renames filestore/<src_db> → filestore/<tgt_db>
+    // so the byte-for-byte snapshot clone lines up with the freshly-cloned DB).
     fake_pvc_bound(c, ns, "tgt-snap-filestore-pvc").await;
+    let fs_job = wait_for_refresh_sub_job(c, ns, "tgt-snap-refresh", "filestoreJobName").await;
+
+    // filestorePhase stays Running until the rename Job terminates; faking it
+    // Succeeded lets the settle block mirror the phase forward to Completed.
+    jobs.patch_status(
+        &fs_job,
+        &PatchParams::apply("odoo-operator-test"),
+        &Patch::Merge(&json!({ "status": { "succeeded": 1 } })),
+    )
+    .await?;
     wait_for_filestore_phase(c, ns, "tgt-snap-refresh", Phase::Completed).await;
 
     // Neutralize spawns once both DB and filestore are Completed.


### PR DESCRIPTION
## Problem

On the **snapshot** filestore path, a staging refresh reports `filestorePhase: Completed` / `phase: Completed` but the staging instance comes up with **no filestore** — every `ir.attachment`-backed file (images, uploads, favicons) 500s while CSS/JS bundles regenerate fine (styled site, broken content).

**Root cause:** the snapshot path clones the source filestore PVC byte-for-byte via `dataSourceRef → VolumeSnapshot`, so the filestore lands under the **source** database name (`filestore/<src_db>`). The DB is cloned under a **new** target name, so Odoo resolves `filestore/<target_db>` and finds nothing. The copy path already maps `SRC_DB → TGT_DB` at copy time (`clone-filestore.sh`); the snapshot path had no equivalent, and `filestore_phase` settled to `Completed` purely on the recreated PVC reaching `Bound`, so the broken refresh masqueraded as success.

## Fix

Wire in `scripts/rename-filestore.sh`. Once the recreated PVC is `Bound`, the operator launches a rename Job that renames `filestore/<src_db>` → `filestore/<tgt_db>` in place on the dest PVC (atomic `mv` fast-path; content-addressable merge if a target dir already exists).

- Reuses the existing `filestore_job_name` / `filestore_job_phase` plumbing, so the aggregate rollup, GC-durable phase recording, and mirror-to-`filestore_phase` all work unchanged.
- **Completion is now gated on the rename Job succeeding** rather than on PVC `Bound` — this failure mode can no longer report success without the filestore actually being reconciled (addresses the issue's second hardening suggestion).
- The rename runs on the snapshot path **regardless of the `neutralize` flag**, so a non-neutralized refresh can't silently ship a broken filestore.
- The existing race guard is preserved: the rename Job is only launched when the PVC is `Bound` **and** has no `deletionTimestamp`, so a still-terminating old PVC can't trigger it.

## Tests

- Updated the snapshot-path integration test: it now asserts the rename Job launches once the recreated PVC is `Bound`, and that `filestore_phase` settles `Completed` only after the rename Job succeeds.
- Added `scripts/tests/test-rename-filestore.sh` covering all four script branches (mv fast-path, copytree merge, identical-names no-op, source-absent no-op) — pure bash + python3, no docker.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and the full test suite pass.

Closes #147