### PR TITLE
feat(postgres): ensure pg_trgm and unaccent exist in tenant databases

### DIFF
--- a/charts/odoo-operator/templates/crds/odoo-crd.yaml
+++ b/charts/odoo-operator/templates/crds/odoo-crd.yaml
@@ -613,6 +613,17 @@ spec:
                   name:
                     nullable: true
                     type: string
+                  unaccent:
+                    default: true
+                    description: |-
+                      Whether to ensure the `unaccent` PostgreSQL extension exists in this instance's database.
+
+                      Odoo treats unaccent as opt-in (the `--unaccent` startup flag, which defaults off) because it changes search semantics database-wide: with it, `ilike` matching folds accents, so "Montreal" matches "Montréal". Most deployments want that, so this defaults to `true` — but it is a behavioural change, not purely an optimisation, and an operator should be able to decline it per instance.
+
+                      Setting this to `false` does not *remove* an already-installed extension; it only stops the operator from creating one. Dropping it is deliberately left as a manual action, since other objects may already depend on it.
+
+                      `pg_trgm` is not configurable here: Odoo creates it unconditionally in `_initialize_db`, so the operator matches that rather than inventing a difference.
+                    type: boolean
                 type: object
               environment:
                 default: Staging

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -452,7 +452,9 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
     }
 
     // Ensure report.url points to the in-cluster web service so cron workers
-    // can reach the report rendering endpoint (wkhtmltopdf via HTTP).
+    // can reach the report rendering endpoint (wkhtmltopdf via HTTP), and that
+    // the PostgreSQL extensions Odoo expects are present. Both read the same
+    // credentials, so they share one lookup.
     if snapshot.db_initialized {
         let report_url = format!("http://{name}:8069");
         let (odoo_user, odoo_pass) =
@@ -464,6 +466,17 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
             .await
         {
             warn!(%name, %e, "failed to set report.url — will retry next reconcile");
+        }
+        // Non-fatal: a missing extension degrades Odoo's search behaviour but
+        // does not stop the instance serving, so it must never block a
+        // reconcile. Note the running workers only pick up a newly created
+        // unaccent at registry load, i.e. on their next restart.
+        if let Err(e) = ctx
+            .postgres
+            .ensure_extensions(&pg_cluster, &odoo_user, &odoo_pass, &db)
+            .await
+        {
+            warn!(%name, %e, "failed to ensure postgres extensions — will retry next reconcile");
         }
     }
 

--- a/src/controller/odoo_instance.rs
+++ b/src/controller/odoo_instance.rs
@@ -471,9 +471,15 @@ async fn reconcile_instance(instance: &OdooInstance, ctx: &Context) -> Result<Ac
         // does not stop the instance serving, so it must never block a
         // reconcile. Note the running workers only pick up a newly created
         // unaccent at registry load, i.e. on their next restart.
+        let with_unaccent = instance
+            .spec
+            .database
+            .as_ref()
+            .map(|d| d.unaccent)
+            .unwrap_or(true);
         if let Err(e) = ctx
             .postgres
-            .ensure_extensions(&pg_cluster, &odoo_user, &odoo_pass, &db)
+            .ensure_extensions(&pg_cluster, &odoo_user, &odoo_pass, &db, with_unaccent)
             .await
         {
             warn!(%name, %e, "failed to ensure postgres extensions — will retry next reconcile");

--- a/src/crd/odoo_instance.rs
+++ b/src/crd/odoo_instance.rs
@@ -68,6 +68,26 @@ pub struct DatabaseSpec {
     /// See `DatabaseMissingPolicy`. Default `Ignore`.
     #[serde(default)]
     pub missing_policy: DatabaseMissingPolicy,
+    /// Whether to ensure the `unaccent` PostgreSQL extension exists in this
+    /// instance's database.
+    ///
+    /// Odoo treats unaccent as opt-in (the `--unaccent` startup flag, which
+    /// defaults off) because it changes search semantics database-wide:
+    /// with it, `ilike` matching folds accents, so "Montreal" matches
+    /// "Montréal". Most deployments want that, so this defaults to `true` —
+    /// but it is a behavioural change, not purely an optimisation, and an
+    /// operator should be able to decline it per instance.
+    ///
+    /// Setting this to `false` does not *remove* an already-installed
+    /// extension; it only stops the operator from creating one. Dropping it
+    /// is deliberately left as a manual action, since other objects may
+    /// already depend on it.
+    ///
+    /// `pg_trgm` is not configurable here: Odoo creates it unconditionally in
+    /// `_initialize_db`, so the operator matches that rather than inventing a
+    /// difference.
+    #[serde(default = "default_true")]
+    pub unaccent: bool,
 }
 
 /// Environment tags an OdooInstance as production or staging.  Used by:

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -84,6 +84,7 @@ pub trait PostgresManager: Send + Sync {
         username: &str,
         password: &str,
         db_name: &str,
+        with_unaccent: bool,
     ) -> Result<()>;
 
     /// Query the running PostgreSQL server for its major version (e.g. 16, 17, 18).
@@ -220,6 +221,7 @@ impl PostgresManager for PgPostgresManager {
         username: &str,
         password: &str,
         db_name: &str,
+        with_unaccent: bool,
     ) -> Result<()> {
         // Tenant owner, not admin: the owner has CREATE on its own database,
         // and both extensions are trusted, so no elevated connection is needed
@@ -245,7 +247,14 @@ impl PostgresManager for PgPostgresManager {
             .await?;
         let present: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
 
-        for ext in ["pg_trgm", "unaccent"] {
+        // pg_trgm unconditionally, matching Odoo's own _initialize_db;
+        // unaccent only when the instance opts in.
+        let wanted: &[&str] = if with_unaccent {
+            &["pg_trgm", "unaccent"]
+        } else {
+            &["pg_trgm"]
+        };
+        for ext in wanted.iter().copied() {
             if present.iter().any(|e| e == ext) {
                 continue;
             }
@@ -261,6 +270,10 @@ impl PostgresManager for PgPostgresManager {
                     warn!(%db_name, %ext, %e, "failed to create postgres extension");
                 }
             }
+        }
+
+        if !with_unaccent {
+            return Ok(());
         }
 
         // `unaccent` must be IMMUTABLE to be indexable. provolatile is 'i' when
@@ -679,6 +692,7 @@ impl PostgresManager for NoopPostgresManager {
         _: &str,
         _: &str,
         _: &str,
+        _: bool,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use tokio_postgres::NoTls;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::error::Result;
 
@@ -55,6 +55,35 @@ pub trait PostgresManager: Send + Sync {
         password: &str,
         db_name: &str,
         report_url: &str,
+    ) -> Result<()>;
+
+    /// Ensure the PostgreSQL extensions Odoo relies on exist in the tenant
+    /// database.
+    ///
+    /// Odoo creates `pg_trgm` unconditionally, and `unaccent` only when the
+    /// `--unaccent` flag is set, in `_initialize_db` — i.e. only for databases
+    /// Odoo itself creates. Databases that arrive by restore or clone (see
+    /// `scripts/restore-load-db.sh`, which uses `createdb` + `pg_restore`) never
+    /// run that path, so either extension can be missing.
+    ///
+    /// Without `unaccent`, `registry.has_unaccent` is false and Odoo silently
+    /// loses accent-insensitive search and deduplication across the whole
+    /// database. Reconciling it here rather than in the odoo.conf template is
+    /// what covers the restore and clone paths, and lets existing instances
+    /// self-heal.
+    ///
+    /// Both are trusted extensions on PG13+, so the tenant owner may create
+    /// them. Marking `unaccent` IMMUTABLE requires *ownership* of the function,
+    /// which a trusted-extension install leaves with the bootstrap superuser —
+    /// so that step uses the admin connection and is best-effort. Without it
+    /// Odoo reports the function PRESENT rather than INDEXABLE: fully
+    /// functional for search, but unusable as the basis of a trigram index.
+    async fn ensure_extensions(
+        &self,
+        pg: &PostgresClusterConfig,
+        username: &str,
+        password: &str,
+        db_name: &str,
     ) -> Result<()>;
 
     /// Query the running PostgreSQL server for its major version (e.g. 16, 17, 18).
@@ -182,6 +211,101 @@ impl PostgresManager for PgPostgresManager {
             info!(%db_name, %report_url, "set report.url system parameter");
         }
 
+        Ok(())
+    }
+
+    async fn ensure_extensions(
+        &self,
+        pg: &PostgresClusterConfig,
+        username: &str,
+        password: &str,
+        db_name: &str,
+    ) -> Result<()> {
+        // Tenant owner, not admin: the owner has CREATE on its own database,
+        // and both extensions are trusted, so no elevated connection is needed
+        // to install them.
+        let connstr = format!(
+            "host={} port={} user={} password={} dbname={}",
+            pg.host, pg.port, username, password, db_name
+        );
+        let (client, connection) = tokio_postgres::connect(&connstr, NoTls).await?;
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                warn!("postgres connection error: {e}");
+            }
+        });
+
+        // Check before creating so that the common case (both present) issues
+        // no DDL and logs nothing — this runs on every reconcile.
+        let rows = client
+            .query(
+                "SELECT extname FROM pg_extension WHERE extname IN ('pg_trgm', 'unaccent')",
+                &[],
+            )
+            .await?;
+        let present: Vec<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
+
+        for ext in ["pg_trgm", "unaccent"] {
+            if present.iter().any(|e| e == ext) {
+                continue;
+            }
+            // Extension names here are hardcoded literals, not user input.
+            match client
+                .execute(&format!("CREATE EXTENSION IF NOT EXISTS {ext}"), &[])
+                .await
+            {
+                Ok(_) => info!(%db_name, %ext, "created postgres extension"),
+                Err(e) => {
+                    // Non-fatal: a missing extension degrades Odoo's search,
+                    // it does not stop the instance from serving.
+                    warn!(%db_name, %ext, %e, "failed to create postgres extension");
+                }
+            }
+        }
+
+        // `unaccent` must be IMMUTABLE to be indexable. provolatile is 'i' when
+        // immutable, 's' (stable) as shipped.
+        let volatility = client
+            .query_opt(
+                "SELECT provolatile FROM pg_proc \
+                 WHERE proname = 'unaccent' AND pronargs = 1 \
+                   AND pronamespace = current_schema::regnamespace",
+                &[],
+            )
+            .await?
+            .map(|r| r.get::<_, i8>(0));
+        if volatility == Some(b'i' as i8) {
+            return Ok(());
+        }
+
+        // Needs function ownership, which the tenant role does not have.
+        let admin_connstr = format!(
+            "host={} port={} user={} password={} dbname={}",
+            pg.host, pg.port, pg.admin_user, pg.admin_password, db_name
+        );
+        let (admin, admin_conn) = match tokio_postgres::connect(&admin_connstr, NoTls).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                debug!(%db_name, %e, "no admin connection for unaccent IMMUTABLE; leaving it stable");
+                return Ok(());
+            }
+        };
+        tokio::spawn(async move {
+            if let Err(e) = admin_conn.await {
+                warn!("postgres admin connection error: {e}");
+            }
+        });
+        match admin
+            .execute("ALTER FUNCTION unaccent(text) IMMUTABLE", &[])
+            .await
+        {
+            Ok(_) => info!(%db_name, "marked unaccent() IMMUTABLE"),
+            // Purely an optimisation: without it Odoo still uses unaccent for
+            // search, it just cannot build trigram indexes over it. Logged at
+            // debug so a cluster whose admin lacks the privilege does not warn
+            // on every reconcile.
+            Err(e) => debug!(%db_name, %e, "could not mark unaccent() IMMUTABLE"),
+        }
         Ok(())
     }
 
@@ -543,6 +667,15 @@ impl PostgresManager for NoopPostgresManager {
         &self,
         _: &PostgresClusterConfig,
         _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn ensure_extensions(
+        &self,
+        _: &PostgresClusterConfig,
         _: &str,
         _: &str,
         _: &str,

--- a/tests/helpers_test.rs
+++ b/tests/helpers_test.rs
@@ -149,6 +149,7 @@ fn make_instance(uid: Option<&str>, db_name: Option<&str>) -> OdooInstance {
                 cluster: None,
                 name: Some(n.to_string()),
                 missing_policy: Default::default(),
+                unaccent: true,
             }),
             init: Default::default(),
             environment: Default::default(),

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -439,6 +439,7 @@ impl PostgresManager for MockPostgresManager {
         _: &str,
         _: &str,
         _: &str,
+        _: bool,
     ) -> PgResult<()> {
         Ok(())
     }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -433,6 +433,16 @@ impl PostgresManager for MockPostgresManager {
         Ok(())
     }
 
+    async fn ensure_extensions(
+        &self,
+        _: &PostgresClusterConfig,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> PgResult<()> {
+        Ok(())
+    }
+
     async fn detect_server_major_version(&self, _: &PostgresClusterConfig) -> PgResult<u32> {
         Ok(18)
     }

--- a/tests/postgres_harness/extensions.rs
+++ b/tests/postgres_harness/extensions.rs
@@ -1,0 +1,179 @@
+//! Tests for `PostgresManager::ensure_extensions`.
+//!
+//! ACCEPTANCE CRITERIA
+//!
+//! 1. Both `pg_trgm` and `unaccent` are created in a tenant database that has
+//!    neither. This is the restore/clone case: `scripts/restore-load-db.sh`
+//!    builds the database with `createdb` + `pg_restore`, so Odoo's
+//!    `_initialize_db` — the only thing that would otherwise create them —
+//!    never runs.
+//! 2. Creation happens over the TENANT OWNER connection, which is
+//!    NOSUPERUSER. Both extensions are trusted on PG13+, so this works; if a
+//!    future change routed it through the admin connection instead the
+//!    operator would depend on a privilege it should not need.
+//! 3. `unaccent` ends up IMMUTABLE (`provolatile = 'i'`) when the admin is a
+//!    superuser. This is the non-obvious half: a trusted-extension install
+//!    leaves the function owned by the bootstrap superuser, NOT by the role
+//!    that ran CREATE EXTENSION, so the tenant owner cannot ALTER it. Odoo
+//!    only treats unaccent as INDEXABLE when it is immutable.
+//! 4. Calling twice is a no-op and does not error.
+//! 5. A database that already has the extensions is left alone and reports
+//!    success — the common path, run on every reconcile.
+//!
+//! NON-CRITERIA
+//!
+//! The behaviour when the admin cannot ALTER the function (a non-superuser
+//! admin, as on a cluster whose admin role is externally managed) is
+//! deliberately not asserted here: it is a best-effort optimisation that
+//! logs at debug and returns Ok. Criterion 3 covers the path that matters,
+//! and the fallback is a `return Ok(())` with no observable state.
+
+use odoo_operator::postgres::PostgresManager;
+
+use super::harness::{admin_client, cluster_config, connect_as, pg_manager};
+
+const OWNER_PW: &str = "ext-owner-pw";
+
+/// Create a tenant DB owned by a NOSUPERUSER role, with no extensions.
+async fn setup_tenant(owner_user: &str, tenant_db: &str) {
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{tenant_db}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{owner_user}""#))
+        .await;
+    c.simple_query(&format!(
+        r#"CREATE ROLE "{owner_user}" WITH PASSWORD '{OWNER_PW}' LOGIN CREATEDB NOSUPERUSER"#
+    ))
+    .await
+    .expect("create owner role");
+    c.simple_query(&format!(
+        r#"CREATE DATABASE "{tenant_db}" OWNER "{owner_user}""#
+    ))
+    .await
+    .expect("create tenant db");
+}
+
+async fn cleanup(owner_user: &str, tenant_db: &str) {
+    let c = admin_client().await;
+    let _ = c
+        .simple_query(&format!(r#"DROP DATABASE IF EXISTS "{tenant_db}""#))
+        .await;
+    let _ = c
+        .simple_query(&format!(r#"DROP ROLE IF EXISTS "{owner_user}""#))
+        .await;
+}
+
+async fn installed_extensions(owner_user: &str, tenant_db: &str) -> Vec<String> {
+    let c = connect_as(owner_user, OWNER_PW, tenant_db).await;
+    let rows = c
+        .query(
+            "SELECT extname FROM pg_extension WHERE extname IN ('pg_trgm', 'unaccent') \
+             ORDER BY extname",
+            &[],
+        )
+        .await
+        .expect("query pg_extension");
+    rows.iter().map(|r| r.get::<_, String>(0)).collect()
+}
+
+async fn unaccent_volatility(owner_user: &str, tenant_db: &str) -> Option<i8> {
+    let c = connect_as(owner_user, OWNER_PW, tenant_db).await;
+    c.query_opt(
+        "SELECT provolatile FROM pg_proc WHERE proname = 'unaccent' AND pronargs = 1 \
+           AND pronamespace = current_schema::regnamespace",
+        &[],
+    )
+    .await
+    .expect("query pg_proc")
+    .map(|r| r.get::<_, i8>(0))
+}
+
+#[tokio::test]
+async fn creates_both_extensions_in_a_bare_tenant_db() -> anyhow::Result<()> {
+    let owner = "odoo_ext_owner_bare";
+    let db = "odoo_test_ext_bare";
+    setup_tenant(owner, db).await;
+
+    assert!(
+        installed_extensions(owner, db).await.is_empty(),
+        "precondition: tenant db must start with neither extension"
+    );
+
+    pg_manager()
+        .ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+        .await?;
+
+    // Criteria 1 and 2: created, over a NOSUPERUSER owner connection.
+    assert_eq!(
+        installed_extensions(owner, db).await,
+        vec!["pg_trgm".to_string(), "unaccent".to_string()],
+    );
+
+    // Criterion 3: immutable, which the owner alone could not have done.
+    assert_eq!(
+        unaccent_volatility(owner, db).await,
+        Some(b'i' as i8),
+        "unaccent must be IMMUTABLE for Odoo to treat it as INDEXABLE"
+    );
+
+    cleanup(owner, db).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn is_idempotent_and_leaves_existing_extensions_alone() -> anyhow::Result<()> {
+    let owner = "odoo_ext_owner_idem";
+    let db = "odoo_test_ext_idem";
+    setup_tenant(owner, db).await;
+
+    let mgr = pg_manager();
+    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+        .await?;
+    // Criteria 4 and 5: the every-reconcile path.
+    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+        .await?;
+
+    assert_eq!(
+        installed_extensions(owner, db).await,
+        vec!["pg_trgm".to_string(), "unaccent".to_string()],
+    );
+    assert_eq!(unaccent_volatility(owner, db).await, Some(b'i' as i8));
+
+    cleanup(owner, db).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tenant_owner_alone_cannot_make_unaccent_immutable() -> anyhow::Result<()> {
+    // Not a test of our code, but of the assumption the implementation rests
+    // on: that the admin connection is genuinely required for the ALTER. If a
+    // future PostgreSQL made trusted extensions owned by their installer, the
+    // admin round-trip could be dropped — this test would then fail and say so.
+    let owner = "odoo_ext_owner_priv";
+    let db = "odoo_test_ext_priv";
+    setup_tenant(owner, db).await;
+
+    let c = connect_as(owner, OWNER_PW, db).await;
+    c.simple_query("CREATE EXTENSION IF NOT EXISTS unaccent")
+        .await
+        .expect("trusted extension must be installable by a non-superuser owner");
+    let err = c
+        .simple_query("ALTER FUNCTION unaccent(text) IMMUTABLE")
+        .await
+        .expect_err("owner is expected NOT to own a trusted extension's functions");
+    // Display for tokio_postgres::Error is just "db error"; the server's
+    // message lives in the DbError payload.
+    let message = err
+        .as_db_error()
+        .map(|e| e.message().to_string())
+        .unwrap_or_else(|| err.to_string());
+    assert!(
+        message.contains("must be owner of function"),
+        "unexpected failure mode: {message}"
+    );
+
+    cleanup(owner, db).await;
+    Ok(())
+}

--- a/tests/postgres_harness/extensions.rs
+++ b/tests/postgres_harness/extensions.rs
@@ -20,6 +20,12 @@
 //! 5. A database that already has the extensions is left alone and reports
 //!    success — the common path, run on every reconcile.
 //!
+//! 6. When the instance opts out (`spec.database.unaccent: false`), `unaccent`
+//!    is NOT created, but `pg_trgm` still is — Odoo creates pg_trgm
+//!    unconditionally itself, so the operator matches that rather than
+//!    inventing a difference. Opting out must not be a way to end up with a
+//!    database Odoo would not have produced on its own.
+//!
 //! NON-CRITERIA
 //!
 //! The behaviour when the admin cannot ALTER the function (a non-superuser
@@ -102,7 +108,7 @@ async fn creates_both_extensions_in_a_bare_tenant_db() -> anyhow::Result<()> {
     );
 
     pg_manager()
-        .ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+        .ensure_extensions(&cluster_config(), owner, OWNER_PW, db, true)
         .await?;
 
     // Criteria 1 and 2: created, over a NOSUPERUSER owner connection.
@@ -129,10 +135,10 @@ async fn is_idempotent_and_leaves_existing_extensions_alone() -> anyhow::Result<
     setup_tenant(owner, db).await;
 
     let mgr = pg_manager();
-    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db, true)
         .await?;
     // Criteria 4 and 5: the every-reconcile path.
-    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db)
+    mgr.ensure_extensions(&cluster_config(), owner, OWNER_PW, db, true)
         .await?;
 
     assert_eq!(
@@ -173,6 +179,28 @@ async fn tenant_owner_alone_cannot_make_unaccent_immutable() -> anyhow::Result<(
         message.contains("must be owner of function"),
         "unexpected failure mode: {message}"
     );
+
+    cleanup(owner, db).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn skips_unaccent_when_the_instance_opts_out() -> anyhow::Result<()> {
+    let owner = "odoo_ext_owner_optout";
+    let db = "odoo_test_ext_optout";
+    setup_tenant(owner, db).await;
+
+    pg_manager()
+        .ensure_extensions(&cluster_config(), owner, OWNER_PW, db, false)
+        .await?;
+
+    // Criterion 6: pg_trgm yes, unaccent no.
+    assert_eq!(
+        installed_extensions(owner, db).await,
+        vec!["pg_trgm".to_string()],
+        "opting out of unaccent must not also skip pg_trgm"
+    );
+    assert_eq!(unaccent_volatility(owner, db).await, None);
 
     cleanup(owner, db).await;
     Ok(())

--- a/tests/postgres_harness/main.rs
+++ b/tests/postgres_harness/main.rs
@@ -9,4 +9,5 @@ mod harness;
 mod database_exists;
 mod delete_role_errors;
 mod ensure_role;
+mod extensions;
 mod readonly_role;

--- a/tests/readonly_sql_access_test.rs
+++ b/tests/readonly_sql_access_test.rs
@@ -35,6 +35,7 @@ fn make_instance_with_ro(ro_enabled: bool, connection_limit: i32) -> OdooInstanc
                 cluster: None,
                 name: Some("odoo_ae819407_a467_4155_b2b2_8f38c400fb1f".to_string()),
                 missing_policy: Default::default(),
+                unaccent: true,
             }),
             init: Default::default(),
             environment: Default::default(),


### PR DESCRIPTION
## Problem

Odoo creates `pg_trgm` unconditionally and `unaccent` only when `--unaccent` is set — both inside `_initialize_db`, i.e. only for databases **Odoo itself creates**. Databases that arrive by restore or clone never run that path: `scripts/restore-load-db.sh` builds them with `createdb` + `pg_restore`, and `clone-db.sh` likewise.

Without `unaccent`, `registry.has_unaccent` is false and Odoo silently loses accent-insensitive search across the whole database — searching "Montreal" stops finding "Montréal", and the Data Cleaning app's deduplication rules are stuck on strictly case-**sensitive** exact matching.

## Why this cannot be fixed in the odoo.conf template

Setting `--unaccent` only affects databases Odoo initialises itself, so it does nothing for a database that arrives by restore or clone — including any future restore over an instance that already had it.

There is a clear signature for a database that skipped `_initialize_db`: it has `unaccent` (carried in the dump it was restored from) but **not** `pg_trgm`, which `_initialize_db` would have created unconditionally. A config flag would never reach those, and nothing re-checks afterwards.

Reconciling in the operator covers every creation path and lets existing instances self-heal on their next reconcile.

## Opt-out

Installing `unaccent` changes search semantics database-wide, which is presumably why Odoo gates it behind a flag rather than doing it always. So this is configurable per instance:

```yaml
spec:
  database:
    unaccent: false   # default: true
```

Default `true`, so existing instances pick up the fix without editing every manifest. Setting it `false` stops the operator creating the extension; it deliberately does **not** drop an existing one, since other objects may already depend on it — removal stays a deliberate manual action.

`pg_trgm` is not configurable. Odoo creates it in `_initialize_db` regardless of any flag, so opting out of `unaccent` must not leave a database in a state Odoo itself would never have produced. There is a test for exactly that.

## Approach

Mirrors the existing `ensure_report_url` shape: connects to the tenant database with the tenant's own credentials, runs on every reconcile, guarded by `db_initialized`, non-fatal on error.

- **Creation runs on the tenant-owner connection.** Both extensions are trusted on PG13+, so no elevated privilege is needed — verified `trusted = t` on PostgreSQL 16 and 18, with the tenant role owning its own database.
- **`ALTER FUNCTION unaccent(text) IMMUTABLE` runs on the admin connection**, best-effort. A trusted-extension install leaves the function owned by the *bootstrap superuser*, not the installing role, so the tenant owner genuinely cannot do this. Without it Odoo reports the function `PRESENT` rather than `INDEXABLE` (`odoo/modules/db.py`) — fully functional for search, but unusable as the basis of a trigram index. Logged at `debug` so a cluster whose admin lacks the privilege doesn't warn on every reconcile.
- **The common path (both present) issues no DDL and logs nothing**, since this runs every reconcile.

## Tests

Four new tests in the docker-backed harness, against real PostgreSQL 18:

- `creates_both_extensions_in_a_bare_tenant_db` — the restore/clone case, including asserting `provolatile = 'i'` at the end.
- `is_idempotent_and_leaves_existing_extensions_alone` — the every-reconcile path.
- `skips_unaccent_when_the_instance_opts_out` — opt-out still gets `pg_trgm`.
- `tenant_owner_alone_cannot_make_unaccent_immutable` — pins the *assumption* the admin round-trip rests on. It asserts a non-superuser owner can install the trusted extension but gets `must be owner of function` on the ALTER. If a future PostgreSQL ever made trusted extensions owned by their installer, this fails and tells us the admin hop can be dropped.

13/13 harness tests pass; fmt and clippy clean; CRDs regenerated and synced to the chart.

## Notes for review

- Running workers only pick up a newly created `unaccent` at **registry load**, i.e. on their next restart. The operator creating it does not retroactively change a running process's `has_unaccent`.
- Existing `data_merge.rule` records stay on `exact` — `_update_default_rules()` only runs at module install, so flipping them to `accent` is a per-instance data change, not something this covers.
- A CloudNativePG cluster's `bootstrap.initdb.postInitTemplateSQL` should also gain `CREATE EXTENSION unaccent` so future clusters seed it into `template1`, but that is bootstrap-only and has no effect on an existing cluster — deliberately not in this PR.