### PR TITLE
perf(reconcile): server-side filter job-CR lists via selectableFields

### DIFF
--- a/charts/odoo-operator/templates/crds/backupjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/backupjob-crd.yaml
@@ -181,6 +181,9 @@ spec:
         - spec
         title: OdooBackupJob
         type: object
+    selectableFields:
+    - jsonPath: .spec.odooInstanceRef.name
+    - jsonPath: .status.phase
     served: true
     storage: true
     subresources:

--- a/charts/odoo-operator/templates/crds/initjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/initjob-crd.yaml
@@ -145,6 +145,9 @@ spec:
         - spec
         title: OdooInitJob
         type: object
+    selectableFields:
+    - jsonPath: .spec.odooInstanceRef.name
+    - jsonPath: .status.phase
     served: true
     storage: true
     subresources:

--- a/charts/odoo-operator/templates/crds/restorejob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/restorejob-crd.yaml
@@ -209,6 +209,9 @@ spec:
         - spec
         title: OdooRestoreJob
         type: object
+    selectableFields:
+    - jsonPath: .spec.odooInstanceRef.name
+    - jsonPath: .status.phase
     served: true
     storage: true
     subresources:

--- a/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/stagingrefreshjob-crd.yaml
@@ -226,6 +226,9 @@ spec:
         - spec
         title: OdooStagingRefreshJob
         type: object
+    selectableFields:
+    - jsonPath: .spec.odooInstanceRef.name
+    - jsonPath: .status.phase
     served: true
     storage: true
     subresources:

--- a/charts/odoo-operator/templates/crds/upgradejob-crd.yaml
+++ b/charts/odoo-operator/templates/crds/upgradejob-crd.yaml
@@ -150,6 +150,9 @@ spec:
         - spec
         title: OdooUpgradeJob
         type: object
+    selectableFields:
+    - jsonPath: .spec.odooInstanceRef.name
+    - jsonPath: .status.phase
     served: true
     storage: true
     subresources:

--- a/src/controller/gc.rs
+++ b/src/controller/gc.rs
@@ -31,6 +31,36 @@ use crate::error::Result;
 
 use super::odoo_instance::Context;
 
+/// List CRs of type `K` in `ns` server-side-filtered by `field_selector`
+/// (a `selectableFields` selector). Falls back to an unfiltered list if the API
+/// server rejects the selector — e.g. during a rollout where the CRD hasn't yet
+/// been updated with its `selectableFields`. Callers must still filter
+/// client-side, so the fallback is correct, just less efficient.
+pub(crate) async fn list_by_field_selector<K>(api: &Api<K>, field_selector: &str) -> Result<Vec<K>>
+where
+    K: Resource<DynamicType = (), Scope = NamespaceResourceScope>
+        + Clone
+        + DeserializeOwned
+        + Debug,
+{
+    match api
+        .list(&ListParams::default().fields(field_selector))
+        .await
+    {
+        Ok(list) => Ok(list.items),
+        // 400/422: unknown field selector (CRD without selectableFields yet).
+        Err(kube::Error::Api(e)) if e.code == 400 || e.code == 422 => {
+            warn!(
+                selector = field_selector,
+                code = e.code,
+                "field-selector list rejected; falling back to unfiltered list"
+            );
+            Ok(api.list(&ListParams::default()).await?.items)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Prune terminal job CRs of type `K` for one instance, keeping the newest
 /// `limit` by creation timestamp and deleting the rest. Returns the number of
 /// CRs deleted. Deletion is best-effort: an already-gone CR (404) is not an
@@ -51,10 +81,12 @@ where
         + Debug,
 {
     let api: Api<K> = Api::namespaced(client.clone(), ns);
-    let mut terminal: Vec<K> = api
-        .list(&ListParams::default())
+    // Ownership is filtered server-side; the terminal-phase check stays
+    // client-side because an unset phase must NOT be treated as terminal
+    // (a field selector `status.phase!=Running` would wrongly match it).
+    let selector = format!("spec.odooInstanceRef.name={instance_name}");
+    let mut terminal: Vec<K> = list_by_field_selector(&api, &selector)
         .await?
-        .items
         .into_iter()
         .filter(|o| ref_name(o) == Some(instance_name))
         .filter(|o| matches!(phase_of(o), Some(Phase::Completed) | Some(Phase::Failed)))

--- a/src/controller/state_machine.rs
+++ b/src/controller/state_machine.rs
@@ -151,6 +151,17 @@ impl ReconcileSnapshot {
             .map(|s| s.db_initialized)
             .unwrap_or(false);
 
+        // Server-side filter every job-CR list to this instance's *active*
+        // (non-terminal) CRs via selectableFields, instead of pulling every CR
+        // in the namespace and filtering in memory. The loops below still
+        // filter client-side, so a fallback to an unfiltered list (older CRD
+        // without selectableFields, mid-rollout) stays correct. An unset phase
+        // reads as "" and correctly matches `!=Completed,!=Failed`, so
+        // just-created CRs are still observed.
+        let active_selector = format!(
+            "spec.odooInstanceRef.name={instance_name},status.phase!=Completed,status.phase!=Failed"
+        );
+
         // Deployment replicas (spec + ready).
         let (deployment_replicas, ready_replicas) = {
             let deps: Api<Deployment> = Api::namespaced(client.clone(), ns);
@@ -190,7 +201,7 @@ impl ReconcileSnapshot {
         let db_init_from_jobs = db_initialized;
         {
             let inits: Api<OdooInitJob> = Api::namespaced(client.clone(), ns);
-            for job in inits.list(&ListParams::default()).await?.items {
+            for job in super::gc::list_by_field_selector(&inits, &active_selector).await? {
                 if job.spec.odoo_instance_ref.name != instance_name {
                     continue;
                 }
@@ -213,7 +224,7 @@ impl ReconcileSnapshot {
         let mut restore_job_active = false;
         {
             let restores: Api<OdooRestoreJob> = Api::namespaced(client.clone(), ns);
-            for job in restores.list(&ListParams::default()).await?.items {
+            for job in super::gc::list_by_field_selector(&restores, &active_selector).await? {
                 if job.spec.odoo_instance_ref.name != instance_name {
                     continue;
                 }
@@ -235,7 +246,7 @@ impl ReconcileSnapshot {
         let mut upgrade_job_active = false;
         {
             let upgrades: Api<OdooUpgradeJob> = Api::namespaced(client.clone(), ns);
-            for job in upgrades.list(&ListParams::default()).await?.items {
+            for job in super::gc::list_by_field_selector(&upgrades, &active_selector).await? {
                 if job.spec.odoo_instance_ref.name != instance_name {
                     continue;
                 }
@@ -263,7 +274,7 @@ impl ReconcileSnapshot {
         let mut refresh_job = JobStatus::Absent;
         {
             let refreshes: Api<OdooStagingRefreshJob> = Api::namespaced(client.clone(), ns);
-            for job in refreshes.list(&ListParams::default()).await?.items {
+            for job in super::gc::list_by_field_selector(&refreshes, &active_selector).await? {
                 if job.spec.odoo_instance_ref.name != instance_name {
                     continue;
                 }
@@ -350,7 +361,7 @@ impl ReconcileSnapshot {
         let mut pending_backup_jobs: usize = 0;
         {
             let backups: Api<OdooBackupJob> = Api::namespaced(client.clone(), ns);
-            for job in backups.list(&ListParams::default()).await?.items {
+            for job in super::gc::list_by_field_selector(&backups, &active_selector).await? {
                 if job.spec.odoo_instance_ref.name != instance_name {
                     continue;
                 }

--- a/src/crd/odoo_backup_job.rs
+++ b/src/crd/odoo_backup_job.rs
@@ -29,6 +29,8 @@ pub struct BackupDestination {
     shortname = "backupjob",
     namespaced,
     status = "OdooBackupJobStatus",
+    selectable = ".spec.odooInstanceRef.name",
+    selectable = ".status.phase",
     printcolumn = r#"{"name": "Target", "type": "string", "jsonPath": ".spec.odooInstanceRef.name"}"#,
     printcolumn = r#"{"name": "Format", "type": "string", "jsonPath": ".spec.format"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,

--- a/src/crd/odoo_init_job.rs
+++ b/src/crd/odoo_init_job.rs
@@ -13,6 +13,8 @@ use super::shared::{OdooInstanceRef, Phase, WebhookConfig};
     shortname = "initjob",
     namespaced,
     status = "OdooInitJobStatus",
+    selectable = ".spec.odooInstanceRef.name",
+    selectable = ".status.phase",
     printcolumn = r#"{"name": "Target", "type": "string", "jsonPath": ".spec.odooInstanceRef.name"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,
     printcolumn = r#"{"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"}"#

--- a/src/crd/odoo_restore_job.rs
+++ b/src/crd/odoo_restore_job.rs
@@ -45,6 +45,8 @@ pub struct RestoreSource {
     shortname = "restore",
     namespaced,
     status = "OdooRestoreJobStatus",
+    selectable = ".spec.odooInstanceRef.name",
+    selectable = ".status.phase",
     printcolumn = r#"{"name": "Target", "type": "string", "jsonPath": ".spec.odooInstanceRef.name"}"#,
     printcolumn = r#"{"name": "Source", "type": "string", "jsonPath": ".spec.source.type"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,

--- a/src/crd/odoo_staging_refresh_job.rs
+++ b/src/crd/odoo_staging_refresh_job.rs
@@ -43,6 +43,8 @@ pub struct StagingSource {
     shortname = "staging-refresh",
     namespaced,
     status = "OdooStagingRefreshJobStatus",
+    selectable = ".spec.odooInstanceRef.name",
+    selectable = ".status.phase",
     printcolumn = r#"{"name": "Target", "type": "string", "jsonPath": ".spec.odooInstanceRef.name"}"#,
     printcolumn = r#"{"name": "Source", "type": "string", "jsonPath": ".spec.source.instanceName"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,

--- a/src/crd/odoo_upgrade_job.rs
+++ b/src/crd/odoo_upgrade_job.rs
@@ -13,6 +13,8 @@ use super::shared::{OdooInstanceRef, Phase, WebhookConfig};
     shortname = "upgradejob",
     namespaced,
     status = "OdooUpgradeJobStatus",
+    selectable = ".spec.odooInstanceRef.name",
+    selectable = ".status.phase",
     printcolumn = r#"{"name": "Target", "type": "string", "jsonPath": ".spec.odooInstanceRef.name"}"#,
     printcolumn = r#"{"name": "Phase", "type": "string", "jsonPath": ".status.phase"}"#,
     printcolumn = r#"{"name": "Age", "type": "date", "jsonPath": ".metadata.creationTimestamp"}"#

--- a/tests/integration/gc.rs
+++ b/tests/integration/gc.rs
@@ -127,3 +127,38 @@ async fn gc_disabled_when_limit_zero() {
 
     assert_eq!(backup_names(&api).await.len(), 3, "GC ran despite limit 0");
 }
+
+/// End-to-end proof that the CRD's selectableFields are declared correctly and
+/// the API server filters server-side: the reconcile loop's "active CRs for
+/// this instance" query must return exactly the non-terminal CRs owned by the
+/// target instance — including a just-created CR with no status yet (phase "").
+#[tokio::test]
+async fn server_side_selector_filters_by_owner_and_phase() {
+    let tc = TestContext::new_ns().await;
+    let (client, ns) = (tc.client.clone(), tc.ns.clone());
+    let api: Api<OdooBackupJob> = Api::namespaced(client.clone(), &ns);
+
+    make_backup(&api, "a-running", "inst-a", Some(Phase::Running)).await;
+    make_backup(&api, "a-done", "inst-a", Some(Phase::Completed)).await;
+    make_backup(&api, "a-nostatus", "inst-a", None).await;
+    make_backup(&api, "b-running", "inst-b", Some(Phase::Running)).await;
+
+    // Same selector gather() builds for the active-CR list.
+    let selector = "spec.odooInstanceRef.name=inst-a,status.phase!=Completed,status.phase!=Failed";
+    let mut got: Vec<String> = api
+        .list(&ListParams::default().fields(selector))
+        .await
+        .expect("field-selector list must be accepted (selectableFields declared)")
+        .items
+        .into_iter()
+        .map(|o| o.metadata.name.unwrap())
+        .collect();
+    got.sort();
+
+    assert_eq!(
+        got,
+        vec!["a-nostatus".to_string(), "a-running".to_string()],
+        "server-side selector should return inst-a's non-terminal CRs only \
+         (excl. a-done by phase, b-running by owner)"
+    );
+}


### PR DESCRIPTION
Stacked on #162 (review/merge that first).

## Problem

`ReconcileSnapshot::gather()` listed every job CR in the namespace and filtered by instance + phase in memory. In a busy namespace that meant transferring and deserializing hundreds of CRs per reconcile — the CPU driver behind the throttling that #162 mitigates. #162 caps the volume; this removes the client-side filtering entirely by pushing it to the API server.

## Change

Declare `spec.odooInstanceRef.name` (ownership) and `status.phase` (activity) as CRD `selectableFields` (KEP-4358, GA in k8s 1.32) on all five job CR types, and filter the lists server-side:

- `gather()` requests only this instance's **non-terminal** CRs (`spec.odooInstanceRef.name=<inst>,status.phase!=Completed,status.phase!=Failed`). An unset phase reads as `""` and correctly matches, so just-created CRs are still observed.
- GC requests only this instance's CRs; the terminal-phase check stays client-side so an unset phase is never mistaken for terminal.

Why `selectableFields` and not labels: ownership can't be filtered any other way — `ownerReferences` aren't field-selectable, and the CRs are created **unlabeled** by external systems, so a label selector would need continuous relabeling.

## Rollout safety

`list_by_field_selector()` falls back to an unfiltered list if the selector is rejected (CRD not yet carrying `selectableFields` mid-rollout); callers still filter client-side, so the fallback is correct. No backfill needed — CR field selectors are evaluated per-list against stored objects, so existing CRs are queryable the moment the CRD updates.

CRDs regenerated (`make helm-crds`) and synced to the chart. An end-to-end test asserts the API server filters by owner + phase against the applied CRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)